### PR TITLE
pulumi script to spinup and setup any AWS VM #139

### DIFF
--- a/docs/setting-up-in-aws.md
+++ b/docs/setting-up-in-aws.md
@@ -1,0 +1,98 @@
+
+# Setting Up DiceDB Infrastructure on AWS using Pulumi
+
+## Prerequisites
+
+- AWS CLI installed and configured
+- Pulumi CLI installed
+- This Pulumi project uses an S3 backend for state management. Ensure that the specified S3 bucket (dice-pulumi or any suitable bucketname) is created before running the Pulumi script. Alternatively we can use the pulumi cloud for storing the state
+
+## Setup Steps
+
+### 1. Configure AWS Credentials
+
+Ensure the AWS credentials are properly set up:
+
+```bash
+aws configure
+```
+
+Follow the prompts to configure the AWS Access Key ID, Secret Access Key, and default region.
+
+### 2. Create and Activate a Virtual Environment
+
+```bash
+python -m venv venv
+source venv/bin/activate # On Windows, use `venv\Scripts\activate`
+```
+
+### 3. Install Required Dependencies
+
+```bash
+cd pulumi
+pip install -r requirements.txt
+```
+
+### 4. Initialize or Select a Pulumi Stack
+
+Create a new stack:
+```bash
+pulumi stack init <stack-name>
+```
+Or select an existing stack:
+```bash
+pulumi stack select <stack-name>
+```
+
+### 5. Configure the Pulumi Stack
+
+Review and update the configuration in `Pulumi.<stack-name>.yaml`. You can also set config values using the CLI:
+
+```bash
+pulumi config set aws:region us-east-1
+pulumi config set instance_name dice-db
+pulumi config set instance_type t2.medium
+```
+
+### 6. Preview the Infrastructure Changes
+
+```bash
+pulumi preview
+```
+
+This command shows you what changes will be made without actually applying them.
+
+### 7. Deploy the Infrastructure
+
+When you're ready to create the resources:
+
+```bash
+pulumi up
+```
+
+Review the proposed changes and confirm to proceed.
+
+### 8. Access Your Resources
+
+After deployment, Pulumi will output important information like the instance's public IP and SSH command. Make note of these for accessing the DiceDB instance; or SSH into the instance via the console.
+
+## Clean Up
+
+To destroy the created resources when they're no longer needed:
+
+```bash
+pulumi destroy
+```
+
+Confirm the action when prompted.
+
+## Troubleshooting
+
+- If you encounter any issues with AWS permissions, ensure your AWS CLI is configured with the correct credentials and has the necessary IAM permissions.
+- For Pulumi-specific problems, consult the [Pulumi documentation](https://www.pulumi.com/docs/).
+- If you face issues with DiceDB setup, check the EC2 instance logs or SSH into the instance for further investigation.
+
+## Additional Resources
+
+- [Pulumi AWS Documentation](https://www.pulumi.com/docs/clouds/aws/)
+- [AWS CLI Configuration Guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)

--- a/pulumi/Pulumi.dev.yaml
+++ b/pulumi/Pulumi.dev.yaml
@@ -1,0 +1,6 @@
+encryptionsalt: v1:KwvTlW5pKiE=:v1:C6Jv32y38hqCXwbj:XprqfQxo5SCkgtsxLzD/YrnS29hKlA==
+config:
+  aws:region: us-east-1
+  instance_name: dice-db
+  instance_type: t2.medium
+  aws-native:region: us-east-1

--- a/pulumi/Pulumi.yaml
+++ b/pulumi/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: dice-db
+runtime:
+  name: python
+description: Pulumi project to deploy dice-db instance
+backend:
+  url: s3://dice-pulumi-2?region=us-east-1&awssdk=v2

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -1,0 +1,195 @@
+"""
+Pulumi script for deploying DiceDB on AWS EC2
+
+This script creates the necessary AWS infrastructure to run DiceDB,
+including VPC, subnet, security group, and EC2 instance. It also
+sets up DiceDB as a systemd service on the instance.
+
+Important: Ensure an S3 bucket for Pulumi state management is created
+before running this script. The bucket name is specified in Pulumi.yaml.
+"""
+
+import pulumi
+import pulumi_aws as aws
+import pulumi_aws_native as aws_native
+import pulumi_command as command
+import boto3
+from botocore.exceptions import ClientError
+import time
+
+# Input parameters
+# These can be customized through Pulumi config at Pulumi.<stackname>.yaml
+config = pulumi.Config()
+instance_name = config.require("instance_name")
+instance_type = config.get("instance_type") or "t2.micro"
+ami_id = config.get("ami_id") or "ami-0b72821e2f351e396"  # Amazon Linux 2 AMI
+vpc_cidr = config.get("vpc_cidr") or "10.0.0.0/16"
+subnet_cidr = config.get("subnet_cidr") or "10.0.1.0/24"
+region = config.get("region") or "us-east-1"
+boto_profile = config.get("boto_profile") or "default"
+
+
+# Create Internet gateway --> Assign to VPC --> Add internet gateway entry into route table that is assigned to ec2 subnet.
+vpc = aws.ec2.Vpc(
+    "dice-vpc",
+    cidr_block=vpc_cidr,
+    enable_dns_hostnames=True,
+    enable_dns_support=True,
+    tags={"Name": f"{instance_name}-vpc", "Project": "DiceDB"},
+)
+
+
+igw = aws.ec2.InternetGateway(
+    "dice-igw",
+    vpc_id=vpc.id,
+    tags={"Name": f"{instance_name}-igw", "Project": "DiceDB"},
+)
+
+
+route_table = aws.ec2.RouteTable(
+    "dice-rt",
+    vpc_id=vpc.id,
+    routes=[
+        aws.ec2.RouteTableRouteArgs(
+            cidr_block="0.0.0.0/0",
+            gateway_id=igw.id,
+        )
+    ],
+    tags={"Name": f"{instance_name}-rt", "Project": "DiceDB"},
+)
+
+subnet = aws.ec2.Subnet(
+    "dice-subnet",
+    vpc_id=vpc.id,
+    cidr_block=subnet_cidr,
+    map_public_ip_on_launch=True,
+    tags={"Name": f"{instance_name}-subnet", "Project": "DiceDB"},
+)
+
+# Associate the route table with the subnet
+route_table_association = aws.ec2.RouteTableAssociation(
+    "dice-rta",
+    subnet_id=subnet.id,
+    route_table_id=route_table.id,
+)
+
+security_group = aws.ec2.SecurityGroup(
+    "dice-sg",
+    description="Allow inbound traffic for DiceDB",
+    vpc_id=vpc.id,
+    ingress=[
+        aws.ec2.SecurityGroupIngressArgs(
+            description="SSH from anywhere",
+            from_port=22,
+            to_port=22,
+            protocol="tcp",
+            cidr_blocks=["0.0.0.0/0"],
+        ),
+        aws.ec2.SecurityGroupIngressArgs(
+            description="DiceDB port",
+            from_port=7379,
+            to_port=7379,
+            protocol="tcp",
+            cidr_blocks=["0.0.0.0/0"],
+        ),
+    ],
+    egress=[
+        aws.ec2.SecurityGroupEgressArgs(
+            from_port=0,
+            to_port=0,
+            protocol="-1",
+            cidr_blocks=["0.0.0.0/0"],
+        )
+    ],
+    tags={"Name": f"{instance_name}-sg", "Project": "DiceDB"},
+)
+
+# Create a new key pair and store it in AWS Parameter Store
+key_pair = aws_native.ec2.KeyPair("dice-keypair", key_name=f"{instance_name}-keypair")
+
+
+# Function to retrieve the private key using boto3 with retry logic
+def get_key_pair_material(key_pair_id):
+    boto_session = boto3.Session(profile_name=boto_profile, region_name=region)
+    ssm_client = boto_session.client("ssm")
+    max_retries = 5
+    retry_delay = 5  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            response = ssm_client.get_parameter(
+                Name=f"/ec2/keypair/{key_pair_id}", WithDecryption=True
+            )
+            return response["Parameter"]["Value"]
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ParameterNotFound":
+                if attempt < max_retries - 1:
+                    time.sleep(retry_delay)
+                    continue
+                else:
+                    raise Exception(
+                        f"Failed to retrieve key pair after {max_retries} attempts"
+                    )
+            else:
+                raise
+
+
+# Retrieve the private key material
+private_key = pulumi.Output.all(key_pair.key_pair_id).apply(
+    lambda args: get_key_pair_material(args[0])
+)
+
+# Create an EC2 instance
+instance = aws.ec2.Instance(
+    "dice-instance",
+    instance_type=instance_type,
+    ami=ami_id,
+    subnet_id=subnet.id,
+    vpc_security_group_ids=[security_group.id],
+    key_name=key_pair.key_name,
+    tags={"Name": instance_name, "Project": "DiceDB"},
+)
+
+# Use the remote-exec provisioner to set up DiceDB
+# This installs necessary dependencies, clones the DiceDB repo,
+# builds the executable, and sets up a systemd service
+setup_dice = command.remote.Command(
+    "setup-dice",
+    connection=command.remote.ConnectionArgs(
+        host=instance.public_ip,
+        user="ec2-user",
+        private_key=private_key,
+    ),
+    create=pulumi.Output.all(instance.public_ip).apply(
+        lambda args: """
+        set -e
+        sudo yum update -y
+        sudo yum install -y git golang
+        git clone https://github.com/dicedb/dice.git
+        cd dice
+        go build -o dicedb main.go
+        sudo mv dicedb /usr/local/bin/
+        sudo bash -c 'cat > /etc/systemd/system/dicedb.service << EOT
+[Unit]
+Description=DiceDB Service
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/dicedb
+Restart=always
+User=ec2-user
+Group=ec2-user
+Environment=HOME=/home/ec2-user
+
+[Install]
+WantedBy=multi-user.target
+EOT'
+        sudo systemctl daemon-reload
+        sudo systemctl start dicedb
+        sudo systemctl enable dicedb
+        echo "DiceDB setup completed successfully"
+        """
+    ),
+)
+
+pulumi.export("instance_public_ip", instance.public_ip)

--- a/pulumi/requirements.txt
+++ b/pulumi/requirements.txt
@@ -1,0 +1,5 @@
+pulumi
+pulumi-aws
+pulumi-aws-native
+pulumi-command
+boto3


### PR DESCRIPTION
Add Pulumi script to automate the deployment of DiceDB on AWS. 
## How to Run the Script

1. Configure AWS credentials:
   ```
   aws configure
   ```

2. Create and activate a virtual environment:
   ```
   python -m venv venv
   source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
   ```

3. Install requirements:
   ```
   pip install -r requirements.txt
   ```

4. Create a new Pulumi stack or use an existing one:
   ```
   pulumi stack init my-stack  # Create new stack
   # OR
   pulumi stack select dev     # Use existing dev stack
   ```

5. Review and update inputs in the Pulumi config file (`Pulumi.<stack-name>.yaml`)

6. Preview the changes:
   ```
   pulumi preview
   ```

7. Deploy the infrastructure:
   ```
   pulumi up
   ```

## Implementation Details
- Uses Pulumi with Python for infrastructure as code
- Creates a new VPC, subnet, internet gateway, and route table
- Provisions an EC2 instance with Amazon Linux 2
- Installs Go, and sets up DiceDB as a systemd service

## Testing Results
The deployment successfully creates the infrastructure and installs DiceDB. However, there's a connectivity issue:

- The first connection and operations (SET/GET) work as expected
- Subsequent attempts result in connection timeouts
- The `systemctl status dicedb` shows the service as active and running

test script: 
```python
import redis
import logging
import time

logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
logger = logging.getLogger(__name__)


REDIS_HOST = 'public ip of the ec2'
REDIS_PORT = 7379
REDIS_DB = 0
MAX_RETRIES = 3
RETRY_DELAY = 2  # seconds

def connect_to_redis():
    for attempt in range(MAX_RETRIES):
        try:
            logger.info(f"Attempting to connect to Redis (Attempt {attempt + 1}/{MAX_RETRIES})")
            r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, socket_timeout=10)
            r.ping()  # Test the connection
            logger.info("Successfully connected to Redis")
            return r
        except redis.exceptions.ConnectionError as e:
            logger.error(f"Failed to connect to Redis: {e}")
            if attempt < MAX_RETRIES - 1:
                logger.info(f"Retrying in {RETRY_DELAY} seconds...")
                time.sleep(RETRY_DELAY)
            else:
                logger.error("Max retries reached. Unable to connect to Redis.")
                raise

try:
      r = connect_to_redis()

    logger.info("Setting 'foo' to 'bar'")
    r.set('foo', 'bar')

    logger.info("Getting value of 'foo'")
    value = r.get('foo')
    logger.info(f"Value of 'foo': {value.decode('utf-8')}")

except redis.exceptions.RedisError as e:
    logger.error(f"Redis error occurred: {e}")
except Exception as e:
    logger.error(f"An unexpected error occurred: {e}")
finally:
    if 'r' in locals():
        logger.info("Closing Redis connection")
        r.close()
```

### Test Script Output
```python
# First attempt (successful)
2024-07-15 18:46:00,530 INFO - Attempting to connect to Redis (Attempt 1/3)
2024-07-15 18:46:01,362 INFO - Successfully connected to Redis
2024-07-15 18:46:01,362 INFO - Setting 'foo' to 'bar'
2024-07-15 18:46:01,570 - INFO Getting value of 'foo'
2024-07-15 18:46:01,777 INFO Value of 'foo': bar
2024-07-15 18:46:01,779 INFO Closing Redis connection

# Second attempt (timeout)
2024-07-15 18:46:03,684 INFO - Attempting to connect to Redis (Attempt 1/3)
2024-07-15 18:46:13,898 ERROR - Redis error occurred: Timeout reading from socket
```

I'd appreciate any insights or suggestions on addressing the connection timeout issue, as well as any improvements to the infrastructure setup or DiceDB configuration.

## Note on S3 Backend
This Pulumi project uses an S3 backend for state management. **Important:** Ensure that the specified S3 bucket (`dice-pulumi`/any suitable bucketname) is created before running the Pulumi script. Alternatively we can use the pulumi cloud for storing the state.

