### PR TITLE
Added benchmarks for queueint - #68

### DIFF
--- a/core/queueint_test.go
+++ b/core/queueint_test.go
@@ -69,3 +69,106 @@ func TestQueueInt(t *testing.T) {
 		}
 	}
 }
+
+func TestSize(t *testing.T) {
+	qi := core.NewQueueInt()
+	for i := 0; i < 20; i++ {
+		qi.Insert(int64(i))
+	}
+	qsize := qi.Length
+	if qsize != 20 {
+		t.Errorf("queueint test failed. should have been 20 but found %v", qsize)
+	}
+}
+
+func insertMany(howmany int, qi core.QueueIntI, b *testing.B) {
+	for i := 0; i < howmany; i++ {
+		qi.Insert(int64(i))
+	}
+	obsList := qi.Iterate(howmany + 10)
+	if len(obsList) != howmany {
+		b.Errorf("queueint test failed. should have been %d but found %v", howmany, len(obsList))
+	}
+}
+
+func BenchmarkInsert20(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(20, core.NewQueueInt(), b)
+	}
+}
+
+func BenchmarkInsert200(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(200, core.NewQueueInt(), b)
+	}
+}
+
+func BenchmarkInsert2000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(2000, core.NewQueueInt(), b)
+	}
+}
+
+func BenchmarkInsertLL20(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(20, core.NewQueueIntLL(), b)
+	}
+}
+
+func BenchmarkInsertLL200(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(200, core.NewQueueIntLL(), b)
+	}
+}
+
+func BenchmarkInsertLL2000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(2000, core.NewQueueIntLL(), b)
+	}
+}
+
+func BenchmarkInsertBasic20(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(20, core.NewQueueIntBasic(), b)
+	}
+}
+
+func BenchmarkInsertBasic200(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(200, core.NewQueueIntBasic(), b)
+	}
+}
+
+func BenchmarkInsertBasic2000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		insertMany(2000, core.NewQueueIntBasic(), b)
+	}
+}
+
+func BenchmarkInsertRemove(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		qi := core.NewQueueInt()
+		for i := 0; i < 20; i++ {
+			qi.Insert(int64(i))
+		}
+		for i := 0; i < 20; i++ {
+			_, err := qi.Remove()
+			if err != nil {
+				b.Errorf("queueint test failed. should have been nil but found %v", err)
+			}
+		}
+	}
+}
+
+func BenchmarkSize(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		qi := core.NewQueueInt()
+		for i := 0; i < 20; i++ {
+			qi.Insert(int64(i))
+		}
+		qsize := qi.Length
+		if qsize != 20 {
+			b.Errorf("queueint test failed. should have been 20 but found %v", qsize)
+		}
+	}
+}


### PR DESCRIPTION
## Purpose

To optimise the `QueueInt` implementation. Corresponding issue #68 

## What changed

- Added an interface `core.QueueIntI` for `core.QueueInt` to try out different implementations
- Added a doubly linked list implementation `QueueIntLL` and a basic implementation wrapping an `int64` slice `QueueIntBasic`
- Added benchmark tests to run Inserts for the different implementation. All other operations depend on Inserts`therefore this serves as a good benchmark to begin with

## Findings

`QueueIntBasic` performs best with space and time. Raises the question - Why do we need a custom serialisation to bytes to store and remove?

Sample output of the benchmark tests on an M1 Mac with 16GB Ram is as follows
```
goos: darwin
goarch: arm64
pkg: github.com/dicedb/dice/core
BenchmarkInsert20-8          	 2086051	       556.9 ns/op	     880 B/op	      30 allocs/op
BenchmarkInsert200-8         	  292335	      4072 ns/op	    5016 B/op	     215 allocs/op
BenchmarkInsert2000-8        	   26910	     44530 ns/op	   68808 B/op	    2048 allocs/op
BenchmarkInsertLL20-8        	 2142868	       559.6 ns/op	    1176 B/op	      23 allocs/op
BenchmarkInsertLL200-8       	  233166	      5071 ns/op	   11448 B/op	     203 allocs/op
BenchmarkInsertLL2000-8      	   18798	     63750 ns/op	  126393 B/op	    3747 allocs/op
BenchmarkInsertBasic20-8     	 6456631	       184.3 ns/op	     536 B/op	       7 allocs/op
BenchmarkInsertBasic200-8    	 1303436	       933.4 ns/op	    4120 B/op	      10 allocs/op
BenchmarkInsertBasic2000-8   	  134974	      8908 ns/op	   60056 B/op	      15 allocs/op
BenchmarkInsertRemove-8      	 2835312	       421.9 ns/op	     324 B/op	      22 allocs/op
BenchmarkSize-8              	 3528886	       338.9 ns/op	     324 B/op	      22 allocs/op
PASS
ok  	github.com/dicedb/dice/core	18.491s
```

## Future directions

The changes are temporary, we would want to keep only one implementation of `QueueInt` that performs the best. 