### PR TITLE
Remove query from watchlist if no clients are watching it.

### DIFF
--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -57,7 +57,7 @@ func WatchKeys(ctx context.Context, wg *sync.WaitGroup) {
 						clientFd := clientKey.(int)
 						_, err := syscall.Write(clientFd, encodedResult)
 						if err != nil {
-							clients.Delete(clientFd)
+							core.RemoveWatcher(query, clientFd)
 						}
 						return true
 					})


### PR DESCRIPTION
Removes a query from the query watch-list if no clients are watching it. This can help prevent memory leaks due to stale queries.