### PR TITLE
#182: Refactor command handling for maintainability

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -11,37 +11,57 @@ var (
 
 	pingCmdMeta = DiceCmdMeta{
 		Name: "PING",
-		Info: "ping command info here",
+		Info: `PING returns with an encoded "PONG" If any message is added with the ping command,the message will be returned.`,
 		Eval: evalPING,
 	}
 	setCmdMeta = DiceCmdMeta{
 		Name: "SET",
-		Info: "set command info here",
+		Info: `SET puts a new <key, value> pair in db as in the args
+		args must contain key and value.
+		args can also contain multiple options -
+		EX or ex which will set the expiry time(in secs) for the key
+		Returns encoded error response if at least a <key, value> pair is not part of args
+		Returns encoded error response if expiry tme value in not integer
+		Returns encoded OK RESP once new entry is added
+		If the key already exists then the value will be overwritten and expiry will be discarded`,
 		Eval: evalSET,
 	}
 	getCmdMeta = DiceCmdMeta{
 		Name: "GET",
-		Info: "get command info here",
+		Info: `GET returns the value for the queried key in args
+		The key should be the only param in args
+		The RESP value of the key is encoded and then returned
+		evalGET returns RESP_NIL if key is expired or it does not exist`,
 		Eval: evalGET,
 	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
-		Info: "ttl command info here",
+		Info: `TTL returns Time-to-Live in secs for the queried key in args
+		 The key should be the only param in args else returns with an error
+		 Returns	
+		 RESP encoded time (in secs) remaining for the key to expire
+		 RESP encoded -2 stating key doesn't exist or key is expired
+		 RESP encoded -1 in case no expiration is set on the key`,
 		Eval: evalTTL,
 	}
 	delCmdMeta = DiceCmdMeta{
 		Name: "DEL",
-		Info: "del command info here",
+		Info: `DEL deletes all the specified keys in args list
+		returns the count of total deleted keys after encoding`,
 		Eval: evalDEL,
 	}
 	expireCmdMeta = DiceCmdMeta{
 		Name: "EXPIRE",
-		Info: "expire command info here",
+		Info: `EXPIRE sets a expiry time(in secs) on the specified key in args
+		args should contain 2 values, key and the expiry time to be set for the key
+		The expiry time should be in integer format; if not, it returns encoded error response
+		Returns RESP_ONE if expiry was set on the key successfully.
+		Once the time is lapsed, the key will be deleted automatically`,
 		Eval: evalEXPIRE,
 	}
 	helloCmdMeta = DiceCmdMeta{
 		Name: "HELLO",
-		Info: "hello command info here",
+		Info: `HELLO always replies with a list of current server and connection properties, such as: versions, modules loaded, client ID, replication role and so forth`,
 		Eval: evalHELLO,
 	}
 	bgrewriteaofCmdMeta = DiceCmdMeta{
@@ -51,163 +71,236 @@ var (
 	}
 	incrCmdMeta = DiceCmdMeta{
 		Name: "INCR",
-		Info: "incr command info here",
+		Info: `INCR increments the value of the specified key in args by 1,
+		if the key exists and the value is integer format.
+		The key should be the only param in args.
+		If the key does not exist, new key is created with value 0,
+		the value of the new key is then incremented.
+		The value for the queried key should be of integer format,
+		if not evalINCR returns encoded error response.
+		evalINCR returns the incremented value for the key if there are no errors.`,
 		Eval: evalINCR,
 	}
 	infoCmdMeta = DiceCmdMeta{
 		Name: "INFO",
-		Info: "info command info here",
+		Info: `INFO creates a buffer with the info of total keys per db
+		Returns the encoded buffer as response`,
 		Eval: evalINFO,
 	}
 	clientCmdMeta = DiceCmdMeta{
 		Name: "CLIENT",
-		Info: "client command info here",
+		Info: `This is a container command for client connection commands.`,
 		Eval: evalCLIENT,
 	}
 	latencyCmdMeta = DiceCmdMeta{
 		Name: "LATENCY",
-		Info: "latency command info here",
+		Info: `This is a container command for latency diagnostics commands.`,
 		Eval: evalLATENCY,
 	}
 	lruCmdMeta = DiceCmdMeta{
 		Name: "LRU",
-		Info: "lru command info here",
+		Info: `LRU deletes all the keys from the LRU
+		returns encoded RESP OK`,
 		Eval: evalLRU,
 	}
 	sleepCmdMeta = DiceCmdMeta{
 		Name: "SLEEP",
-		Info: "sleep command info here",
+		Info: `SLEEP sets db to sleep for the specified number of seconds.
+		The sleep time should be the only param in args.
+		Returns error response if the time param in args is not of integer format.
+		SLEEP returns RESP_OK after sleeping for mentioned seconds`,
 		Eval: evalSLEEP,
 	}
 	qintinsCmdMeta = DiceCmdMeta{
 		Name: "QINTINS",
-		Info: "qintins command info here",
+		Info: `QINTINS inserts the provided integer in the key identified by key
+		first argument will be the key, that should be of type "QINT"
+		second argument will be the integer value
+		if the key does not exist, QINTINS will also create the integer queue`,
 		Eval: evalQINTINS,
 	}
 	qintremCmdMeta = DiceCmdMeta{
 		Name: "QINTREM",
-		Info: "qintrem command info here",
+		Info: `QINTREM removes the element from the QINT identified by key
+		first argument will be the key, that should be of type "QINT"
+		if the key does not exist, QINTREM returns nil otherwise it
+		returns the integer value popped from the queue
+		if we remove from the empty queue, nil is returned`,
 		Eval: evalQINTREM,
 	}
 	qintlenCmdMeta = DiceCmdMeta{
 		Name: "QINTLEN",
-		Info: "qintlen command info here",
+		Info: `QINTLEN returns the length of the QINT identified by key
+		returns the integer value indicating the length of the queue
+		if the key does not exist, the response is 0`,
 		Eval: evalQINTLEN,
 	}
 	qintpeekCmdMeta = DiceCmdMeta{
 		Name: "QINTPEEK",
-		Info: "qintpeek command info here",
+		Info: `QINTPEEK peeks into the QINT and returns 5 elements without popping them
+		returns the array of integers as the response.
+		if the key does not exist, then we return an empty array`,
 		Eval: evalQINTPEEK,
 	}
 	bfinitCmdMeta = DiceCmdMeta{
 		Name: "BFINIT",
-		Info: "bfinit command info here",
+		Info: `BFINIT command initializes a new bloom filter and allocation it's relevant parameters based on given inputs.
+		If no params are provided, it uses defaults.`,
 		Eval: evalBFINIT,
 	}
 	bfaddCmdMeta = DiceCmdMeta{
 		Name: "BFADD",
-		Info: "bfadd command info here",
+		Info: `BFADD adds an element to
+		a bloom filter. If the filter does not exists, it will create a new one
+		with default parameters.`,
 		Eval: evalBFADD,
 	}
 	bfexistsCmdMeta = DiceCmdMeta{
 		Name: "BFEXISTS",
-		Info: "bfexists command info here",
+		Info: `BFEXISTS checks existance of an element in a bloom filter.`,
 		Eval: evalBFEXISTS,
 	}
 	bfinfoCmdMeta = DiceCmdMeta{
 		Name: "BFINFO",
-		Info: "bfinfo command info here",
+		Info: `BFINFO returns the parameters and metadata of an existing bloom filter.`,
 		Eval: evalBFINFO,
 	}
 	qrefinsCmdMeta = DiceCmdMeta{
 		Name: "QREFINS",
-		Info: "qrefins command info here",
+		Info: `QREFINS inserts the reference of the provided key identified by key
+		first argument will be the key, that should be of type "QREF"
+		second argument will be the key that needs to be added to the queueref
+		if the queue does not exist, QREFINS will also create the queueref
+		returns 1 if the key reference was inserted
+		returns 0 otherwise`,
 		Eval: evalQREFINS,
 	}
 	qrefremCmdMeta = DiceCmdMeta{
 		Name: "QREFREM",
-		Info: "qrefrem command info here",
+		Info: `QREFREM removes the element from the QREF identified by key
+		first argument will be the key, that should be of type "QREF"
+		if the key does not exist, QREFREM returns nil otherwise it
+		returns the RESP encoded value of the key reference from the queue
+		if we remove from the empty queue, nil is returned`,
 		Eval: evalQREFREM,
 	}
 	qreflenCmdMeta = DiceCmdMeta{
 		Name: "QREFLEN",
-		Info: "qreflen command info here",
+		Info: `QREFLEN returns the length of the QREF identified by key
+		returns the integer value indicating the length of the queue
+		if the key does not exist, the response is 0`,
 		Eval: evalQREFLEN,
 	}
 	qrefpeekCmdMeta = DiceCmdMeta{
-		Name: "GET",
-		Info: "qrefpeek command info here",
-		Eval: evalGET,
+		Name: "QREFPEEK",
+		Info: `QREFPEEK peeks into the QREF and returns 5 elements without popping them
+		returns the array of resp encoded values as the response.
+		if the key does not exist, then we return an empty array`,
+		Eval: evalQREFPEEK,
 	}
 	stackintpushCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPUSH",
-		Info: "stackintpush command info here",
+		Info: `STACKINTPUSH pushes the provided integer in the key identified by key
+		first argument will be the key, that should be of type "STACKINT"
+		second argument will be the integer value
+		if the key does not exist, STACKINTPUSH will also create the integer stack`,
 		Eval: evalSTACKINTPUSH,
 	}
 	stackintpopCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPOP",
-		Info: "stackintpop command info here",
+		Info: `STACKINTPOP pops the element from the STACKINT identified by key
+		first argument will be the key, that should be of type "STACKINT"
+		if the key does not exist, STACKINTPOP returns nil otherwise it
+		returns the integer value popped from the stack
+		if we remove from the empty stack, nil is returned`,
 		Eval: evalSTACKINTPOP,
 	}
 	stackintlenCmdMeta = DiceCmdMeta{
 		Name: "STACKINTLEN",
-		Info: "stackintlen command info here",
+		Info: `STACKINTLEN returns the length of the STACKINT identified by key
+		returns the integer value indicating the length of the stack
+		if the key does not exist, the response is 0`,
 		Eval: evalSTACKINTLEN,
 	}
 	stackintpeekCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPEEK",
