### PR TITLE
Fixes aof file permission with arbitrary user

### DIFF
--- a/core/aof.go
+++ b/core/aof.go
@@ -20,7 +20,7 @@ func dumpKey(fp *os.File, key string, obj *Obj) {
 
 // TODO: To to new and switch
 func DumpAllAOF() {
-	fp, err := os.OpenFile(config.AOFFile, os.O_CREATE|os.O_WRONLY, os.ModeAppend)
+	fp, err := os.OpenFile(config.AOFFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		fmt.Print("error", err)
 		return

--- a/core/aof.go
+++ b/core/aof.go
@@ -2,11 +2,8 @@ package core
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
-
-	"github.com/dicedb/dice/config"
 )
 
 // TODO: Support Expiration
@@ -16,30 +13,4 @@ func dumpKey(fp *os.File, key string, obj *Obj) {
 	cmd := fmt.Sprintf("SET %s %s", key, obj.Value)
 	tokens := strings.Split(cmd, " ")
 	fp.Write(Encode(tokens, false))
-}
-
-// TODO: To to new and switch
-func DumpAllAOF() {
-	fp, err := os.OpenFile(config.AOFFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		fmt.Print("error", err)
-		return
-	}
-	/* Note: A close function also returns an error, a plain defer is harmful. 
-	A successful close does not guarantee that the data has been successfully saved 
-	to disk,as the kernel uses the buffer cache to defer writes or write calls delays the writing 
-	to disk to mitigate cost of frequent writes to disk. A more reliable method is is to use 
-	fsync() or f.Sync() and Direct I/O
-	*/
-	defer func() {
-	if err := fp.Close(); err != nil {
-		fmt.Print("error", err)
-		return
-	}
-	}()
-	log.Println("rewriting AOF file at", config.AOFFile)
-	for k, obj := range store {
-		dumpKey(fp, k, obj)
-	}
-	log.Println("AOF file rewrite complete")
 }

--- a/core/aof.go
+++ b/core/aof.go
@@ -25,9 +25,25 @@ func DumpAllAOF() {
 		fmt.Print("error", err)
 		return
 	}
+	
+	/* Note: A close function also returns an error, a plain defer is harmful. 
+	A successful close does not guarantee that the data has been successfully saved 
+	to disk,as the kernel uses the buffer cache to defer writes or write calls delays the writing 
+	to disk to mitigate cost of frequent writes to disk. A more reliable method is is to use 
+	fsync() or f.Sync() and Direct I/O
+	*/
+	defer func() {
+	if err := fp.Close(); err != nil {
+		fmt.Print("error", err)
+		return
+	}
+	}()
+
 	log.Println("rewriting AOF file at", config.AOFFile)
 	for k, obj := range store {
 		dumpKey(fp, k, obj)
 	}
+	
+
 	log.Println("AOF file rewrite complete")
 }

--- a/core/aof.go
+++ b/core/aof.go
@@ -25,7 +25,6 @@ func DumpAllAOF() {
 		fmt.Print("error", err)
 		return
 	}
-	
 	/* Note: A close function also returns an error, a plain defer is harmful. 
 	A successful close does not guarantee that the data has been successfully saved 
 	to disk,as the kernel uses the buffer cache to defer writes or write calls delays the writing 
@@ -38,12 +37,9 @@ func DumpAllAOF() {
 		return
 	}
 	}()
-
 	log.Println("rewriting AOF file at", config.AOFFile)
 	for k, obj := range store {
 		dumpKey(fp, k, obj)
 	}
-	
-
 	log.Println("AOF file rewrite complete")
 }

--- a/core/aof_darwin.go
+++ b/core/aof_darwin.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"fmt"
+	"github.com/dicedb/dice/config"
+	"log"
+	"os"
+)
+
+func FileSync(f *os.File) error {
+	_, _, err := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), syscall.F_FULLFSYNC, 0)
+	if err == 0 {
+		return nil
+	}
+	return err
+}
+
+// TODO: To to new and switch
+func DumpAllAOF() error {
+	fp, err := os.OpenFile(config.AOFFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	/* Note: A close function also returns an error, a plain defer is harmful.
+	A successful close does not guarantee that the data has been successfully saved
+	to disk,as the kernel uses the buffer cache to defer writes or write calls delays the writing
+	to disk to mitigate cost of frequent writes to disk. A more reliable method is to use
+	fsync() or f.Sync() and Close()
+	*/
+	defer func() {
+		if err := fp.Close(); err != nil {
+			fmt.Print("error", err)
+			return
+		}
+	}()
+	log.Println("rewriting AOF file at", config.AOFFile)
+	for k, obj := range store {
+		dumpKey(fp, k, obj)
+	}
+	return FileSync(fp)
+}

--- a/core/aof_linux.go
+++ b/core/aof_linux.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"fmt"
+	"github.com/dicedb/dice/config"
+	"log"
+	"os"
+)
+
+// TODO: To to new and switch
+func DumpAllAOF() error {
+	fp, err := os.OpenFile(config.AOFFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	/* Note: A close function also returns an error, a plain defer is harmful.
+	A successful close does not guarantee that the data has been successfully saved
+	to disk,as the kernel uses the buffer cache to defer writes or write calls delays the writing
+	to disk to mitigate cost of frequent writes to disk. A more reliable method is to use
+	fsync() or f.Sync() and Close()
+	*/
+	defer func() {
+		if err := fp.Close(); err != nil {
+			fmt.Print("error", err)
+			return
+		}
+	}()
+	log.Println("rewriting AOF file at", config.AOFFile)
+	for k, obj := range store {
+		dumpKey(fp, k, obj)
+	}
+	return fp.Sync()
+}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ func main() {
 
 	var sigs chan os.Signal = make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT)
+	//Need to clean up zombie process as soon as they appear once AOF background thread exits.
+	signal.Ignore(syscall.SIGCHLD)
 	var wg sync.WaitGroup
 	wg.Add(1)
 


### PR DESCRIPTION
Due to misconfigured file permissions for the AOF file, the command BGREWRITEAOF only works once and successive BGREWRITEAOF fails with an error message on the server console. This commit fixes it and uses the correct & appropriate operation mode flags for underlying system calls.

Fixes https://github.com/DiceDB/dice/issues/90