### PR TITLE
Setting up optional infra for devccontainer in vscode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+	"name": "DiceDB Dev Container",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"context": ".."
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"go.useLanguageServer": true,
+				"go.gopath": "/go",
+				"go.toolsGopath": "/go"
+			},
+			"extensions": [
+				"golang.go",
+				"ms-vscode-remote.remote-containers"
+			],
+		}
+	},
+	"postCreateCommand": "go mod tidy",
+	"runArgs": [
+		"--network=host"
+	],
+	"remoteUser": "root",
+	"forwardPorts": [
+		7379
+	],
+	"remoteEnv": {
+		"GOPATH": "/go"
+	}
+}


### PR DESCRIPTION
With this now users can directly setup dev infra environment in vs-code .

This will ope the vs code with the all depenedencies and UI with the vscode to make it more seamless