-		Info: "stackintpeek command info here",
+		Info: `STACKINTPEEK peeks into the DINT and returns 5 elements without popping them
+		returns the array of integers as the response.
+		if the key does not exist, then we return an empty array`,
 		Eval: evalSTACKINTPEEK,
 	}
 	stackrefpushCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPUSH",
-		Info: "stackrefpush command info here",
+		Info: `STACKREFPUSH inserts the reference of the provided key identified by key
+		first argument will be the key, that should be of type "STACKREF"
+		second argument will be the key that needs to be added to the stackref
+		if the stack does not exist, STACKREFPUSH will also create the stackref
+		returns 1 if the key reference was inserted
+		returns 0 otherwise`,
 		Eval: evalSTACKREFPUSH,
 	}
 	stackrefpopCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPOP",
-		Info: "stackrefpop command info here",
+		Info: `STACKREFPOP removes the element from the DREF identified by key
+		first argument will be the key, that should be of type "STACKREF"
+		if the key does not exist, STACKREFPOP returns nil otherwise it
+		returns the RESP encoded value of the key reference from the stack
+		if we remove from the empty stack, nil is returned`,
 		Eval: evalSTACKREFPOP,
 	}
 	stackreflenCmdMeta = DiceCmdMeta{
 		Name: "STACKREFLEN",
-		Info: "stackreflen command info here",
+		Info: `STACKREFLEN returns the length of the STACKREF identified by key
+		returns the integer value indicating the length of the stack
+		if the key does not exist, the response is 0`,
 		Eval: evalSTACKREFLEN,
 	}
 	stackrefpeekCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPEEK",
