### PR TITLE
EXPIREAT implementation

### DIFF
--- a/core/store.go
+++ b/core/store.go
@@ -18,6 +18,10 @@ func setExpiry(obj *Obj, expDurationMs int64) {
 	expires[obj] = uint64(time.Now().UnixMilli()) + uint64(expDurationMs)
 }
 
+func setExpiryAt(obj *Obj, expiryTimestamp int64) {
+	expires[obj] = uint64(expiryTimestamp)
+}
+
 func NewObj(value interface{}, expDurationMs int64, oType uint8, oEnc uint8) *Obj {
 	obj := &Obj{
 		Value:          value,


### PR DESCRIPTION
ExpireAt is same as expire (even code is pretty much copy paste), with the only difference being, it takes timestamp instead of seconds till expiry. It can be used to implement expiry in  AOF, as 
```
SET t1 100
EXPIRE t1 10
```
can be written as
```
SET t1 100
EXPIREAT t1 $t1_expiry
```
where `$t1_expiry` is evaluated during writing time to be `CurrentUnixTimeInSeconds() + 10`