### PR TITLE
Ensure thread-safe access to store and keypool

### DIFF
--- a/core/aof.go
+++ b/core/aof.go
@@ -28,6 +28,10 @@ func DumpAllAOF() {
 		return
 	}
 	log.Println("rewriting AOF file at", config.AOFFile)
+
+	storeMutex.RLock()
+	defer storeMutex.RUnlock()
+
 	for k, obj := range store {
 		dumpKey(fp, *((*string)(k)), obj)
 	}

--- a/core/executor.go
+++ b/core/executor.go
@@ -1,6 +1,8 @@
 package core
 
-import "sort"
+import (
+	"sort"
+)
 
 type DSQLQueryResultRow struct {
 	Key   string
@@ -11,6 +13,8 @@ type DSQLQueryResultRow struct {
 func ExecuteQuery(query DSQLQuery) ([]DSQLQueryResultRow, error) {
 	var result []DSQLQueryResultRow
 
+	storeMutex.RLock()
+	keypoolMutex.RLock()
 	for key, ptr := range keypool {
 		if RegexMatch(query.KeyRegex, key) {
 			row := DSQLQueryResultRow{
@@ -21,6 +25,8 @@ func ExecuteQuery(query DSQLQuery) ([]DSQLQueryResultRow, error) {
 			result = append(result, row)
 		}
 	}
+	keypoolMutex.RUnlock()
+	storeMutex.RUnlock()
 
 	sortResults(query, result)
 

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -26,7 +26,10 @@ func (q *QueueRef) Size() int64 {
 // Insert inserts reference of the key in the QueueRef q.
 // returns false if key does not exist
 func (q *QueueRef) Insert(key string) bool {
+	keypoolMutex.RLock()
 	x, ok := keypool[key]
+	keypoolMutex.RUnlock()
+
 	if !ok {
 		return false
 	}

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -26,7 +26,10 @@ func (s *StackRef) Size() int64 {
 // Push pushes reference of the key in the StackRef s.
 // returns false if key does not exist
 func (s *StackRef) Push(key string) bool {
+	keypoolMutex.RLock()
 	x, ok := keypool[key]
+	keypoolMutex.RUnlock()
+
 	if !ok {
 		return false
 	}

--- a/core/store.go
+++ b/core/store.go
@@ -15,9 +15,12 @@ type WatchEvent struct {
 }
 
 var store map[unsafe.Pointer]*Obj
-var expires map[*Obj]uint64
+var expires map[*Obj]uint64 // Does not need to be thread-safe as it is only accessed by a single thread.
 var keypool map[string]unsafe.Pointer
 var WatchList sync.Map // Maps queries to the file descriptors of clients that are watching them.
+
+var storeMutex sync.RWMutex
+var keypoolMutex sync.RWMutex
 
 // Channel to receive updates about keys that are being watched.
 // The Watcher goroutine will wait on this channel. When a key is updated, the
@@ -49,6 +52,11 @@ func NewObj(value interface{}, expDurationMs int64, oType uint8, oEnc uint8) *Ob
 }
 
 func Put(k string, obj *Obj) {
+	storeMutex.Lock()
+	defer storeMutex.Unlock()
+	keypoolMutex.Lock()
+	defer keypoolMutex.Unlock()
+
 	if len(store) >= config.KeysLimit {
 		evict()
 	}
@@ -70,6 +78,11 @@ func Put(k string, obj *Obj) {
 }
 
 func Get(k string) *Obj {
+	storeMutex.RLock()
+	defer storeMutex.RUnlock()
+	keypoolMutex.RLock()
+	defer keypoolMutex.RUnlock()
+
 	ptr, ok := keypool[k]
 	if !ok {
 		return nil
@@ -78,7 +91,9 @@ func Get(k string) *Obj {
 	v := store[ptr]
 	if v != nil {
 		if hasExpired(v) {
+			storeMutex.RUnlock()
 			Del(k)
+			storeMutex.RLock()
 			return nil
 		}
 		v.LastAccessedAt = getCurrentClock()
@@ -87,6 +102,11 @@ func Get(k string) *Obj {
 }
 
 func Del(k string) bool {
+	storeMutex.Lock()
+	defer storeMutex.Unlock()
+	keypoolMutex.Lock()
+	defer keypoolMutex.Unlock()
+
 	ptr, ok := keypool[k]
 	if !ok {
 		return false
@@ -105,6 +125,11 @@ func Del(k string) bool {
 }
 
 func DelByPtr(ptr unsafe.Pointer) bool {
+	storeMutex.Lock()
+	defer storeMutex.Unlock()
+	keypoolMutex.Lock()
+	defer keypoolMutex.Unlock()
+
 	if obj, ok := store[ptr]; ok {
 		delete(store, ptr)
 		delete(expires, obj)

--- a/core/store.go
+++ b/core/store.go
@@ -19,8 +19,8 @@ var expires map[*Obj]uint64 // Does not need to be thread-safe as it is only acc
 var keypool map[string]unsafe.Pointer
 var WatchList sync.Map // Maps queries to the file descriptors of clients that are watching them.
 
-var storeMutex sync.RWMutex
-var keypoolMutex sync.RWMutex
+var storeMutex sync.RWMutex   // Mutex to protect the store map, must be acquired before keypoolMutex if both are needed.
+var keypoolMutex sync.RWMutex // Mutex to protect the keypool map, must be acquired after storeMutex if both are needed.
 
 // Channel to receive updates about keys that are being watched.
 // The Watcher goroutine will wait on this channel. When a key is updated, the


### PR DESCRIPTION
With the addition of the WatchKeys goroutine (to enable real-time reactive query subscriptions), concurrent reads can happen on the `store` and `keypool` maps.

This change adds RW locks to guard access to these data structures to prevent race conditions.

## Benchmarks
These benchmarks test existing workflows which are mostly single-threaded, we may see some unavoidable slowdowns once we benchmark more sophisticated scenarios (involving multiple clients, some of which are subscribing to existing queries.

Overall, the performance is quite close to the thread-unsafe implementation, and the time taken seems to have increased within reason.

### Thread-Safe Implementation
| Benchmark                  | Iterations | Time (ns/op) | Memory (B/op) | Allocations (allocs/op) |
|----------------------------|------------|--------------|---------------|-------------------------|
| BenchmarkInsert20-10       | 2,103,750  | 557.2        | 880           | 30                      |
| BenchmarkInsert200-10      | 277,537    | 4,245        | 5,016         | 215                     |
| BenchmarkInsert2000-10     | 26,451     | 45,406       | 68,808        | 2,048                   |
| BenchmarkInsertLL20-10     | 2,076,896  | 578.7        | 1,176         | 23                      |
| BenchmarkInsertLL200-10    | 220,178    | 5,270        | 11,448        | 203                     |
| BenchmarkInsertLL2000-10   | 18,030     | 66,256       | 126,393       | 3,747                   |
| BenchmarkInsertBasic20-10  | 6,297,427  | 189.8        | 536           | 7                       |
| BenchmarkInsertBasic200-10 | 1,241,326  | 982.1        | 4,120         | 10                      |
| BenchmarkInsertBasic2000-10| 131,550    | 9,225        | 60,056        | 15                      |
| BenchmarkInsertRemove-10   | 2,791,825  | 429.7        | 324           | 22                      |
| BenchmarkSize-10           | 3,456,609  | 345.0        | 324           | 22                      |

### Thread-Unsafe Implementation (original)
| Benchmark                  | Iterations | Time (ns/op) | Memory (B/op) | Allocations (allocs/op) |
|----------------------------|------------|--------------|---------------|-------------------------|
| BenchmarkInsert20-10       | 2,093,487  | 559.7        | 880           | 30                      |
| BenchmarkInsert200-10      | 279,596    | 4,152        | 5,016         | 215                     |
| BenchmarkInsert2000-10     | 26,296     | 45,113       | 68,808        | 2,048                   |
| BenchmarkInsertLL20-10     | 2,081,374  | 595.3        | 1,176         | 23                      |
| BenchmarkInsertLL200-10    | 223,196    | 5,247        | 11,448        | 203                     |
| BenchmarkInsertLL2000-10   | 18,140     | 66,432       | 126,393       | 3,747                   |
| BenchmarkInsertBasic20-10  | 6,312,344  | 187.5        | 536           | 7                       |
| BenchmarkInsertBasic200-10 | 1,235,007  | 970.5        | 4,120         | 10                      |
| BenchmarkInsertBasic2000-10| 125,288    | 9,224        | 60,056        | 15                      |
| BenchmarkInsertRemove-10   | 2,746,761  | 433.4        | 324           | 22                      |
| BenchmarkSize-10           | 3,437,666  | 347.7        | 324           | 22                      |