-		Info: "stackrefpeek command info here",
+		Info: `STACKREFPEEK peeks into the STACKREF and returns 5 elements without popping them
+		returns the array of resp encoded values as the response.
+		if the key does not exist, then we return an empty array`,
 		Eval: evalSTACKREFPEEK,
 	}
 	// TODO: Remove this override once we support QWATCH in dice-cli.
 	subscribeCmdMeta = DiceCmdMeta{
 		Name: "SUBSCRIBE",
-		Info: "subscribe command info here",
+		Info: `SUBSCRIBE(or QWATCH) adds the specified key to the watch list for the caller client.
+		Every time a key in the watch list is modified, the client will be sent a response
+		containing the new value of the key along with the operation that was performed on it.
+		Contains only one argument, the key to be watched.`,
 		Eval: nil,
 	}
 	qwatchCmdMeta = DiceCmdMeta{
 		Name: "QWATCH",
-		Info: "qwatch command info here",
+		Info: `QWATCH adds the specified key to the watch list for the caller client.
+		Every time a key in the watch list is modified, the client will be sent a response
+		containing the new value of the key along with the operation that was performed on it.
+		Contains only one argument, the key to be watched.`,
 		Eval: nil,
 	}
 	multiCmdMeta = DiceCmdMeta{
 		Name: "MULTI",
-		Info: "multi command info here",
+		Info: `MULTI marks the start of the transaction for the client.
+		All subsequent commands fired will be queued for atomic execution.
+		The commands will not be executed until EXEC is triggered.
+		Once EXEC is triggered it executes all the commands in queue,
+		and closes the MULTI transaction.`,
 		Eval: evalMULTI,
 	}
 	execCmdMeta = DiceCmdMeta{
 		Name: "EXEC",
-		Info: "exec command info here",
+		Info: `EXEC executes commands in a transaction, which is initiated by MULTI`,
 		Eval: nil,
 	}
 	discardCmdMeta = DiceCmdMeta{
 		Name: "DISCARD",
-		Info: "discard command info here",
+		Info: `DISCARD discards all the commands in a transaction, which is initiated by MULTI`,
 		Eval: nil,
 	}
 	abortCmdMeta = DiceCmdMeta{
 		Name: "ABORT",
-		Info: "abort command info here",
+		Info: "",
 		Eval: nil,
 	}
 )

