### PR TITLE
Disable Cross Protocol Scripting

### DIFF
--- a/core/resp.go
+++ b/core/resp.go
@@ -110,21 +110,26 @@ func DecodeOne(data []byte) (interface{}, int, error) {
 	return nil, 0, nil
 }
 
-func Decode(data []byte) ([]interface{}, error) {
+func Decode(data []byte) ([]interface{}, bool, error) {
 	if len(data) == 0 {
-		return nil, errors.New("no data")
+		return nil, false, errors.New("no data")
 	}
 	var values []interface{} = make([]interface{}, 0)
 	var index int = 0
+	var maliciousFlag bool
 	for index < len(data) {
 		value, delta, err := DecodeOne(data[index:])
 		if err != nil {
-			return values, err
+			return values, false, err
+		}
+		if delta == 0 {
+			maliciousFlag = true
+			break
 		}
 		index = index + delta
 		values = append(values, value)
 	}
-	return values, nil
+	return values, maliciousFlag, nil
 }
 
 func encodeString(v string) []byte {

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -171,8 +171,8 @@ func RunAsyncTCPServer(wg *sync.WaitGroup) error {
 				if comm == nil {
 					continue
 				}
-				cmds, err := readCommands(comm)
-				if err != nil {
+				cmds, maliciousFlag, err := readCommands(comm)
+				if err != nil || maliciousFlag {
 					syscall.Close(int(events[i].Fd))
 					delete(connectedClients, int(events[i].Fd))
 					continue


### PR DESCRIPTION
The issue behind **Cross Protocol Scripting** is that RESP is a serialization protocol and hence any abuse of it by providing incompatible protocols increases the attack surface, Its security risk in the context of RESP spec implementation safety, a few jargon characters could break your RESP handler.  This PR disables "Cross Protocol Scripting", refer to the issue https://github.com/DiceDB/dice/issues/12.