### PR TITLE
Disable running integration tests in github workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,6 @@ jobs:
       - name: Install dependencies
         run: go get .
       - name: Build
-        run: go build -v ./...
+        run: make build
       - name: Run unit tests with the Go CLI
-        run: go test -v -count=1 ./core/...
-      - name: Run integration tests with the Go CLI
-        run: go test -v -count=1 ./tests/...
+        run: make unittest


### PR DESCRIPTION
Issue - https://github.com/DiceDB/dice/issues/164

## Summary:
The PR disables running integration tests when running GitHub workflow.
The PR also changes the build and unit test steps to use the Makefile commands to reuse the same commands as defined in the Makefile.

## Testing:
The PR has been tested both locally and via github workflows in the downstream repository.