--- a/core/commands.go
+++ b/core/commands.go
@@ -1,0 +1,297 @@
+package core
+
+type DiceCmdMeta struct {
+	Name string
+	Info string
+	Docs string
+	Eval func([]string) []byte
+}
+
+var (
+	diceCmds = map[string]DiceCmdMeta{}
+
+	pingCmdMeta = DiceCmdMeta{
+		Name: "PING",
+		Info: "ping command info here",
+		Docs: "ping command docs here",
+		Eval: evalPING,
+	}
+	setCmdMeta = DiceCmdMeta{
+		Name: "SET",
+		Info: "set command info here",
+		Docs: "set command docs here",
+		Eval: evalSET,
+	}
+	getCmdMeta = DiceCmdMeta{
+		Name: "GET",
+		Info: "get command info here",
+		Docs: "get command docs here",
+		Eval: evalGET,
+	}
+	ttlCmdMeta = DiceCmdMeta{
+		Name: "TTL",
+		Info: "ttl command info here",
+		Docs: "ttl command docs here",
+		Eval: evalTTL,
+	}
+	delCmdMeta = DiceCmdMeta{
+		Name: "DEL",
+		Info: "del command info here",
+		Docs: "del command docs here",
+		Eval: evalDEL,
+	}
+	expireCmdMeta = DiceCmdMeta{
+		Name: "EXPIRE",
+		Info: "expire command info here",
+		Docs: "expire command docs here",
+		Eval: evalEXPIRE,
+	}
+	helloCmdMeta = DiceCmdMeta{
+		Name: "HELLO",
+		Info: "hello command info here",
+		Docs: "hello command docs here",
+		Eval: evalHELLO,
+	}
+	bgrewriteaofCmdMeta = DiceCmdMeta{
+		Name: "BGREWRITEAOF",
+		Info: "bgrewriteaof command info here",
+		Docs: "bgrewriteaof command docs here",
+		Eval: evalBGREWRITEAOF,
+	}
+	incrCmdMeta = DiceCmdMeta{
+		Name: "INCR",
+		Info: "incr command info here",
+		Docs: "incr command docs here",
+		Eval: evalINCR,
+	}
+	infoCmdMeta = DiceCmdMeta{
+		Name: "INFO",
+		Info: "info command info here",
+		Docs: "info command docs here",
+		Eval: evalINFO,
+	}
+	clientCmdMeta = DiceCmdMeta{
+		Name: "CLIENT",
+		Info: "client command info here",
+		Docs: "client command docs here",
+		Eval: evalCLIENT,
+	}
+	latencyCmdMeta = DiceCmdMeta{
+		Name: "LATENCY",
+		Info: "latency command info here",
+		Docs: "latency command docs here",
+		Eval: evalLATENCY,
+	}
+	lruCmdMeta = DiceCmdMeta{
+		Name: "LRU",
+		Info: "lru command info here",
+		Docs: "lru command docs here",
+		Eval: evalLRU,
+	}
+	sleepCmdMeta = DiceCmdMeta{
+		Name: "SLEEP",
+		Info: "sleep command info here",
+		Docs: "sleep command docs here",
+		Eval: evalSLEEP,
+	}
+	qintinsCmdMeta = DiceCmdMeta{
+		Name: "QINTINS",
+		Info: "qintins command info here",
+		Docs: "qintins command docs here",
+		Eval: evalQINTINS,
+	}
+	qintremCmdMeta = DiceCmdMeta{
+		Name: "QINTREM",
+		Info: "qintrem command info here",
+		Docs: "qintrem command docs here",
+		Eval: evalQINTREM,
+	}
+	qintlenCmdMeta = DiceCmdMeta{
+		Name: "QINTLEN",
+		Info: "qintlen command info here",
+		Docs: "qintlen command docs here",
+		Eval: evalQINTLEN,
+	}
+	qintpeekCmdMeta = DiceCmdMeta{
+		Name: "QINTPEEK",
+		Info: "qintpeek command info here",
+		Docs: "qintpeek command docs here",
+		Eval: evalQINTPEEK,
+	}
+	bfinitCmdMeta = DiceCmdMeta{
+		Name: "BFINIT",
+		Info: "bfinit command info here",
+		Docs: "bfinit command docs here",
+		Eval: evalBFINIT,
+	}
+	bfaddCmdMeta = DiceCmdMeta{
+		Name: "BFADD",
+		Info: "bfadd command info here",
+		Docs: "bfadd command docs here",
+		Eval: evalBFADD,
+	}
+	bfexistsCmdMeta = DiceCmdMeta{
+		Name: "BFEXISTS",
+		Info: "bfexists command info here",
+		Docs: "bfexists command docs here",
+		Eval: evalBFEXISTS,
+	}
+	bfinfoCmdMeta = DiceCmdMeta{
+		Name: "BFINFO",
+		Info: "bfinfo command info here",
+		Docs: "bfinfo command docs here",
+		Eval: evalBFINFO,
+	}
+	qrefinsCmdMeta = DiceCmdMeta{
+		Name: "QREFINS",
+		Info: "qrefins command info here",
+		Docs: "qrefins command docs here",
+		Eval: evalQREFINS,
+	}
+	qrefremCmdMeta = DiceCmdMeta{
+		Name: "QREFREM",
+		Info: "qrefrem command info here",
+		Docs: "qrefrem command docs here",
+		Eval: evalQREFREM,
+	}
+	qreflenCmdMeta = DiceCmdMeta{
+		Name: "QREFLEN",
+		Info: "qreflen command info here",
+		Docs: "qreflen command docs here",
+		Eval: evalQREFLEN,
+	}
+	qrefpeekCmdMeta = DiceCmdMeta{
+		Name: "GET",
+		Info: "qrefpeek command info here",
+		Docs: "qrefpeek command docs here",
+		Eval: evalGET,
+	}
+	stackintpushCmdMeta = DiceCmdMeta{
+		Name: "STACKINTPUSH",
+		Info: "stackintpush command info here",
+		Docs: "stackintpush command docs here",
+		Eval: evalSTACKINTPUSH,
+	}
+	stackintpopCmdMeta = DiceCmdMeta{
+		Name: "STACKINTPOP",
+		Info: "stackintpop command info here",
+		Docs: "stackintpop command docs here",
+		Eval: evalSTACKINTPOP,
+	}
+	stackintlenCmdMeta = DiceCmdMeta{
+		Name: "STACKINTLEN",
+		Info: "stackintlen command info here",
+		Docs: "stackintlen command docs here",
+		Eval: evalSTACKINTLEN,
+	}
+	stackintpeekCmdMeta = DiceCmdMeta{
+		Name: "STACKINTPEEK",
+		Info: "stackintpeek command info here",
+		Docs: "stackintpeek command docs here",
+		Eval: evalSTACKINTPEEK,
+	}
+	stackrefpushCmdMeta = DiceCmdMeta{
+		Name: "STACKREFPUSH",
+		Info: "stackrefpush command info here",
+		Docs: "stackrefpush command docs here",
+		Eval: evalSTACKREFPUSH,
+	}
+	stackrefpopCmdMeta = DiceCmdMeta{
+		Name: "STACKREFPOP",
+		Info: "stackrefpop command info here",
+		Docs: "stackrefpop command docs here",
+		Eval: evalSTACKREFPOP,
+	}
+	stackreflenCmdMeta = DiceCmdMeta{
+		Name: "STACKREFLEN",
+		Info: "stackreflen command info here",
+		Docs: "stackreflen command docs here",
+		Eval: evalSTACKREFLEN,
+	}
+	stackrefpeekCmdMeta = DiceCmdMeta{
+		Name: "STACKREFPEEK",
+		Info: "stackrefpeek command info here",
+		Docs: "stackrefpeek command docs here",
+		Eval: evalSTACKREFPEEK,
+	}
+	// TODO: Remove this override once we support QWATCH in dice-cli.
+	subscribeCmdMeta = DiceCmdMeta{
+		Name: "SUBSCRIBE",
+		Info: "subscribe command info here",
+		Docs: "subscribe command docs here",
+		Eval: nil,
+	}
+	qwatchCmdMeta = DiceCmdMeta{
+		Name: "QWATCH",
+		Info: "qwatch command info here",
+		Docs: "qwatch command docs here",
+		Eval: nil,
+	}
+	multiCmdMeta = DiceCmdMeta{
+		Name: "MULTI",
+		Info: "multi command info here",
+		Docs: "multi command docs here",
+		Eval: evalMULTI,
+	}
+	execCmdMeta = DiceCmdMeta{
+		Name: "EXEC",
+		Info: "exec command info here",
+		Docs: "exec command docs here",
+		Eval: nil,
+	}
+	discardCmdMeta = DiceCmdMeta{
+		Name: "DISCARD",
+		Info: "discard command info here",
+		Docs: "discard command docs here",
+		Eval: nil,
+	}
+	abortCmdMeta = DiceCmdMeta{
+		Name: "ABORT",
+		Info: "abort command info here",
+		Docs: "abort command docs here",
+		Eval: nil,
+	}
+)
+
+func init() {
+	diceCmds["PING"] = pingCmdMeta
+	diceCmds["SET"] = setCmdMeta
+	diceCmds["GET"] = getCmdMeta
+	diceCmds["TTL"] = ttlCmdMeta
+	diceCmds["DEL"] = delCmdMeta
+	diceCmds["EXPIRE"] = expireCmdMeta
+	diceCmds["HELLO"] = helloCmdMeta
+	diceCmds["BGREWRITEAOF"] = bgrewriteaofCmdMeta
+	diceCmds["INCR"] = incrCmdMeta
+	diceCmds["INFO"] = infoCmdMeta
+	diceCmds["CLIENT"] = clientCmdMeta
+	diceCmds["LATENCY"] = latencyCmdMeta
+	diceCmds["LRU"] = lruCmdMeta
+	diceCmds["SLEEP"] = sleepCmdMeta
+	diceCmds["QINTINS"] = qintinsCmdMeta
+	diceCmds["QINTREM"] = qintremCmdMeta
+	diceCmds["QINTLEN"] = qintlenCmdMeta
+	diceCmds["QINTPEEK"] = qintpeekCmdMeta
+	diceCmds["BFINIT"] = bfinitCmdMeta
+	diceCmds["BFADD"] = bfaddCmdMeta
+	diceCmds["BFEXISTS"] = bfexistsCmdMeta
+	diceCmds["BFINFO"] = bfinfoCmdMeta
+	diceCmds["QREFINS"] = qrefinsCmdMeta
+	diceCmds["QREFREM"] = qrefremCmdMeta
+	diceCmds["QREFLEN"] = qreflenCmdMeta
+	diceCmds["QREFPEEK"] = qrefpeekCmdMeta
+	diceCmds["STACKINTPUSH"] = stackintpushCmdMeta
+	diceCmds["STACKINTPOP"] = stackintpopCmdMeta
+	diceCmds["STACKINTLEN"] = stackintlenCmdMeta
+	diceCmds["STACKINTPEEK"] = stackintpeekCmdMeta
+	diceCmds["STACKREFPUSH"] = stackrefpushCmdMeta
+	diceCmds["STACKREFPOP"] = stackrefpopCmdMeta
+	diceCmds["STACKREFLEN"] = stackreflenCmdMeta
+	diceCmds["STACKREFPEEK"] = stackrefpeekCmdMeta
+	diceCmds["SUBSCRIBE"] = subscribeCmdMeta
+	diceCmds["QWATCH"] = qwatchCmdMeta
+	diceCmds["MULTI"] = multiCmdMeta
+	diceCmds["EXEC"] = execCmdMeta
+	diceCmds["DISCARD"] = discardCmdMeta
+	diceCmds["ABORT"] = abortCmdMeta
+}

