### PR TITLE
Improve QWATCH tests to validate functionality with multiple subscribers.

### DIFF
--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -231,7 +231,7 @@ func RunAsyncTCPServer(serverFD int, wg *sync.WaitGroup) {
 				}
 				respond(cmds, comm)
 				if hasABORT {
-					ctx.Done()
+					cancel()
 					return
 				}
 			}


### PR DESCRIPTION
Improved QWATCH Tests to ensure reactive functionality works reliably with multiple subscribers.

* Replaced `ctx.Done()` with `cancel()` in `RunAsyncTCPServer` for idiomatic abort signal handling.
* Refactored TestQWATCH and TestQWATCHWithSDK to support multiple subscribers.