### PR TITLE
[Fixes] #95 Added exit status and log message when user tries to spin a new instance on same port.

### DIFF
--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -80,6 +80,7 @@ func RunAsyncTCPServer(wg *sync.WaitGroup) error {
 		Port: config.Port,
 		Addr: [4]byte{ip4[0], ip4[1], ip4[2], ip4[3]},
 	}); err != nil {
+		log.Fatal(err)
 		return err
 	}
 


### PR DESCRIPTION
![Screenshot 2023-06-12 at 11 41 38 PM](https://github.com/DiceDB/dice/assets/52465652/9b5c1f8b-36a4-40da-a0c4-f7a1569e598e)
Error message with status code.
<img width="960" alt="Screenshot 2023-06-12 at 11 41 51 PM" src="https://github.com/DiceDB/dice/assets/52465652/e02509df-f7b9-4877-b1bc-cc3b39a66e73">
No error when there is only one instance