--- a/core/commands.go
+++ b/core/commands.go
@@ -31,7 +31,7 @@ var (
 		Info: `GET returns the value for the queried key in args
 		The key should be the only param in args
 		The RESP value of the key is encoded and then returned
-		evalGET returns RESP_NIL if key is expired or it does not exist`,
+		GET returns RESP_NIL if key is expired or it does not exist`,
 		Eval: evalGET,
 	}
 	ttlCmdMeta = DiceCmdMeta{
@@ -66,7 +66,7 @@ var (
 	}
 	bgrewriteaofCmdMeta = DiceCmdMeta{
 		Name: "BGREWRITEAOF",
-		Info: "bgrewriteaof command info here",
+		Info: `Instruct Dice to start an Append Only File rewrite process. The rewrite will create a small optimized version of the current Append Only File.`,
 		Eval: evalBGREWRITEAOF,
 	}
 	incrCmdMeta = DiceCmdMeta{
@@ -77,7 +77,7 @@ var (
 		If the key does not exist, new key is created with value 0,
 		the value of the new key is then incremented.
 		The value for the queried key should be of integer format,
-		if not evalINCR returns encoded error response.
+		if not INCR returns encoded error response.
 		evalINCR returns the incremented value for the key if there are no errors.`,
 		Eval: evalINCR,
 	}
