### PR TITLE
Add support for JSON 

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -34,6 +34,23 @@ var (
 		GET returns RESP_NIL if key is expired or it does not exist`,
 		Eval: evalGET,
 	}
+	jsonsetCmdMeta = DiceCmdMeta{
+		Name: "JSON.SET",
+		Info: `JSON.SET key path json-string
+		Sets a JSON value at the specified key.
+		Returns OK if successful.
+		Returns encoded error message if the number of arguments is incorrect or the JSON string is invalid.`,
+		Eval: evalJSONSET,
+	}
+
+	jsongetCmdMeta = DiceCmdMeta{
+		Name: "JSON.GET",
+		Info: `JSON.GET key [path]
+		Returns the encoded RESP value of the key, if present
+		Null reply: If the key doesn't exist or has expired.
+		Error reply: If the number of arguments is incorrect or the stored value is not a JSON type.`,
+		Eval: evalJSONGET,
+	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
 		Info: `TTL returns Time-to-Live in secs for the queried key in args
@@ -314,6 +331,8 @@ func init() {
 	diceCmds["PING"] = pingCmdMeta
 	diceCmds["SET"] = setCmdMeta
 	diceCmds["GET"] = getCmdMeta
+	diceCmds["JSON.SET"] = jsonsetCmdMeta
+	diceCmds["JSON.GET"] = jsongetCmdMeta
 	diceCmds["TTL"] = ttlCmdMeta
 	diceCmds["DEL"] = delCmdMeta
 	diceCmds["EXPIRE"] = expireCmdMeta

--- a/core/eval.go
+++ b/core/eval.go
@@ -165,8 +165,7 @@ func evalJSONSET(args []string) []byte {
 	jsonStr := args[2]
 
 	// Parse the JSON string
-	var p fastjson.Parser
-	v, err := p.Parse(jsonStr)
+	v, err := parser.Parse(jsonStr)
 	if err != nil {
 		return Encode(errors.New("ERR invalid JSON"), false)
 	}

--- a/core/object.go
+++ b/core/object.go
@@ -21,14 +21,14 @@ var OBJ_TYPE_BYTELIST uint8 = 1 << 4
 var OBJ_ENCODING_QINT uint8 = 0
 var OBJ_ENCODING_QREF uint8 = 1
 
-var OBJ_TYPE_JSON uint8 = 2 << 4 // 00100000
-var OBJ_ENCODING_JSON uint8 = 0
-
 var OBJ_ENCODING_STACKINT uint8 = 2
 var OBJ_ENCODING_STACKREF uint8 = 3
 
-var OBJ_TYPE_BITSET uint8 = 1 << 5 // 00100000
+var OBJ_TYPE_BITSET uint8 = 2 << 4 // 00100000
 var OBJ_ENCODING_BF uint8 = 2      // 00000010
+
+var OBJ_TYPE_JSON uint8 = 3 << 4 // 00110000
+var OBJ_ENCODING_JSON uint8 = 0
 
 func ExtractTypeEncoding(obj *Obj) (uint8, uint8) {
 	return obj.TypeEncoding & 0b11110000, obj.TypeEncoding & 0b00001111

--- a/core/object.go
+++ b/core/object.go
@@ -21,6 +21,9 @@ var OBJ_TYPE_BYTELIST uint8 = 1 << 4
 var OBJ_ENCODING_QINT uint8 = 0
 var OBJ_ENCODING_QREF uint8 = 1
 
+var OBJ_TYPE_JSON uint8 = 2 << 4 // 00100000
+var OBJ_ENCODING_JSON uint8 = 0
+
 var OBJ_ENCODING_STACKINT uint8 = 2
 var OBJ_ENCODING_STACKREF uint8 = 3
 

--- a/go.mod
+++ b/go.mod
@@ -12,13 +12,13 @@ require (
 	github.com/dicedb/go-dice v0.0.0-20240717053902-2a3e67c8bda0 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/kinbiko/jsonassert v1.1.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/valyala/fastjson v1.6.4 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/dicedb/go-dice v0.0.0-20240717053902-2a3e67c8bda0 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/kinbiko/jsonassert v1.1.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KE
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/kinbiko/jsonassert v1.1.1 h1:DB12divY+YB+cVpHULLuKePSi6+ui4M/shHSzJISkSE=
-github.com/kinbiko/jsonassert v1.1.1/go.mod h1:NO4lzrogohtIdNUNzx8sdzB55M4R4Q1bsrWVdqQ7C+A=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
@@ -51,6 +49,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
+github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
+github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KE
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/kinbiko/jsonassert v1.1.1 h1:DB12divY+YB+cVpHULLuKePSi6+ui4M/shHSzJISkSE=
+github.com/kinbiko/jsonassert v1.1.1/go.mod h1:NO4lzrogohtIdNUNzx8sdzB55M4R4Q1bsrWVdqQ7C+A=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -1,0 +1,121 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/kinbiko/jsonassert"
+	"gotest.tools/v3/assert"
+)
+
+func TestJSONOperations(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+	ja := jsonassert.New(t)
+	t.Run("Set and Get Simple JSON", func(t *testing.T) {
+		setCmd := `JSON.SET user $ {"name":"John","age":30}`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+
+		getCmd := `JSON.GET user`
+		result = fireCommand(conn, getCmd)
+
+		ja.Assertf(result.(string), `{"age":30,"name":"John"}`)
+	})
+
+	t.Run("Set and Get Nested JSON", func(t *testing.T) {
+		setCmd := `JSON.SET user:2 $ {"name":"Alice","address":{"city":"New York","zip":"10001"},"array":[1,2,3,4,5]}`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+
+		getCmd := `JSON.GET user:2`
+		result = fireCommand(conn, getCmd)
+		ja.Assertf(result.(string), `{"name":"Alice","address":{"city":"New York","zip":"10001"},"array":[1,2,3,4,5]}`)
+	})
+
+	t.Run("Set and Get JSON Array", func(t *testing.T) {
+		setCmd := `JSON.SET numbers $ [1,2,3,4,5]`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+
+		getCmd := `JSON.GET numbers`
+		result = fireCommand(conn, getCmd)
+		ja.Assertf(result.(string), `[1,2,3,4,5]`)
+	})
+
+	t.Run("Set and Get JSON with Special Characters", func(t *testing.T) {
+		setCmd := `JSON.SET special $ {"key":"value with spaces","emoji":"😀"}`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+
+		getCmd := `JSON.GET special`
+		result = fireCommand(conn, getCmd)
+		ja.Assertf(result.(string), `{"key":"value with spaces","emoji":"😀"}`)
+	})
+
+	t.Run("Set Invalid JSON", func(t *testing.T) {
+		setCmd := `JSON.SET invalid $ {invalid:json}`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "ERR invalid JSON", result)
+	})
+
+	t.Run("Set JSON with Wrong Number of Arguments", func(t *testing.T) {
+		setCmd := `JSON.SET`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "ERR wrong number of arguments for 'JSON.SET' command", result)
+	})
+
+	t.Run("Get JSON with Wrong Number of Arguments", func(t *testing.T) {
+		getCmd := `JSON.GET`
+		result := fireCommand(conn, getCmd)
+		assert.Equal(t, "ERR wrong number of arguments for 'JSON.GET' command", result)
+	})
+
+	t.Run("Set Non-JSON Value", func(t *testing.T) {
+		setCmd := `SET nonJson "not a json"`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+		getCmd := `JSON.GET nonJson`
+		result = fireCommand(conn, getCmd)
+
+		assert.Equal(t, "WRONGTYPE Operation against a key holding the wrong kind of value", result)
+	})
+
+	t.Run("Set Empty JSON Object", func(t *testing.T) {
+		setCmd := `JSON.SET empty $ {}`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+		getCmd := `JSON.GET empty`
+		result = fireCommand(conn, getCmd)
+		ja.Assertf(result.(string), `{}`)
+	})
+
+	t.Run("Set Empty JSON Array", func(t *testing.T) {
+		setCmd := `JSON.SET emptyArray $ []`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+
+		getCmd := `JSON.GET emptyArray`
+		result = fireCommand(conn, getCmd)
+		ja.Assertf(result.(string), `[]`)
+	})
+	t.Run("Set JSON with Unicode", func(t *testing.T) {
+		setCmd := `JSON.SET unicode $ {"unicode":"こんにちは世界"}`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+		getCmd := `JSON.GET unicode`
+		result = fireCommand(conn, getCmd)
+
+		ja.Assertf(result.(string), `{"unicode":"こんにちは世界"}`)
+	})
+
+	t.Run("Set JSON with Escaped Characters", func(t *testing.T) {
+		setCmd := `JSON.SET escaped $ {"escaped":"\"quoted\", \\backslash\\ and \/forward\/slash"}`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+		getCmd := `JSON.GET escaped`
+		result = fireCommand(conn, getCmd)
+
+		ja.Assertf(result.(string), `{"escaped":"\"quoted\", \\backslash\\ and /forward/slash"}`)
+	})
+
+}

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -11,6 +11,37 @@ func TestJSONOperations(t *testing.T) {
 	conn := getLocalConnection()
 	defer conn.Close()
 	ja := jsonassert.New(t)
+
+	t.Run("Set and Get Integer", func(t *testing.T) {
+		setCmd := `JSON.SET tools $ 2`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+
+		getCmd := `JSON.GET tools`
+		result = fireCommand(conn, getCmd)
+		ja.Assertf(result.(string), `2`)
+	})
+
+	t.Run("Set and Get Boolean True", func(t *testing.T) {
+		setCmd := `JSON.SET booleanTrue $ true`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+
+		getCmd := `JSON.GET booleanTrue`
+		result = fireCommand(conn, getCmd)
+		ja.Assertf(result.(string), `true`)
+	})
+
+	t.Run("Set and Get Boolean False", func(t *testing.T) {
+		setCmd := `JSON.SET booleanFalse $ false`
+		result := fireCommand(conn, setCmd)
+		assert.Equal(t, "OK", result)
+
+		getCmd := `JSON.GET booleanFalse`
+		result = fireCommand(conn, getCmd)
+		ja.Assertf(result.(string), `false`)
+	})
+
 	t.Run("Set and Get Simple JSON", func(t *testing.T) {
 		setCmd := `JSON.SET user $ {"name":"John","age":30}`
 		result := fireCommand(conn, setCmd)


### PR DESCRIPTION
#165 Added support for JSON.SET and JSON.GET operations; (jsonpath operations is wip)

@JyotinderSingh the existing `Encode` function seems to be sophisticated enough for handling the encoding of the json strings to RESP2. 

However, in RESP3 standard; things have been changed a bit in case of handling of [maps](https://redis.io/docs/latest/develop/reference/protocol-spec/#maps) 

Kindly take a look at the following docs/discussion:
https://redis.io/docs/latest/develop/data-types/json/resp3/
https://github.com/RedisJSON/RedisJSON/issues/1090
https://redis.io/docs/latest/commands/json.set/