### PR TITLE
Add support for COMMAND command #144

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -863,6 +863,51 @@ func evalQWATCH(args []string, c *Client) []byte {
 	return RESP_OK
 }
 
+func evalCOMMANDLIST(args []string) []byte {
+	return RESP_OK
+}
+func evalCOMMANDCOUNT(args []string) []byte {
+	return RESP_OK
+}
+func evalCOMMANDINFO(args []string) []byte {
+	return RESP_OK
+}
+func evalCOMMANDDOCS(args []string) []byte {
+	return RESP_OK
+}
+func evalCOMMANDGETKEYS(args []string) []byte {
+	return RESP_OK
+}
+
+// evalCOMMAND returns info of all the commands in Dice when no args are provided
+// When args are provided:
+// LIST: return lists all the Dice commands.
+// COUNT: return total count of commands in Dice.
+// INF0: returns info of command(s).
+// DOCS: returns docs of command(s).
+// GETKEYS: returns keys from a full Dice command.
+func evalCOMMAND(args []string) []byte {
+	if len(args) == 0 {
+		return evalCOMMANDINFO(args)
+	}
+
+	subcommand := args[0]
+	switch subcommand {
+	case "LIST":
+		return evalCOMMANDLIST(args)
+	case "COUNT":
+		return evalCOMMANDCOUNT(args)
+	case "INFO":
+		return evalCOMMANDINFO(args)
+	case "DOCS":
+		return evalCOMMANDDOCS(args)
+	case "GETKEYS":
+		return evalCOMMANDGETKEYS(args)
+	default:
+		return Encode(fmt.Errorf("ERR unknown subcommand '%s'. Try COMMAND HELP", subcommand), false)
+	}
+}
+
 func executeCommand(cmd *RedisCmd, c *Client) []byte {
 	switch cmd.Cmd {
 	case "PING":
@@ -937,6 +982,8 @@ func executeCommand(cmd *RedisCmd, c *Client) []byte {
 		return evalQWATCH(cmd.Args, c)
 	case "QWATCH":
 		return evalQWATCH(cmd.Args, c)
+	case "COMMAND":
+		return evalCOMMAND(cmd.Args)
 	case "MULTI":
 		c.TxnBegin()
 		return evalMULTI(cmd.Args)

--- a/core/eval.go
+++ b/core/eval.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -878,6 +879,9 @@ func evalCOMMANDDOCS(args []string) []byte {
 func evalCOMMANDGETKEYS(args []string) []byte {
 	return RESP_OK
 }
+func evalCOMMANDHELP(args []string) []byte {
+	return RESP_OK
+}
 
 // evalCOMMAND returns info of all the commands in Dice when no args are provided
 // When args are provided:
@@ -891,7 +895,7 @@ func evalCOMMAND(args []string) []byte {
 		return evalCOMMANDINFO(args)
 	}
 
-	subcommand := args[0]
+	subcommand := strings.ToUpper(args[0])
 	switch subcommand {
 	case "LIST":
 		return evalCOMMANDLIST(args)
@@ -903,6 +907,8 @@ func evalCOMMAND(args []string) []byte {
 		return evalCOMMANDDOCS(args)
 	case "GETKEYS":
 		return evalCOMMANDGETKEYS(args)
+	case "HELP":
+		return evalCOMMANDHELP(args)
 	default:
 		return Encode(fmt.Errorf("ERR unknown subcommand '%s'. Try COMMAND HELP", subcommand), false)
 	}

--- a/tests/commands_test.go
+++ b/tests/commands_test.go
@@ -1,0 +1,27 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCommandCOMMAND(t *testing.T) {
+	conn := getLocalConnection()
+
+	tests := []struct {
+		subcommand string
+		expected   string
+	}{
+		{
+			subcommand: "invalid-cmd",
+			expected:   "ERR unknown subcommand 'invalid-cmd'. Try COMMAND HELP",
+		},
+	}
+
+	for _, test := range tests {
+		actual := fireCommand(conn, fmt.Sprintf("COMMAND %s", test.subcommand))
+		assert.Equal(t, actual, test.expected)
+	}
+}


### PR DESCRIPTION
Added COMMAND command.

Summary of change:
Added support for `COMMAND` command, its subcommands are being implemented in following mentioned issues.

Implementation details taken from Redis:
- When `COMMAND` command in fired, it results output of `COMMAND INFO` of all the commands.
- When a valid subcommand (`COUNT`, `LIST` etc) is fired, it results output of that subcommand.
- When an invalid subcommand is fired, returns an error msg `ERR unknown subcommand 'invalid'. Try COMMAND HELP.`


This PR can be merged once issues #145 #146 #147 #148 #149 are resolved and we merge/accomodate those changes in this.

- [ ] COMMAND LIST
- [ ] COMMAND COUNT
- [ ] COMMAND DOCS
- [ ] COMMAND INFO
- [ ] COMMAND GETKEYS