@@ -300,7 +300,7 @@ var (
 	}
 	abortCmdMeta = DiceCmdMeta{
 		Name: "ABORT",
-		Info: "",
+		Info: "Quit the server",
 		Eval: nil,
 	}
 )

--- a/core/commands.go
+++ b/core/commands.go
@@ -3,7 +3,6 @@ package core
 type DiceCmdMeta struct {
 	Name string
 	Info string
-	Docs string
 	Eval func([]string) []byte
 }
 
@@ -13,242 +12,202 @@ var (
 	pingCmdMeta = DiceCmdMeta{
 		Name: "PING",
 		Info: "ping command info here",
-		Docs: "ping command docs here",
 		Eval: evalPING,
 	}
 	setCmdMeta = DiceCmdMeta{
 		Name: "SET",
 		Info: "set command info here",
-		Docs: "set command docs here",
 		Eval: evalSET,
 	}
 	getCmdMeta = DiceCmdMeta{
 		Name: "GET",
 		Info: "get command info here",
-		Docs: "get command docs here",
 		Eval: evalGET,
 	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
 		Info: "ttl command info here",
-		Docs: "ttl command docs here",
 		Eval: evalTTL,
 	}
 	delCmdMeta = DiceCmdMeta{
 		Name: "DEL",
 		Info: "del command info here",
-		Docs: "del command docs here",
 		Eval: evalDEL,
 	}
 	expireCmdMeta = DiceCmdMeta{
 		Name: "EXPIRE",
 		Info: "expire command info here",
-		Docs: "expire command docs here",
 		Eval: evalEXPIRE,
 	}
 	helloCmdMeta = DiceCmdMeta{
 		Name: "HELLO",
 		Info: "hello command info here",
-		Docs: "hello command docs here",
 		Eval: evalHELLO,
 	}
 	bgrewriteaofCmdMeta = DiceCmdMeta{
 		Name: "BGREWRITEAOF",
 		Info: "bgrewriteaof command info here",
-		Docs: "bgrewriteaof command docs here",
 		Eval: evalBGREWRITEAOF,
 	}
 	incrCmdMeta = DiceCmdMeta{
 		Name: "INCR",
 		Info: "incr command info here",
-		Docs: "incr command docs here",
 		Eval: evalINCR,
 	}
 	infoCmdMeta = DiceCmdMeta{
 		Name: "INFO",
 		Info: "info command info here",
-		Docs: "info command docs here",
 		Eval: evalINFO,
 	}
 	clientCmdMeta = DiceCmdMeta{
 		Name: "CLIENT",
 		Info: "client command info here",
-		Docs: "client command docs here",
 		Eval: evalCLIENT,
 	}
 	latencyCmdMeta = DiceCmdMeta{
 		Name: "LATENCY",
 		Info: "latency command info here",
-		Docs: "latency command docs here",
 		Eval: evalLATENCY,
 	}
 	lruCmdMeta = DiceCmdMeta{
 		Name: "LRU",
 		Info: "lru command info here",
-		Docs: "lru command docs here",
 		Eval: evalLRU,
 	}
 	sleepCmdMeta = DiceCmdMeta{
 		Name: "SLEEP",
 		Info: "sleep command info here",
-		Docs: "sleep command docs here",
 		Eval: evalSLEEP,
 	}
 	qintinsCmdMeta = DiceCmdMeta{
 		Name: "QINTINS",
 		Info: "qintins command info here",
-		Docs: "qintins command docs here",
 		Eval: evalQINTINS,
 	}
 	qintremCmdMeta = DiceCmdMeta{
 		Name: "QINTREM",
 		Info: "qintrem command info here",
-		Docs: "qintrem command docs here",
 		Eval: evalQINTREM,
 	}
 	qintlenCmdMeta = DiceCmdMeta{
 		Name: "QINTLEN",
 		Info: "qintlen command info here",
-		Docs: "qintlen command docs here",
 		Eval: evalQINTLEN,
 	}
 	qintpeekCmdMeta = DiceCmdMeta{
 		Name: "QINTPEEK",
 		Info: "qintpeek command info here",
-		Docs: "qintpeek command docs here",
 		Eval: evalQINTPEEK,
 	}
 	bfinitCmdMeta = DiceCmdMeta{
 		Name: "BFINIT",
 		Info: "bfinit command info here",
-		Docs: "bfinit command docs here",
 		Eval: evalBFINIT,
 	}
 	bfaddCmdMeta = DiceCmdMeta{
 		Name: "BFADD",
 		Info: "bfadd command info here",
-		Docs: "bfadd command docs here",
 		Eval: evalBFADD,
 	}
 	bfexistsCmdMeta = DiceCmdMeta{
 		Name: "BFEXISTS",
 		Info: "bfexists command info here",
-		Docs: "bfexists command docs here",
 		Eval: evalBFEXISTS,
 	}
 	bfinfoCmdMeta = DiceCmdMeta{
 		Name: "BFINFO",
 		Info: "bfinfo command info here",
-		Docs: "bfinfo command docs here",
 		Eval: evalBFINFO,
 	}
 	qrefinsCmdMeta = DiceCmdMeta{
 		Name: "QREFINS",
 		Info: "qrefins command info here",
-		Docs: "qrefins command docs here",
 		Eval: evalQREFINS,
 	}
 	qrefremCmdMeta = DiceCmdMeta{
 		Name: "QREFREM",
 		Info: "qrefrem command info here",
-		Docs: "qrefrem command docs here",
 		Eval: evalQREFREM,
 	}
 	qreflenCmdMeta = DiceCmdMeta{
 		Name: "QREFLEN",
 		Info: "qreflen command info here",
-		Docs: "qreflen command docs here",
 		Eval: evalQREFLEN,
 	}
 	qrefpeekCmdMeta = DiceCmdMeta{
 		Name: "GET",
 		Info: "qrefpeek command info here",
-		Docs: "qrefpeek command docs here",
 		Eval: evalGET,
 	}
 	stackintpushCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPUSH",
 		Info: "stackintpush command info here",
-		Docs: "stackintpush command docs here",
 		Eval: evalSTACKINTPUSH,
 	}
 	stackintpopCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPOP",
 		Info: "stackintpop command info here",
