### PR TITLE
#145 : Added support for COMMAND COUNT command 

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -303,6 +303,11 @@ var (
 		Info: "Quit the server",
 		Eval: nil,
 	}
+	commandCmdMeta = DiceCmdMeta{
+		Name: "COMMAND <subcommand>",
+		Info: "Evaluates COMMAND <subcommand> command based on subcommand",
+		Eval: evalCommand,
+	}
 )
 
 func init() {
@@ -346,4 +351,5 @@ func init() {
 	diceCmds["EXEC"] = execCmdMeta
 	diceCmds["DISCARD"] = discardCmdMeta
 	diceCmds["ABORT"] = abortCmdMeta
+	diceCmds["COMMAND"] = commandCmdMeta
 }

--- a/core/eval.go
+++ b/core/eval.go
@@ -21,63 +21,18 @@ var RESP_MINUS_1 []byte = []byte(":-1\r\n")
 var RESP_MINUS_2 []byte = []byte(":-2\r\n")
 var RESP_EMPTY_ARRAY []byte = []byte("*0\r\n")
 
-// All supported Dice Commands
-const (
-	PING         = "PING"
-	SET          = "SET"
-	GET          = "GET"
-	TTL          = "TTL"
-	DEL          = "DEL"
-	EXPIRE       = "EXPIRE"
-	HELLO        = "HELLO"
-	BGREWRITEAOF = "BGREWRITEAOF"
-	INCR         = "INCR"
-	INFO         = "INFO"
-	CLIENT       = "CLIENT"
-	LATENCY      = "LATENCY"
-	LRU          = "LRU"
-	SLEEP        = "SLEEP"
-	QINTINS      = "QINTINS"
-	QINTREM      = "QINTREM"
-	QINTLEN      = "QINTLEN"
-	QINTPEEK     = "QINTPEEK"
-	BFINIT       = "BFINIT"
-	BFADD        = "BFADD"
-	BFEXISTS     = "BFEXISTS"
-	BFINFO       = "BFINFO"
-	QREFINS      = "QREFINS"
-	QREFREM      = "QREFREM"
-	QREFLEN      = "QREFLEN"
-	QREFPEEK     = "QREFPEEK"
-	STACKINTPUSH = "STACKINTPUSH"
-	STACKINTPOP  = "STACKINTPOP"
-	STACKINTLEN  = "STACKINTLEN"
-	STACKINTPEEK = "STACKINTPEEK"
-	STACKREFPUSH = "STACKREFPUSH"
-	STACKREFPOP  = "STACKREFPOP"
-	STACKREFLEN  = "STACKREFLEN"
-	STACKREFPEEK = "STACKREFPEEK"
-	SUBSCRIBE    = "SUBSCRIBE"
-	QWATCH       = "QWATCH"
-	COMMAND      = "COMMAND"
-	MULTI        = "MULTI"
-	EXEC         = "EXEC"
-	DISCARD      = "DISCARD"
-	ABORT        = "ABORT"
-)
-
-var diceCommands = []string{
-	PING, SET, GET, TTL, DEL, EXPIRE, BGREWRITEAOF, INCR, INFO, CLIENT, LATENCY, LRU,
-	SLEEP, QINTINS, QINTREM, QINTLEN, QINTPEEK, BFINIT, BFADD, BFEXISTS, BFINFO,
-	QREFINS, QREFREM, QREFLEN, QREFPEEK, STACKINTPUSH, STACKINTPOP, STACKINTLEN,
-	STACKINTPEEK, STACKREFPUSH, STACKREFPOP, STACKREFLEN, STACKREFPEEK, SUBSCRIBE,
-	QWATCH, COMMAND, MULTI, EXEC, DISCARD, ABORT}
-
 var txnCommands map[string]bool
 var serverID string
 
+var (
+	diceCommandsCount = len(diceCmds)
+)
+
 func init() {
-	txnCommands = map[string]bool{EXEC: true, DISCARD: true}
+	if len(diceCmds) != diceCommandsCount {
+		panic("diceCmds map has been modified")
+	}
+	txnCommands = map[string]bool{"EXEC": true, "DISCARD": true}
 	serverID = fmt.Sprintf("%s:%d", config.Host, config.Port)
 }
 
@@ -908,24 +863,24 @@ func evalQWATCH(args []string, c *Client) []byte {
 	return RESP_OK
 }
 
-// evalCOMMAND evaluates COMMAND <subcommand> command based on subcommand
+// evalCommand evaluates COMMAND <subcommand> command based on subcommand
 // COUNT: return total count of commands in Dice.
-func evalCOMMAND(args []string) []byte {
+func evalCommand(args []string) []byte {
 	if len(args) == 0 {
 		return Encode(fmt.Errorf("(error) ERR wrong number of arguments for 'command' command"), false)
 	}
 	subcommand := strings.ToUpper(args[0])
 	switch subcommand {
 	case "COUNT":
-		return evalCOMMANDCOUNT()
+		return evalCommandCount(nil)
 	default:
 		return Encode(fmt.Errorf("ERR unknown subcommand '%s'. Try COMMAND HELP", subcommand), false)
 	}
 }
 
-// evalCOMMANDCOUNT returns an number of commands supported by DiceDB
-func evalCOMMANDCOUNT() []byte {
-	return Encode(len(diceCommands), false)
+// evalCommandCount returns an number of commands supported by DiceDB
+func evalCommandCount(args []string) []byte {
+	return Encode(diceCommandsCount, false)
 }
 
 func executeCommand(cmd *RedisCmd, c *Client) []byte {

--- a/core/eval.go
+++ b/core/eval.go
@@ -22,11 +22,63 @@ var RESP_MINUS_1 []byte = []byte(":-1\r\n")
 var RESP_MINUS_2 []byte = []byte(":-2\r\n")
 var RESP_EMPTY_ARRAY []byte = []byte("*0\r\n")
 
+// All supported Dice Commands
+const (
+	PING         = "PING"
+	SET          = "SET"
+	GET          = "GET"
+	TTL          = "TTL"
+	DEL          = "DEL"
+	EXPIRE       = "EXPIRE"
+	HELLO		 = "HELLO"
+	BGREWRITEAOF = "BGREWRITEAOF"
+	INCR         = "INCR"
+	INFO         = "INFO"
+	CLIENT       = "CLIENT"
+	LATENCY      = "LATENCY"
+	LRU          = "LRU"
+	SLEEP        = "SLEEP"
+	QINTINS      = "QINTINS"
+	QINTREM      = "QINTREM"
+	QINTLEN      = "QINTLEN"
+	QINTPEEK     = "QINTPEEK"
+	BFINIT       = "BFINIT"
+	BFADD        = "BFADD"
+	BFEXISTS     = "BFEXISTS"
+	BFINFO       = "BFINFO"
+	QREFINS      = "QREFINS"
+	QREFREM      = "QREFREM"
+	QREFLEN      = "QREFLEN"
+	QREFPEEK     = "QREFPEEK"
+	STACKINTPUSH = "STACKINTPUSH"
+	STACKINTPOP  = "STACKINTPOP"
+	STACKINTLEN  = "STACKINTLEN"
+	STACKINTPEEK = "STACKINTPEEK"
+	STACKREFPUSH = "STACKREFPUSH"
+	STACKREFPOP  = "STACKREFPOP"
+	STACKREFLEN  = "STACKREFLEN"
+	STACKREFPEEK = "STACKREFPEEK"
+	SUBSCRIBE    = "SUBSCRIBE"
+	QWATCH       = "QWATCH"
+	COUNT        = "COUNT"
+	MULTI        = "MULTI"
+	EXEC         = "EXEC"
+	DISCARD      = "DISCARD"
+	ABORT        = "ABORT"
+)
+
+var diceCommands = []string{
+	PING, SET, GET, TTL, DEL, EXPIRE, BGREWRITEAOF, INCR, INFO, CLIENT, LATENCY, LRU,
+	SLEEP, QINTINS, QINTREM, QINTLEN, QINTPEEK, BFINIT, BFADD, BFEXISTS, BFINFO,
+	QREFINS, QREFREM, QREFLEN, QREFPEEK, STACKINTPUSH, STACKINTPOP, STACKINTLEN,
+	STACKINTPEEK, STACKREFPUSH, STACKREFPOP, STACKREFLEN, STACKREFPEEK, SUBSCRIBE,
+	QWATCH, COUNT, MULTI, EXEC, DISCARD, ABORT}
+
 var txnCommands map[string]bool
 var serverID string
 
 func init() {
-	txnCommands = map[string]bool{"EXEC": true, "DISCARD": true}
+	txnCommands = map[string]bool{EXEC: true, DISCARD: true}
 	serverID = fmt.Sprintf("%s:%d", config.Host, config.Port)
 }
 
@@ -855,6 +907,11 @@ func evalQWATCH(args []string, c *Client) []byte {
 	AddWatcher(query, c.Fd)
 
 	return RESP_OK
+}
+
+// evalCOUNT returns an number of commands supported by DiceDB
+func evalCOUNT() []byte {
+	return Encode(len(diceCommands), false)
 }
 
 func executeCommand(cmd *RedisCmd, c *Client) []byte {

--- a/core/eval.go
+++ b/core/eval.go
@@ -867,7 +867,7 @@ func evalQWATCH(args []string, c *Client) []byte {
 // COUNT: return total count of commands in Dice.
 func evalCommand(args []string) []byte {
 	if len(args) == 0 {
-		return Encode(fmt.Errorf("(error) ERR wrong number of arguments for 'command' command"), false)
+		return Encode(errors.New("(error) ERR wrong number of arguments for 'command' command"), false)
 	}
 	subcommand := strings.ToUpper(args[0])
 	switch subcommand {

--- a/core/eval.go
+++ b/core/eval.go
@@ -23,15 +23,10 @@ var RESP_EMPTY_ARRAY []byte = []byte("*0\r\n")
 
 var txnCommands map[string]bool
 var serverID string
-
-var (
-	diceCommandsCount = len(diceCmds)
-)
+var diceCommandsCount int
 
 func init() {
-	if len(diceCmds) != diceCommandsCount {
-		panic("diceCmds map has been modified")
-	}
+	diceCommandsCount = len(diceCmds)
 	txnCommands = map[string]bool{"EXEC": true, "DISCARD": true}
 	serverID = fmt.Sprintf("%s:%d", config.Host, config.Port)
 }

--- a/core/eval.go
+++ b/core/eval.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
+	"strings"
 	"github.com/dicedb/dice/config"
 )
 
@@ -60,7 +60,7 @@ const (
 	STACKREFPEEK = "STACKREFPEEK"
 	SUBSCRIBE    = "SUBSCRIBE"
 	QWATCH       = "QWATCH"
-	COUNT        = "COUNT"
+	COMMAND      = "COMMAND"
 	MULTI        = "MULTI"
 	EXEC         = "EXEC"
 	DISCARD      = "DISCARD"
@@ -72,7 +72,7 @@ var diceCommands = []string{
 	SLEEP, QINTINS, QINTREM, QINTLEN, QINTPEEK, BFINIT, BFADD, BFEXISTS, BFINFO,
 	QREFINS, QREFREM, QREFLEN, QREFPEEK, STACKINTPUSH, STACKINTPOP, STACKINTLEN,
 	STACKINTPEEK, STACKREFPUSH, STACKREFPOP, STACKREFLEN, STACKREFPEEK, SUBSCRIBE,
-	QWATCH, COUNT, MULTI, EXEC, DISCARD, ABORT}
+	QWATCH, COMMAND, MULTI, EXEC, DISCARD, ABORT}
 
 var txnCommands map[string]bool
 var serverID string
@@ -909,8 +909,23 @@ func evalQWATCH(args []string, c *Client) []byte {
 	return RESP_OK
 }
 
-// evalCOUNT returns an number of commands supported by DiceDB
-func evalCOUNT() []byte {
+// evalCOMMAND evaluates COMMAND <subcommand> command based on subcommand
+// COUNT: return total count of commands in Dice.
+func evalCOMMAND(args []string) []byte {
+	if len(args) == 0 {
+		return Encode(fmt.Errorf("(error) ERR wrong number of arguments for 'command' command"), false)
+	}
+	subcommand := strings.ToUpper(args[0])
+	switch subcommand {
+		case "COUNT":
+			return evalCOMMANDCOUNT()
+		default:
+			return Encode(fmt.Errorf("ERR unknown subcommand '%s'. Try COMMAND HELP", subcommand), false)
+	}
+}
+
+// evalCOMMANDCOUNT returns an number of commands supported by DiceDB
+func evalCOMMANDCOUNT() []byte {
 	return Encode(len(diceCommands), false)
 }
 

--- a/core/eval.go
+++ b/core/eval.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/dicedb/dice/config"
 	"log"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
-	"strings"
-	"github.com/dicedb/dice/config"
 )
 
 var RESP_NIL []byte = []byte("$-1\r\n")
@@ -30,7 +29,7 @@ const (
 	TTL          = "TTL"
 	DEL          = "DEL"
 	EXPIRE       = "EXPIRE"
-	HELLO		 = "HELLO"
+	HELLO        = "HELLO"
 	BGREWRITEAOF = "BGREWRITEAOF"
 	INCR         = "INCR"
 	INFO         = "INFO"
@@ -917,10 +916,10 @@ func evalCOMMAND(args []string) []byte {
 	}
 	subcommand := strings.ToUpper(args[0])
 	switch subcommand {
-		case "COUNT":
-			return evalCOMMANDCOUNT()
-		default:
-			return Encode(fmt.Errorf("ERR unknown subcommand '%s'. Try COMMAND HELP", subcommand), false)
+	case "COUNT":
+		return evalCOMMANDCOUNT()
+	default:
+		return Encode(fmt.Errorf("ERR unknown subcommand '%s'. Try COMMAND HELP", subcommand), false)
 	}
 }
 

--- a/tests/command_count_test.go
+++ b/tests/command_count_test.go
@@ -2,33 +2,35 @@ package tests
 
 import (
 	"fmt"
+	"net"
 	"testing"
 	"gotest.tools/v3/assert"
 )
 
 func TestCommandCount(t *testing.T) {
 	connection := getLocalConnection()
-	responseValue := fireCommand(connection, "COMMAND COUNT")
-	responseCount  := responseValue.(int64)
-	if responseValue == nil {
+	commandCount := getCommandCount(connection)
+	if commandCount <= 0 {
 		t.Fail()
 	}
-
-	assert.Assert(t, responseCount > 0,
-		fmt.Sprintf("Unexpected number of CLI commands found. expected greater than 0, %d found", responseCount))
+	assert.Assert(t, commandCount > 0,
+		fmt.Sprintf("Unexpected number of CLI commands found. expected greater than 0, %d found", commandCount))
 }
 
-func getCommandCount(t *testing.B) {
-	connection := getLocalConnection()
+func getCommandCount(connection net.Conn) int64 {
 	responseValue := fireCommand(connection, "COMMAND COUNT")
-	responseCount  := responseValue.(int64)
-	if responseValue == nil || responseCount <= 0 {
-		t.Fail()
+	if responseValue == nil {
+		return -1
 	}
+	return responseValue.(int64)
 }
 
 func BenchmarkCountCommand(b *testing.B) {
+	connection := getLocalConnection()
 	for n := 0; n < b.N; n++ {
-		getCommandCount(b)
+		commandCount := getCommandCount(connection)
+		if commandCount <= 0 {
+			b.Fail()
+		}
 	}
 }

--- a/tests/command_count_test.go
+++ b/tests/command_count_test.go
@@ -3,39 +3,32 @@ package tests
 import (
 	"fmt"
 	"testing"
-
 	"gotest.tools/v3/assert"
 )
 
-func TestCommandCOUNT(t *testing.T) {
-	commandsCount := 40
-
-	subscriber := getLocalConnection()
-
-	responseValue := fireCommand(subscriber, "COUNT")
+func TestCommandCount(t *testing.T) {
+	connection := getLocalConnection()
+	responseValue := fireCommand(connection, "COMMAND COUNT")
 	responseCount  := responseValue.(int64)
 	if responseValue == nil {
 		t.Fail()
 	}
 
-	assert.Assert(t, responseCount == int64(commandsCount),
-		fmt.Sprintf("Unexpected number of CLI commands found. %d expected, %d found", commandsCount, responseCount))
+	assert.Assert(t, responseCount > 0,
+		fmt.Sprintf("Unexpected number of CLI commands found. expected greater than 0, %d found", responseCount))
 }
 
-func call(howmany int, t *testing.B) {
-	subscriber := getLocalConnection()
-	for i := 0; i < howmany; i++ {
-		rp := fireCommandAndGetRESPParser(subscriber, "COUNT")
-		if rp == nil {
-			t.Fail()
-		}
+func getCommandCount(t *testing.B) {
+	connection := getLocalConnection()
+	responseValue := fireCommand(connection, "COMMAND COUNT")
+	responseCount  := responseValue.(int64)
+	if responseValue == nil || responseCount <= 0 {
+		t.Fail()
 	}
 }
 
-func BenchmarkCountCommand200(t *testing.B) {
-	call(200, t)
-}
-
-func BenchmarkCountCommand2000(t *testing.B) {
-	call(2000, t)
+func BenchmarkCountCommand(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		getCommandCount(b)
+	}
 }

--- a/tests/command_count_test.go
+++ b/tests/command_count_test.go
@@ -1,0 +1,41 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCommandCOUNT(t *testing.T) {
+	commandsCount := 40
+
+	subscriber := getLocalConnection()
+
+	responseValue := fireCommand(subscriber, "COUNT")
+	responseCount  := responseValue.(int64)
+	if responseValue == nil {
+		t.Fail()
+	}
+
+	assert.Assert(t, responseCount == int64(commandsCount),
+		fmt.Sprintf("Unexpected number of CLI commands found. %d expected, %d found", commandsCount, responseCount))
+}
+
+func call(howmany int, t *testing.B) {
+	subscriber := getLocalConnection()
+	for i := 0; i < howmany; i++ {
+		rp := fireCommandAndGetRESPParser(subscriber, "COUNT")
+		if rp == nil {
+			t.Fail()
+		}
+	}
+}
+
+func BenchmarkCountCommand200(t *testing.B) {
+	call(200, t)
+}
+
+func BenchmarkCountCommand2000(t *testing.B) {
+	call(2000, t)
+}

--- a/tests/command_count_test.go
+++ b/tests/command_count_test.go
@@ -2,9 +2,9 @@ package tests
 
 import (
 	"fmt"
+	"gotest.tools/v3/assert"
 	"net"
 	"testing"
-	"gotest.tools/v3/assert"
 )
 
 func TestCommandCount(t *testing.T) {


### PR DESCRIPTION
### Summary
Added support for  count command. Please review.
COMMAND COUNT is used to get total number of commands in dicedb.
redis documentation : https://redis.io/docs/latest/commands/command-count
This is my first PR and just getting started with the project. I have referred @yashs360's PR #150 for making the code changes. Thank you @yashs360 

### Changes

- Reused used the changes made by @yashs360  in PR #150 for adding constants for command names. Thanks @yashs360.
- Updated the eval methods as per PR #158  to support COMMAND|subcommand, thanks @kakdeykaushik
-  Added method to get the total number of commands.
- Added test and benchmark.

Benchmark results

<img width="927" alt="image" src="https://github.com/user-attachments/assets/b6de961a-074a-461f-afa1-1f9b45e8654f">




Issue : #145 