### PR TITLE
Issue 95: Unhandled "Port Address already in use"

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -14,5 +14,5 @@ var AOFFile string = "./dice-master.aof"
 // Network
 var IOBufferLength int = 512
 var IOBufferLengthMAX int = 50 * 1024
-var DEBUG bool = true
+var DEBUG bool = false
 var DEBUG_PORTS = []int{7380, 7381}

--- a/config/main.go
+++ b/config/main.go
@@ -14,3 +14,5 @@ var AOFFile string = "./dice-master.aof"
 // Network
 var IOBufferLength int = 512
 var IOBufferLengthMAX int = 50 * 1024
+var DEBUG bool = true
+var DEBUG_PORTS = []int{7380}

--- a/config/main.go
+++ b/config/main.go
@@ -15,4 +15,4 @@ var AOFFile string = "./dice-master.aof"
 var IOBufferLength int = 512
 var IOBufferLengthMAX int = 50 * 1024
 var DEBUG bool = true
-var DEBUG_PORTS = []int{7380}
+var DEBUG_PORTS = []int{7380, 7381}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 func setupFlags() {
 	flag.StringVar(&config.Host, "host", "0.0.0.0", "host for the dice server")
 	flag.IntVar(&config.Port, "port", 7379, "port for the dice server")
+	flag.BoolVar(&config.DEBUG, "debug", false, "server debug mode")
 	flag.Parse()
 }
 

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -80,7 +80,27 @@ func RunAsyncTCPServer(wg *sync.WaitGroup) error {
 		Port: config.Port,
 		Addr: [4]byte{ip4[0], ip4[1], ip4[2], ip4[3]},
 	}); err != nil {
-		return err
+
+		if !config.DEBUG {
+			log.Fatal(err)
+			return err
+		}
+		log.Printf("debug mode enabled. trying to start the asynchronous TCP server on %d", config.DEBUG_PORTS)
+		for _, debugPort := range config.DEBUG_PORTS {
+			log.Println(err)
+			log.Println("debug mode enabled. starting an asynchronous TCP server on", config.Host, debugPort)
+			if err = syscall.Bind(serverFD, &syscall.SockaddrInet4{
+				Port: debugPort,
+				Addr: [4]byte{ip4[0], ip4[1], ip4[2], ip4[3]}}); err == nil {
+				break
+			}
+		}
+		if err != nil {
+			log.Fatal(err)
+			log.Printf("could not start the synchronous TCP server on %d", config.DEBUG_PORTS)
+			return err
+		}
+
 	}
 
 	// Start listening

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -85,10 +85,10 @@ func RunAsyncTCPServer(wg *sync.WaitGroup) error {
 			log.Fatal(err)
 			return err
 		}
+		log.Println(err)
 		log.Printf("debug mode enabled. trying to start the asynchronous TCP server on %d", config.DEBUG_PORTS)
 		for _, debugPort := range config.DEBUG_PORTS {
-			log.Println(err)
-			log.Println("debug mode enabled. starting an asynchronous TCP server on", config.Host, debugPort)
+			log.Println("starting an asynchronous TCP server on", config.Host, debugPort)
 			if err = syscall.Bind(serverFD, &syscall.SockaddrInet4{
 				Port: debugPort,
 				Addr: [4]byte{ip4[0], ip4[1], ip4[2], ip4[3]}}); err == nil {
@@ -96,8 +96,8 @@ func RunAsyncTCPServer(wg *sync.WaitGroup) error {
 			}
 		}
 		if err != nil {
+			log.Printf("could not start the asynchronous TCP server on %d", config.DEBUG_PORTS)
 			log.Fatal(err)
-			log.Printf("could not start the synchronous TCP server on %d", config.DEBUG_PORTS)
 			return err
 		}
 


### PR DESCRIPTION
This PR has below changes.

-  logs the error  if 7379 port "Address already in use" and exits with status 1.
-  Adds debug flag (default false) and set of debug ports. (for now 7380,7381)
-  If debug mode enabled. (debug = true) and port 7379 already in use. Try starting the async tcp server on debug ports.