### PR TITLE
Fix unreachable code in storm set function

### DIFF
--- a/storm/set/main.go
+++ b/storm/set/main.go
@@ -24,7 +24,7 @@ func stormSet(wg *sync.WaitGroup) {
 	if err != nil {
 		panic(err)
 	}
-
+	defer conn.Close()
 	for {
 		time.Sleep(500 * time.Millisecond)
 		k, v := getRandomKeyValue()
@@ -43,7 +43,6 @@ func stormSet(wg *sync.WaitGroup) {
 			panic(err)
 		}
 	}
-	conn.Close()
 }
 
 func main() {


### PR DESCRIPTION
Fix Unreachable Code in stormSet Function

Description:
This pull request addresses the "unreachable code" error encountered in the stormSet function. The issue arises due to the conn.Close() statement being unreachable after a return statement. To resolve this, the code has been rearranged to ensure that the conn.Close() statement is reachable and executed properly. Additionally, a defer statement has been added at the beginning of the function to ensure proper cleanup of resources even if the function returns early due to an error. This improves the reliability and maintainability of the codebase.

Changes Made:

1. Moved the conn.Close() statement to a reachable location in the function.
2. Added a defer statement to ensure the connection is closed when the function exits, improving code readability and maintainability.