### PR TITLE
Added GitHub actions to build Dice for platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          # DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - '*'
 
 jobs:
   goreleaser:
@@ -21,11 +21,8 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
-          # DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,5 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
 builds:
   - env:
@@ -30,28 +27,3 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-# announce:
-#   discord:
-#     # Whether its enabled or not.
-#     # Defaults to false.
-#     enabled: true
-
-#     # Message template to use while publishing.
-#     # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
-#     message_template: 'DiceDB {{ .Tag }} is out!'
-
-#     # Set author of the embed.
-#     # Defaults to `GoReleaser`
-#     author: 'DiceDB'
-
-#     # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
-#     # Defaults to `3888754` - the grey-ish from goreleaser
-#     color: '16711680'
-
-#     # URL to an image to use as the icon for the embed.
-#     # Defaults to `https://goreleaser.com/static/avatar.png`
-#     icon_url: 'https://avatars.githubusercontent.com/u/112580013?s=200&v=4'
-
-# modelines, feel free to remove those if you don't want/use them:
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,57 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+    ignore:
+      - goarch: arm
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+# announce:
+#   discord:
+#     # Whether its enabled or not.
+#     # Defaults to false.
+#     enabled: true
+
+#     # Message template to use while publishing.
+#     # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
+#     message_template: 'DiceDB {{ .Tag }} is out!'
+
+#     # Set author of the embed.
+#     # Defaults to `GoReleaser`
+#     author: 'DiceDB'
+
+#     # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
+#     # Defaults to `3888754` - the grey-ish from goreleaser
+#     color: '16711680'
+
+#     # URL to an image to use as the icon for the embed.
+#     # Defaults to `https://goreleaser.com/static/avatar.png`
+#     icon_url: 'https://avatars.githubusercontent.com/u/112580013?s=200&v=4'
+
+# modelines, feel free to remove those if you don't want/use them:
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
- Issue#27, Added GitHub actions to build Dice for
   OS : linux and darwin
   arch: amd64
- Used Goreleaser-actions for github which gets triggered on pushing with new tag.
- Need to follow Semantic versioning

[Follow-up] : 
Goreleaser also provides following features but I have not added them in this issue.
1. Currently the release files are tar files, for future this could be changed to release .rpm, .deb, .apk, docker image ,etc.
2. Can create a webhook for discord to make announcements in discord channels in new releases.

