### PR TITLE
Use sync.Map for watching queries

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -851,14 +851,7 @@ func evalQWATCH(args []string, c *Client) []byte {
 		return Encode(error, false)
 	}
 
-	WatchListMutex.Lock()
-	defer WatchListMutex.Unlock()
-	if WatchList[query] == nil {
-		WatchList[query] = make(map[int]struct{})
-	}
-
-	// Add the client to this key's watch list
-	WatchList[query][c.Fd] = struct{}{}
+	AddWatcher(query, c.Fd)
 
 	return RESP_OK
 }

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -40,35 +40,30 @@ func WatchKeys(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		select {
 		case event := <-core.WatchChannel:
-			core.WatchListMutex.Lock()
 			// Check if the key matches any RegexMatcher in the watch list.
-			var affectedQueries []core.DSQLQuery
-			for query := range core.WatchList {
-				var regex = query.KeyRegex
-				// Check if event.KEY matches the regex.
-				if core.RegexMatch(regex, event.Key) {
-					affectedQueries = append(affectedQueries, query)
-				}
-			}
+			core.WatchList.Range(func(key, value interface{}) bool {
+				query := key.(core.DSQLQuery)
+				clients := value.(*sync.Map)
 
-			// Execute all the affected queries and send the results to the subscribed clients.
-			for _, query := range affectedQueries {
-				result, err := core.ExecuteQuery(query)
-				if err != nil {
-					log.Error(err)
-					continue
-				}
-
-				for clientFd := range core.WatchList[query] {
-					_, err := syscall.Write(clientFd, core.Encode(result, false))
-
-					// if the client is not reachable, remove it from the watch list.
+				if core.RegexMatch(query.KeyRegex, event.Key) {
+					result, err := core.ExecuteQuery(query)
 					if err != nil {
-						delete(core.WatchList[query], clientFd)
+						log.Error(err)
+						return true // continue to next item
 					}
+
+					encodedResult := core.Encode(result, false)
+					clients.Range(func(clientKey, _ interface{}) bool {
+						clientFd := clientKey.(int)
+						_, err := syscall.Write(clientFd, encodedResult)
+						if err != nil {
+							clients.Delete(clientFd)
+						}
+						return true
+					})
 				}
-			}
-			core.WatchListMutex.Unlock()
+				return true
+			})
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
Refactor WatchList implementation using sync.Map for thread safety and performance improvements

- Replaced `WatchList` and `WatchListMutex` with `sync.Map` for concurrent access.
- Added `AddWatcher` and `RemoveWatcher` functions to manage watchers.
- Updated `evalQWATCH` to use the new `AddWatcher` function.
- Modified `WatchKeys` to utilize `sync.Map` methods for iterating and managing clients.
- Simplified regex matching and client notification logic within `WatchKeys`.
