### PR TITLE
`varint` implementation for unsigned int

### DIFF
--- a/core/xencoding/byte_utils.go
+++ b/core/xencoding/byte_utils.go
@@ -1,0 +1,21 @@
+package xencoding
+
+var BITMASK = []byte{
+	0x01,
+	0x03,
+	0x07,
+	0x0F,
+	0x1F,
+	0x3F,
+	0x7F,
+	0xFF,
+}
+
+// getLSB returns the least significant `n` bits from
+// the byte value `x`.
+func getLSB(x byte, n uint8) byte {
+	if n > 8 {
+		panic("can extract at max 8 bits from the number")
+	}
+	return byte(x) & BITMASK[n-1]
+}

--- a/core/xencoding/int.go
+++ b/core/xencoding/int.go
@@ -1,0 +1,31 @@
+package xencoding
+
+// TOOD: not thread safe
+var buf [11]byte
+var bitShifts []uint8 = []uint8{7, 7, 7, 7, 7, 7, 7, 7, 7, 1}
+
+// XEncodeInt encodes the unsigned 64 bit integer value into a varint
+// and returns an array of bytes (little endian encoded)
+func XEncodeUInt(x uint64) []byte {
+	var i int = 0
+	for i = 0; i < len(bitShifts); i++ {
+		buf[i] = getLSB(byte(x), bitShifts[i]) | 0b10000000 // marking the continuation bit
+		x = x >> bitShifts[i]
+		if x == 0 {
+			break
+		}
+	}
+	buf[len(buf)-1] = buf[len(buf)-1] & 0b01111111 // marking the termination bit
+	return append(make([]byte, 0, i+1), buf[:i+1]...)
+}
+
+// XDecodeInt decodes the array of bytes and returns an unsigned 64 bit integer
+func XDecodeUInt(vint []byte) uint64 {
+	var i int = 0
+	var v uint64 = 0
+	for i = 0; i < len(vint); i++ {
+		b := getLSB(vint[i], 7)
+		v = v | uint64(b)<<(7*i)
+	}
+	return v
+}

--- a/tests/xencoding_int_test.go
+++ b/tests/xencoding_int_test.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/dicedb/dice/core/xencoding"
+)
+
+func TestXencodingInt(t *testing.T) {
+	var tests []uint64
+
+	tests = append(tests, 0)
+	for i := 0; i < 64; i++ {
+		tests = append(tests, 1<<i)
+		tests = append(tests, (1<<i)-1)
+		tests = append(tests, (1<<i)+1)
+	}
+
+	for _, v := range tests {
+		if v != xencoding.XDecodeUInt(xencoding.XEncodeUInt(v)) {
+			t.Errorf("xencoding failed for value: %d\n", v)
+		}
+	}
+
+	for k, v := range map[uint64]int{
+		0:   1,
+		127: 1,
+		128: 2,
+		129: 2,
+	} {
+		b := xencoding.XEncodeUInt(k)
+		if len(b) != v {
+			t.Errorf("xencoding for integer value %d failed. encoded length should be: %d, but found %d\n", k, v, len(b))
+		}
+	}
+}


### PR DESCRIPTION
Addresses issue: #81

I chose to re-implement `varint` and not use existing implementation because I forsee us needing to change `varint` implementation for advanced data structures we would be supporting.

I have also added tests for the same. I am calling our encoding scheme `XEncoding` - an umbrella that holds space and cache-efficient encoding for int, string, list, and much more.