### PR TITLE
For all client connections, set the file descriptor to be non-blocking so that any blocking operation errors out

### DIFF
--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -156,7 +156,7 @@ func RunAsyncTCPServer(wg *sync.WaitGroup) error {
 				}
 
 				connectedClients[fd] = core.NewClient(fd)
-				syscall.SetNonblock(serverFD, true)
+				syscall.SetNonblock(fd, true)
 
 				// add this new TCP connection to be monitored
 				var socketClientEvent syscall.EpollEvent = syscall.EpollEvent{


### PR DESCRIPTION


Because of typo, we were accidentally setting the server file descriptor to non blocking again and again