### PR TITLE
Add support for Basic Auth

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -19,3 +19,9 @@ var (
 	IOBufferLength    int = 512
 	IOBufferLengthMAX int = 50 * 1024
 )
+
+// Users and ACLs
+var (
+	// If requirepass is set to an empty string, no authentication is required
+	RequirePass string = ""
+)

--- a/core/comm.go
+++ b/core/comm.go
@@ -9,9 +9,10 @@ import (
 
 type Client struct {
 	io.ReadWriter
-	Fd     int
-	cqueue RedisCmds
-	isTxn  bool
+	Fd      int
+	cqueue  RedisCmds
+	isTxn   bool
+	Session *Session
 }
 
 func (c Client) Write(b []byte) (int, error) {
@@ -52,7 +53,8 @@ func (c *Client) TxnQueue(cmd *RedisCmd) {
 
 func NewClient(fd int) *Client {
 	return &Client{
-		Fd:     fd,
-		cqueue: make(RedisCmds, 0),
+		Fd:      fd,
+		cqueue:  make(RedisCmds, 0),
+		Session: NewSession(),
 	}
 }

--- a/core/commands.go
+++ b/core/commands.go
@@ -23,6 +23,12 @@ var (
 		Eval:  evalPING,
 		Arity: -1,
 	}
+	authCmdMeta = DiceCmdMeta{
+		Name: "AUTH",
+		Info: `AUTH returns with an encoded "OK" if the user is authenticated.
+		If the user is not authenticated, it returns with an encoded error message`,
+		Eval: nil,
+	}
 	setCmdMeta = DiceCmdMeta{
 		Name: "SET",
 		Info: `SET puts a new <key, value> pair in db as in the args
@@ -406,6 +412,7 @@ var (
 
 func init() {
 	diceCmds["PING"] = pingCmdMeta
+	diceCmds["AUTH"] = authCmdMeta
 	diceCmds["SET"] = setCmdMeta
 	diceCmds["GET"] = getCmdMeta
 	diceCmds["JSON.SET"] = jsonsetCmdMeta

--- a/core/eval.go
+++ b/core/eval.go
@@ -61,7 +61,6 @@ func evalAUTH(args []string, c *Client) []byte {
 		b   []byte
 		err error
 	)
-	log.Print("Authenticating user")
 
 	if len(args) < 1 || len(args) > 2 {
 		return Encode(errors.New("ERR wrong number of arguments for 'AUTH' command"), false)
@@ -1051,10 +1050,8 @@ func EvalAndRespond(cmds RedisCmds, c *Client) {
 	for _, cmd := range cmds {
 		// Check if the command has been authenticated
 		if cmd.Cmd != AuthCmd && !c.Session.IsActive() {
-			// TODO: Check required response
-			log.Println("Session not active for CMD:", cmd.Cmd)
 			if _, err := c.Write(RESP_AUTH_FAILURE); err != nil {
-				log.Panic(err)
+				log.Println("Error writing to client:", err)
 			}
 			continue
 		}

--- a/core/eval.go
+++ b/core/eval.go
@@ -16,6 +16,7 @@ import (
 
 var RESP_NIL []byte = []byte("$-1\r\n")
 var RESP_OK []byte = []byte("+OK\r\n")
+var RESP_AUTH_FAILURE []byte = []byte("+NOAUTH\r\n")
 var RESP_QUEUED []byte = []byte("+QUEUED\r\n")
 var RESP_ZERO []byte = []byte(":0\r\n")
 var RESP_ONE []byte = []byte(":1\r\n")
@@ -48,6 +49,38 @@ func evalPING(args []string) []byte {
 		b = Encode("PONG", true)
 	} else {
 		b = Encode(args[0], false)
+	}
+
+	return b
+}
+
+// evalAUTH returns with an encoded "OK" if the user is authenticated
+// If the user is not authenticated, it returns with an encoded error message
+func evalAUTH(args []string, c *Client) []byte {
+	var (
+		b   []byte
+		err error
+	)
+	log.Print("Authenticating user")
+
+	if len(args) < 1 || len(args) > 2 {
+		return Encode(errors.New("ERR wrong number of arguments for 'AUTH' command"), false)
+	}
+
+	if len(args) == 1 {
+		if err = c.Session.Validate(DefaultUserName, args[0]); err != nil {
+			log.Println("AUTH failed: ", err)
+			return Encode(errors.New("AUTH failed"), false)
+		}
+		return RESP_OK
+	}
+
+	if len(args) == 2 {
+		if err = c.Session.Validate(args[0], args[1]); err != nil {
+			log.Println("AUTH failed: ", err)
+			return Encode(errors.New("AUTH failed"), false)
+		}
+		return RESP_OK
 	}
 
 	return b
@@ -984,6 +1017,9 @@ func executeCommand(cmd *RedisCmd, c *Client) []byte {
 		c.TxnBegin()
 		return diceCmd.Eval(cmd.Args)
 	}
+	if diceCmd.Name == AuthCmd {
+		return evalAUTH(cmd.Args, c)
+	}
 	if diceCmd.Name == "EXEC" {
 		if !c.isTxn {
 			return Encode(errors.New("ERR EXEC without MULTI"), false)
@@ -1013,6 +1049,13 @@ func EvalAndRespond(cmds RedisCmds, c *Client) {
 	buf := bytes.NewBuffer(response)
 
 	for _, cmd := range cmds {
+		// Check if the command has been authenticated
+		if cmd.Cmd != AuthCmd && !c.Session.IsActive() {
+			// TODO: Check required response
+			log.Println("Session not active for CMD:", cmd.Cmd)
+			c.Write(RESP_AUTH_FAILURE)
+			continue
+		}
 		// if txn is not in progress, then we can simply
 		// execute the command and add the response to the buffer
 		if !c.isTxn {

--- a/core/eval.go
+++ b/core/eval.go
@@ -1053,7 +1053,9 @@ func EvalAndRespond(cmds RedisCmds, c *Client) {
 		if cmd.Cmd != AuthCmd && !c.Session.IsActive() {
 			// TODO: Check required response
 			log.Println("Session not active for CMD:", cmd.Cmd)
-			c.Write(RESP_AUTH_FAILURE)
+			if _, err := c.Write(RESP_AUTH_FAILURE); err != nil {
+				log.Panic(err)
+			}
 			continue
 		}
 		// if txn is not in progress, then we can simply

--- a/core/session.go
+++ b/core/session.go
@@ -1,0 +1,150 @@
+package core
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/dicedb/dice/config"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	DefaultUserName = "default"
+	AuthCmd         = "AUTH"
+
+	SessionStatusPending SessionStatusT = SessionStatusT(0)
+	SessionStatusActive  SessionStatusT = SessionStatusT(1)
+	SessionStatusExpired SessionStatusT = SessionStatusT(2)
+)
+
+var (
+	UserStore *Users = NewUsers()
+)
+
+type (
+	SessionStatusT uint8
+	Session        struct {
+		ID   uint64
+		User *User
+
+		CreatedAt      time.Time
+		LastAccessedAt time.Time
+
+		Status SessionStatusT
+	}
+
+	Users struct {
+		store  map[string]*User
+		stLock *sync.RWMutex
+	}
+
+	User struct {
+		Username          string
+		Passwords         []string
+		IsPasswordEnabled bool
+	}
+)
+
+func NewUsers() (users *Users) {
+	users = &Users{
+		store:  make(map[string]*User),
+		stLock: &sync.RWMutex{},
+	}
+	return
+}
+
+func (users *Users) Get(username string) (user *User, err error) {
+	users.stLock.RLock()
+	defer users.stLock.RUnlock()
+	isPresent := false
+	if user, isPresent = users.store[username]; !isPresent {
+		err = fmt.Errorf("user %s not found", username)
+		return
+	}
+	return
+}
+
+func (users *Users) Add(username string) (user *User, err error) {
+	user = &User{
+		Username: username,
+	}
+	users.stLock.Lock()
+	defer users.stLock.Unlock()
+	users.store[username] = user
+	return
+}
+
+func (user *User) SetPassword(password string) (err error) {
+	var (
+		hashedPassword []byte
+	)
+	if hashedPassword, err = bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); err != nil {
+		return
+	}
+	user.Passwords = append(user.Passwords, string(hashedPassword))
+	return
+}
+
+func NewSession() (session *Session) {
+	session = &Session{
+		ID: uint64(time.Now().UTC().Unix()),
+
+		CreatedAt:      time.Now(),
+		LastAccessedAt: time.Now(),
+
+		Status: SessionStatusPending,
+	}
+	return
+}
+
+func (session *Session) IsActive() (isActive bool) {
+	if config.RequirePass == "" && session.Status != SessionStatusActive {
+		session.Activate(session.User)
+	}
+	isActive = session.Status == SessionStatusActive
+	if isActive {
+		session.LastAccessedAt = time.Now().UTC()
+	}
+	return
+}
+
+func (session *Session) Activate(user *User) (err error) {
+	session.User = user
+	session.Status = SessionStatusActive
+	session.CreatedAt = time.Now().UTC()
+	session.LastAccessedAt = time.Now().UTC()
+	return
+}
+
+func (session *Session) Validate(username, password string) (err error) {
+	var (
+		user *User
+	)
+	if user, err = UserStore.Get(username); err != nil {
+		return
+	}
+	if username == DefaultUserName && len(user.Passwords) == 0 {
+		session.Activate(user)
+		return
+	}
+	for _, userPassword := range user.Passwords {
+		if err = bcrypt.CompareHashAndPassword([]byte(userPassword), []byte(password)); err != nil {
+			continue
+		}
+		if err = session.Activate(user); err != nil {
+			log.Println("error activating session for user", username, err)
+			continue
+		}
+		// User has been validated and the session has been activated
+		return
+	}
+	err = fmt.Errorf("no password matched for user %s", username)
+	return
+}
+
+func (session *Session) Expire() (err error) {
+	session.Status = SessionStatusExpired
+	return
+}

--- a/core/session.go
+++ b/core/session.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	UserStore *Users = NewUsers()
+	UserStore *Users = NewUsersStore()
 )
 
 type (
@@ -47,7 +47,7 @@ type (
 	}
 )
 
-func NewUsers() (users *Users) {
+func NewUsersStore() (users *Users) {
 	users = &Users{
 		store:  make(map[string]*User),
 		stLock: &sync.RWMutex{},

--- a/core/session.go
+++ b/core/session.go
@@ -101,7 +101,9 @@ func NewSession() (session *Session) {
 
 func (session *Session) IsActive() (isActive bool) {
 	if config.RequirePass == "" && session.Status != SessionStatusActive {
-		session.Activate(session.User)
+		if err := session.Activate(session.User); err != nil {
+			return
+		}
 	}
 	isActive = session.Status == SessionStatusActive
 	if isActive {
@@ -126,7 +128,9 @@ func (session *Session) Validate(username, password string) (err error) {
 		return
 	}
 	if username == DefaultUserName && len(user.Passwords) == 0 {
-		session.Activate(user)
+		if err = session.Activate(user); err != nil {
+			return
+		}
 		return
 	}
 	for _, userPassword := range user.Passwords {

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"testing"
 	"time"
+
+	"github.com/dicedb/dice/config"
 )
 
 func TestNewUsers(t *testing.T) {
@@ -65,6 +67,7 @@ func TestNewSession(t *testing.T) {
 }
 
 func TestSessionIsActive(t *testing.T) {
+	config.RequirePass = "testpassword"
 	session := NewSession()
 	if session.IsActive() {
 		t.Error("New session should not be active")
@@ -81,6 +84,7 @@ func TestSessionIsActive(t *testing.T) {
 	if !session.LastAccessedAt.After(oldLastAccessed) {
 		t.Error("IsActive() should update LastAccessedAt")
 	}
+	config.RequirePass = ""
 }
 
 func TestSessionActivate(t *testing.T) {

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -1,0 +1,133 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewUsers(t *testing.T) {
+	users := NewUsers()
+	if users == nil {
+		t.Error("NewUsers() returned nil")
+	}
+	if users.store == nil {
+		t.Error("NewUsers() created Users with nil store")
+	}
+	if users.stLock == nil {
+		t.Error("NewUsers() created Users with nil stLock")
+	}
+}
+
+func TestUsersAddAndGet(t *testing.T) {
+	users := NewUsers()
+	username := "testuser"
+
+	// Test Add
+	user, err := users.Add(username)
+	if err != nil {
+		t.Errorf("Users.Add() returned an error: %v", err)
+	}
+	if user.Username != username {
+		t.Errorf("Users.Add() created user with incorrect username. Got %s, want %s", user.Username, username)
+	}
+
+	// Test Get
+	retrievedUser, err := users.Get(username)
+	if err != nil {
+		t.Errorf("Users.Get() returned an error: %v", err)
+	}
+	if retrievedUser != user {
+		t.Error("Users.Get() returned a different user than the one added")
+	}
+}
+
+func TestUserSetPassword(t *testing.T) {
+	user := &User{Username: "testuser"}
+	password := "testpassword"
+
+	err := user.SetPassword(password)
+	if err != nil {
+		t.Errorf("User.SetPassword() returned an error: %v", err)
+	}
+	if len(user.Passwords) != 1 {
+		t.Errorf("User.SetPassword() did not add password. Got %d passwords, want 1", len(user.Passwords))
+	}
+}
+
+func TestNewSession(t *testing.T) {
+	session := NewSession()
+	if session == nil {
+		t.Error("NewSession() returned nil")
+	}
+	if session.Status != SessionStatusPending {
+		t.Errorf("NewSession() created session with incorrect status. Got %v, want %v", session.Status, SessionStatusPending)
+	}
+}
+
+func TestSessionIsActive(t *testing.T) {
+	session := NewSession()
+	if session.IsActive() {
+		t.Error("New session should not be active")
+	}
+
+	session.Status = SessionStatusActive
+	if !session.IsActive() {
+		t.Error("Session with SessionStatusActive should be active")
+	}
+
+	oldLastAccessed := session.LastAccessedAt
+	time.Sleep(time.Millisecond) // Ensure some time passes
+	session.IsActive()
+	if !session.LastAccessedAt.After(oldLastAccessed) {
+		t.Error("IsActive() should update LastAccessedAt")
+	}
+}
+
+func TestSessionActivate(t *testing.T) {
+	session := NewSession()
+	user := &User{Username: DefaultUserName}
+
+	err := session.Activate(user)
+	if err != nil {
+		t.Errorf("Session.Activate() returned an error: %v", err)
+	}
+	if session.Status != SessionStatusActive {
+		t.Errorf("Session.Activate() did not set status to Active. Got %v, want %v", session.Status, SessionStatusActive)
+	}
+	if session.User != user {
+		t.Error("Session.Activate() did not set the User correctly")
+	}
+}
+
+func TestSessionValidate(t *testing.T) {
+	username := DefaultUserName
+	password := "testpassword"
+
+	user, _ := UserStore.Add(username)
+	user.SetPassword(password)
+
+	session := NewSession()
+	err := session.Validate(username, password)
+	if err != nil {
+		t.Errorf("Session.Validate() returned an error: %v", err)
+	}
+	if session.Status != SessionStatusActive {
+		t.Error("Session.Validate() did not activate the session")
+	}
+
+	err = session.Validate(username, "wrongpassword")
+	if err == nil {
+		t.Error("Session.Validate() did not return an error for wrong password")
+	}
+}
+
+func TestSessionExpire(t *testing.T) {
+	session := NewSession()
+	err := session.Expire()
+	if err != nil {
+		t.Errorf("Session.Expire() returned an error: %v", err)
+	}
+	if session.Status != SessionStatusExpired {
+		t.Errorf("Session.Expire() did not set status to Expired. Got %v, want %v", session.Status, SessionStatusExpired)
+	}
+}

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNewUsers(t *testing.T) {
-	users := NewUsers()
+	users := NewUsersStore()
 	if users == nil {
 		t.Error("NewUsers() returned nil")
 	}
@@ -21,7 +21,7 @@ func TestNewUsers(t *testing.T) {
 }
 
 func TestUsersAddAndGet(t *testing.T) {
-	users := NewUsers()
+	users := NewUsersStore()
 	if users == nil {
 		t.Fatal("NewUsers() returned nil")
 	}

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -12,16 +12,19 @@ func TestNewUsers(t *testing.T) {
 	if users == nil {
 		t.Error("NewUsers() returned nil")
 	}
-	if users.store == nil {
+	if users != nil && users.store == nil {
 		t.Error("NewUsers() created Users with nil store")
 	}
-	if users.stLock == nil {
+	if users != nil && users.stLock == nil {
 		t.Error("NewUsers() created Users with nil stLock")
 	}
 }
 
 func TestUsersAddAndGet(t *testing.T) {
 	users := NewUsers()
+	if users == nil {
+		t.Fatal("NewUsers() returned nil")
+	}
 	username := "testuser"
 
 	// Test Add
@@ -29,14 +32,23 @@ func TestUsersAddAndGet(t *testing.T) {
 	if err != nil {
 		t.Errorf("Users.Add() returned an error: %v", err)
 	}
+	if user == nil {
+		t.Fatal("Users.Add() returned nil user")
+	}
 	if user.Username != username {
 		t.Errorf("Users.Add() created user with incorrect username. Got %s, want %s", user.Username, username)
 	}
 
 	// Test Get
+	if users == nil {
+		t.Fatal("Users is nil")
+	}
 	retrievedUser, err := users.Get(username)
 	if err != nil {
 		t.Errorf("Users.Get() returned an error: %v", err)
+	}
+	if retrievedUser == nil {
+		t.Fatal("Users.Get() returned nil user")
 	}
 	if retrievedUser != user {
 		t.Error("Users.Get() returned a different user than the one added")
@@ -61,7 +73,7 @@ func TestNewSession(t *testing.T) {
 	if session == nil {
 		t.Error("NewSession() returned nil")
 	}
-	if session.Status != SessionStatusPending {
+	if session != nil && session.Status != SessionStatusPending {
 		t.Errorf("NewSession() created session with incorrect status. Got %v, want %v", session.Status, SessionStatusPending)
 	}
 }
@@ -108,7 +120,9 @@ func TestSessionValidate(t *testing.T) {
 	password := "testpassword"
 
 	user, _ := UserStore.Add(username)
-	user.SetPassword(password)
+	if err := user.SetPassword(password); err != nil {
+		t.Fatalf("User.SetPassword() returned an error: %v", err)
+	}
 
 	session := NewSession()
 	err := session.Validate(username, password)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/sys v0.22.0 // indirect
 )
 
 require (
@@ -27,4 +27,5 @@ require (
 	github.com/twmb/murmur3 v1.1.8
 	github.com/valyala/fastjson v1.6.4
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
+	golang.org/x/crypto v0.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -45,11 +45,13 @@ github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXV
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
+golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
+golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 func setupFlags() {
 	flag.StringVar(&config.Host, "host", "0.0.0.0", "host for the dice server")
 	flag.IntVar(&config.Port, "port", 7379, "port for the dice server")
+	flag.StringVar(&config.RequirePass, "requirepass", config.RequirePass, "enable authentication for the default user")
 	flag.Parse()
 }
 

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -31,6 +31,20 @@ func init() {
 	connectedClients = make(map[int]*core.Client)
 }
 
+func setupUsers() {
+	var (
+		user *core.User
+		err  error
+	)
+	log.Info("setting up default user.", "password required", !(config.RequirePass == ""))
+	if user, err = core.UserStore.Add(core.DefaultUserName); err != nil {
+		log.Fatal(err)
+	}
+	if err = user.SetPassword(config.RequirePass); err != nil {
+		log.Fatal(err)
+	}
+}
+
 // Waits on `core.WatchChannel` to receive updates about keys. Sends the update
 // to all the clients that are watching the key.
 // The message sent to the client will contain the new value and the operation
@@ -123,6 +137,8 @@ func RunAsyncTCPServer(serverFD int, wg *sync.WaitGroup) {
 	defer syscall.Close(serverFD)
 
 	log.Info("starting an asynchronous TCP server on", config.Host, config.Port)
+
+	setupUsers()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
https://github.com/DiceDB/dice/issues/141

Prior to Redis 6, authentication for a connection was enabled by passing in `requirepass` in the redis.conf or while starting the redis server. If the above config is set, prior to any command, the authentication has to be by running the following command:

```
AUTH '<password>'
```

[
![Screenshot 2024-08-03 at 10 21 05 PM](https://github.com/user-attachments/assets/7019ccf9-194e-4f03-b8b4-60568f6cfab0)
](url)

`requirepass` can be set in the config by changing `config/main.go` before running the server.

The storage of user credentials and ACLs will be implemented in the subsequent PRs.
