### PR TITLE
Add support for HELLO command.

### DIFF
--- a/core/resp.go
+++ b/core/resp.go
@@ -157,8 +157,8 @@ func Encode(value interface{}, isSimple bool) []byte {
 	case []interface{}:
 		var b []byte
 		buf := bytes.NewBuffer(b)
-		for _, b := range value.([]string) {
-			buf.Write(Encode(b, false))
+		for _, elem := range v {
+			buf.Write(Encode(elem, false))
 		}
 		return []byte(fmt.Sprintf("*%d\r\n%s", len(v), buf.Bytes()))
 	case *QueueElement:

--- a/tests/hello_test.go
+++ b/tests/hello_test.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHello(t *testing.T) {
+	conn := getLocalConnection()
+
+	expected := []interface{}{
+		"proto", int64(2),
+		"id", "0.0.0.0:7379",
+		"mode", "standalone",
+		"role", "master",
+		"modules", []interface{}{},
+	}
+
+	actual := fireCommand(conn, "HELLO")
+
+	assert.DeepEqual(t, expected, actual)
+}


### PR DESCRIPTION
# Summary
Adds support for `HELLO` command to negotiate protocol version and provide other server information.

Also fixes a bug in RESP encoding logic for `[]interface{}`

# Tests
Added related integration test.