-		Docs: "stackintpop command docs here",
 		Eval: evalSTACKINTPOP,
 	}
 	stackintlenCmdMeta = DiceCmdMeta{
 		Name: "STACKINTLEN",
 		Info: "stackintlen command info here",
-		Docs: "stackintlen command docs here",
 		Eval: evalSTACKINTLEN,
 	}
 	stackintpeekCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPEEK",
 		Info: "stackintpeek command info here",
-		Docs: "stackintpeek command docs here",
 		Eval: evalSTACKINTPEEK,
 	}
 	stackrefpushCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPUSH",
 		Info: "stackrefpush command info here",
-		Docs: "stackrefpush command docs here",
 		Eval: evalSTACKREFPUSH,
 	}
 	stackrefpopCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPOP",
 		Info: "stackrefpop command info here",
-		Docs: "stackrefpop command docs here",
 		Eval: evalSTACKREFPOP,
 	}
 	stackreflenCmdMeta = DiceCmdMeta{
 		Name: "STACKREFLEN",
 		Info: "stackreflen command info here",
-		Docs: "stackreflen command docs here",
 		Eval: evalSTACKREFLEN,
 	}
 	stackrefpeekCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPEEK",
 		Info: "stackrefpeek command info here",
-		Docs: "stackrefpeek command docs here",
 		Eval: evalSTACKREFPEEK,
 	}
 	// TODO: Remove this override once we support QWATCH in dice-cli.
 	subscribeCmdMeta = DiceCmdMeta{
 		Name: "SUBSCRIBE",
 		Info: "subscribe command info here",
-		Docs: "subscribe command docs here",
 		Eval: nil,
 	}
 	qwatchCmdMeta = DiceCmdMeta{
 		Name: "QWATCH",
 		Info: "qwatch command info here",
-		Docs: "qwatch command docs here",
 		Eval: nil,
 	}
 	multiCmdMeta = DiceCmdMeta{
 		Name: "MULTI",
 		Info: "multi command info here",
-		Docs: "multi command docs here",
 		Eval: evalMULTI,
 	}
 	execCmdMeta = DiceCmdMeta{
 		Name: "EXEC",
 		Info: "exec command info here",
-		Docs: "exec command docs here",
 		Eval: nil,
 	}
 	discardCmdMeta = DiceCmdMeta{
 		Name: "DISCARD",
 		Info: "discard command info here",
-		Docs: "discard command docs here",
 		Eval: nil,
 	}
 	abortCmdMeta = DiceCmdMeta{
 		Name: "ABORT",
 		Info: "abort command info here",
-		Docs: "abort command docs here",
 		Eval: nil,
 	}
 )

