### PR TITLE
Enable linting for entire codebase

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,4 +22,3 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.59
-          only-new-issues: true


### PR DESCRIPTION
We should enable linting for entire codebase now that we have addresed all existing lint errors.