--- a/core/eval.go
+++ b/core/eval.go
@@ -890,6 +890,9 @@ func executeCommand(cmd *RedisCmd, c *Client) []byte {
 		c.TxnDiscard()
 		return RESP_OK
 	}
+	if diceCmd.Name == "ABORT" {
+		return RESP_OK
+	}
 
 	return diceCmd.Eval(cmd.Args)
 }


### PR DESCRIPTION
#182 

Dice cmds via struct

Summary of change:
Designed a struct to implement dice commands

Implementation details:
`DiceCmdMeta` encapsulates information about a dice command. A map `map[string]DiceCmdMeta{}` stores all the `DiceCmdMeta` _objects_ and acts as a source of truth for all the commands.
- `Eval` method contains business logic of the command.
- if a command is not a valid DiceDB command then an error message is returned, earlier an invalid cmd was resolved as `PING`.  This change is taken from Redis (refer img below)
- few commands which requires `Client` struct are handled separately in `func executeCommand` as it was earlier. Handling them gracefully is a topic of discussion.
- `Info` and `Docs` are kept placeholder and will be accomplished in  #148 and #146 respectively.

Redis reference:
<img width="907" alt="Screenshot 2024-07-19 at 16 40 08" src="https://github.com/user-attachments/assets/bf7c835b-e1ae-4729-ae35-8008920b6e40">

Note - changes in `core/eval.go` be better viewed in spit mode