### PR TITLE
Add WHERE Clause Support to DSQL Parser and Executor

### DIFF
--- a/core/dsql_test.go
+++ b/core/dsql_test.go
@@ -3,8 +3,8 @@ package core
 import (
 	"testing"
 
+	"github.com/xwb1989/sqlparser"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 )
 
 func TestParseQuery(t *testing.T) {
@@ -27,13 +27,39 @@ func TestParseQuery(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "valid select key only with order and limit",
-			sql:  "SELECT $key FROM `match:100:*` ORDER BY $key LIMIT 5",
+			name: "valid select with where clause",
+			sql:  "SELECT $key, $value FROM `match:100:*` WHERE $value = 'test' ORDER BY $key LIMIT 5",
+			want: DSQLQuery{
+				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
+				KeyRegex:  "match:100:*",
+				Where: &sqlparser.ComparisonExpr{
+					Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+					Operator: "=",
+					Right:    sqlparser.NewStrVal([]byte("test")),
+				},
+				OrderBy: QueryOrder{OrderBy: "$key", Order: "asc"},
+				Limit:   5,
+			},
+			wantErr: false,
+		},
+		{
+			name: "complex where clause",
+			sql:  "SELECT $key FROM `user:*` WHERE $value > 25 AND $key LIKE 'user:1%'",
 			want: DSQLQuery{
 				Selection: QuerySelection{KeySelection: true, ValueSelection: false},
-				KeyRegex:  "match:100:*",
-				OrderBy:   QueryOrder{OrderBy: "$key", Order: "asc"},
-				Limit:     5,
+				KeyRegex:  "user:*",
+				Where: &sqlparser.AndExpr{
+					Left: &sqlparser.ComparisonExpr{
+						Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+						Operator: ">",
+						Right:    sqlparser.NewIntVal([]byte("25")),
+					},
+					Right: &sqlparser.ComparisonExpr{
+						Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_key")},
+						Operator: "like",
+						Right:    sqlparser.NewStrVal([]byte("user:1%")),
+					},
+				},
 			},
 			wantErr: false,
 		},
@@ -46,7 +72,7 @@ func TestParseQuery(t *testing.T) {
 		},
 		{
 			name:    "invalid multiple fields",
-			sql:     "SELECT field1, field2",
+			sql:     "SELECT field1, field2 FROM `test`",
 			want:    DSQLQuery{},
 			wantErr: true,
 			error:   "only $key and $value are supported in SELECT expressions",
@@ -86,16 +112,281 @@ func TestParseQuery(t *testing.T) {
 			wantErr: true,
 			error:   "invalid LIMIT value",
 		},
+		{
+			name: "select only value",
+			sql:  "SELECT $value FROM `test:*`",
+			want: DSQLQuery{
+				Selection: QuerySelection{KeySelection: false, ValueSelection: true},
+				KeyRegex:  "test:*",
+			},
+			wantErr: false,
+		},
+		{
+			name: "order by key ascending",
+			sql:  "SELECT $key, $value FROM `test:*` ORDER BY $key ASC",
+			want: DSQLQuery{
+				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
+				KeyRegex:  "test:*",
+				OrderBy:   QueryOrder{OrderBy: "$key", Order: "asc"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid table name",
+			sql:     "SELECT $key FROM 123",
+			want:    DSQLQuery{},
+			wantErr: true,
+			error:   "error parsing SQL statement: syntax error at position 21 near '123'",
+		},
+		{
+			name: "where clause with NULL comparison",
+			sql:  "SELECT $key, $value FROM `test:*` WHERE $value IS NULL",
+			want: DSQLQuery{
+				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
+				KeyRegex:  "test:*",
+				Where: &sqlparser.IsExpr{
+					Operator: "is null",
+					Expr:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "where clause with multiple conditions",
+			sql:  "SELECT $key FROM `test:*` WHERE $value > 10 AND $key LIKE 'test:%' OR $value < 5",
+			want: DSQLQuery{
+				Selection: QuerySelection{KeySelection: true, ValueSelection: false},
+				KeyRegex:  "test:*",
+				Where: &sqlparser.OrExpr{
+					Left: &sqlparser.AndExpr{
+						Left: &sqlparser.ComparisonExpr{
+							Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+							Operator: ">",
+							Right:    sqlparser.NewIntVal([]byte("10")),
+						},
+						Right: &sqlparser.ComparisonExpr{
+							Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_key")},
+							Operator: "like",
+							Right:    sqlparser.NewStrVal([]byte("test:%")),
+						},
+					},
+					Right: &sqlparser.ComparisonExpr{
+						Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+						Operator: "<",
+						Right:    sqlparser.NewIntVal([]byte("5")),
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			got, err := ParseQuery(testCase.sql)
-			if testCase.wantErr {
-				assert.Error(t, err, testCase.error, "ParseQuery() should have returned an error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseQuery(tt.sql)
+			if tt.wantErr {
+				assert.Error(t, err, tt.error)
 			} else {
-				assert.NilError(t, err, "ParseQuery() should not have returned an error")
-				assert.Check(t, cmp.DeepEqual(testCase.want, got), "ParseQuery() did not return expected output")
+				assert.NilError(t, err)
+				assert.DeepEqual(t, tt.want.Selection, got.Selection)
+				assert.Equal(t, tt.want.KeyRegex, got.KeyRegex)
+				assert.DeepEqual(t, tt.want.OrderBy, got.OrderBy)
+				assert.Equal(t, tt.want.Limit, got.Limit)
+
+				if tt.want.Where == nil {
+					assert.Assert(t, got.Where == nil)
+				} else {
+					assert.Assert(t, got.Where != nil)
+					assert.DeepEqual(t, tt.want.Where, got.Where)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSelectExpressions(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		want    QuerySelection
+		wantErr bool
+	}{
+		{
+			name: "select key and value",
+			sql:  "SELECT $key, $value FROM `test`",
+			want: QuerySelection{KeySelection: true, ValueSelection: true},
+		},
+		{
+			name: "select only key",
+			sql:  "SELECT $key FROM `test`",
+			want: QuerySelection{KeySelection: true, ValueSelection: false},
+		},
+		{
+			name: "select only value",
+			sql:  "SELECT $value FROM `test`",
+			want: QuerySelection{KeySelection: false, ValueSelection: true},
+		},
+		{
+			name:    "select invalid field",
+			sql:     "SELECT invalid FROM `test`",
+			wantErr: true,
+		},
+		{
+			name:    "select too many fields",
+			sql:     "SELECT $key, $value, extra FROM `test`",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			stmt, err := sqlparser.Parse(replaceCustomSyntax(tt.sql))
+			assert.NilError(t, err)
+
+			selectStmt, ok := stmt.(*sqlparser.Select)
+			assert.Assert(t, ok)
+
+			got, err := parseSelectExpressions(selectStmt)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseTableName(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid table name",
+			sql:  "SELECT $key FROM `test:*`",
+			want: "test:*",
+		},
+		{
+			name: "table name with backticks",
+			sql:  "SELECT $key FROM `complex:table:name`",
+			want: "complex:table:name",
+		},
+		{
+			name:    "missing table name",
+			sql:     "SELECT $key",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt, err := sqlparser.Parse(replaceCustomSyntax(tt.sql))
+			assert.NilError(t, err)
+
+			selectStmt, ok := stmt.(*sqlparser.Select)
+			assert.Assert(t, ok)
+
+			got, err := parseTableName(selectStmt)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseOrderBy(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		want    QueryOrder
+		wantErr bool
+	}{
+		{
+			name: "order by key asc",
+			sql:  "SELECT $key FROM `test` ORDER BY $key ASC",
+			want: QueryOrder{OrderBy: "$key", Order: "asc"},
+		},
+		{
+			name: "order by value desc",
+			sql:  "SELECT $value FROM `test` ORDER BY $value DESC",
+			want: QueryOrder{OrderBy: "$value", Order: "desc"},
+		},
+		{
+			name:    "invalid order by field",
+			sql:     "SELECT $key FROM `test` ORDER BY invalid",
+			wantErr: true,
+		},
+		{
+			name: "no order by clause",
+			sql:  "SELECT $key FROM `test`",
+			want: QueryOrder{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt, err := sqlparser.Parse(replaceCustomSyntax(tt.sql))
+			assert.NilError(t, err)
+
+			selectStmt, ok := stmt.(*sqlparser.Select)
+			assert.Assert(t, ok)
+
+			got, err := parseOrderBy(selectStmt)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "valid limit",
+			sql:  "SELECT $key FROM `test` LIMIT 10",
+			want: 10,
+		},
+		{
+			name: "no limit clause",
+			sql:  "SELECT $key FROM `test`",
+			want: 0,
+		},
+		{
+			name:    "invalid limit value",
+			sql:     "SELECT $key FROM `test` LIMIT abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt, err := sqlparser.Parse(replaceCustomSyntax(tt.sql))
+			assert.NilError(t, err)
+
+			selectStmt, ok := stmt.(*sqlparser.Select)
+			assert.Assert(t, ok)
+
+			got, err := parseLimit(selectStmt)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/dicedb/dice/core"
+	"github.com/xwb1989/sqlparser"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 )
@@ -20,6 +21,7 @@ var dataset = []keyValue{
 	{"k3", "v3"},
 	{"k5", "v1"},
 	{"k1", "v5"},
+	{"k", "k"},
 }
 
 func setup() {
@@ -151,4 +153,233 @@ func TestExecuteQueryNoMatch(t *testing.T) {
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Len(result, 0)) // No keys match "x*"
+}
+
+func TestExecuteQueryWithWhere(t *testing.T) {
+	setup()
+	t.Run("BasicWhereClause", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "k*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+				Operator: "=",
+				Right:    sqlparser.NewStrVal([]byte("v3")),
+			},
+		}
+
+		result, err := core.ExecuteQuery(query)
+
+		assert.NilError(t, err)
+		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause")
+		assert.Equal(t, result[0].Key, "k3")
+		assert.DeepEqual(t, result[0].Value.Value, "v3")
+	})
+
+	t.Run("EmptyResult", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "k*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+				Operator: "=",
+				Right:    sqlparser.NewStrVal([]byte("nonexistent")),
+			},
+		}
+
+		result, err := core.ExecuteQuery(query)
+
+		assert.NilError(t, err)
+		assert.Equal(t, len(result), 0, "Expected empty result for non-matching WHERE clause")
+	})
+
+	t.Run("ComplexWhereClause", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "k*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			OrderBy: core.QueryOrder{
+				OrderBy: "$value",
+				Order:   "desc",
+			},
+			Where: &sqlparser.AndExpr{
+				Left: &sqlparser.ComparisonExpr{
+					Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+					Operator: ">",
+					Right:    sqlparser.NewStrVal([]byte("v2")),
+				},
+				Right: &sqlparser.ComparisonExpr{
+					Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+					Operator: "<",
+					Right:    sqlparser.NewStrVal([]byte("v5")),
+				},
+			},
+		}
+
+		result, err := core.ExecuteQuery(query)
+
+		assert.NilError(t, err)
+		assert.Equal(t, len(result), 2, "Expected 2 results for complex WHERE clause")
+		assert.DeepEqual(t, []string{result[0].Key, result[1].Key}, []string{"k2", "k3"})
+	})
+
+	t.Run("ComparingKeyWithValue", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "k*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_key")},
+				Operator: "=",
+				Right:    &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+			},
+		}
+
+		result, err := core.ExecuteQuery(query)
+
+		assert.NilError(t, err)
+		assert.Equal(t, len(result), 1, "Expected 1 result for comparison between key and value")
+		assert.Equal(t, result[0].Key, "k")
+		assert.DeepEqual(t, result[0].Value.Value, "k")
+	})
+}
+
+func TestExecuteQueryWithIncompatibleTypes(t *testing.T) {
+	setup()
+
+	t.Run("ComparingStrWithInt", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "k*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+				Operator: "=",
+				Right:    sqlparser.NewIntVal([]byte("42")),
+			},
+		}
+
+		_, err := core.ExecuteQuery(query)
+
+		assert.Error(t, err, "incompatible types in comparison: string and int")
+	})
+
+	t.Run("NullValue", func(t *testing.T) {
+		// We don't support NULL values in Dice, however, we should include a
+		// test for it to ensure the executor handles it correctly.
+		core.Put("nullKey", &core.Obj{Value: nil})
+		defer core.Del("nullKey")
+
+		query := core.DSQLQuery{
+			KeyRegex: "nullKey",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+				Operator: "=",
+				Right:    &sqlparser.NullVal{},
+			},
+		}
+
+		_, err := core.ExecuteQuery(query)
+
+		assert.Error(t, err, "unsupported value type: <nil>")
+	})
+}
+
+func TestExecuteQueryWithEdgeCases(t *testing.T) {
+	setup()
+
+	t.Run("CaseSensitivity", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "k*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+				Operator: "=",
+				Right:    sqlparser.NewStrVal([]byte("V3")), // Uppercase V3
+			},
+		}
+
+		result, err := core.ExecuteQuery(query)
+
+		assert.NilError(t, err)
+		assert.Equal(t, len(result), 0, "Expected 0 results due to case sensitivity")
+	})
+
+	t.Run("WhereClauseOnKey", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "k*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			OrderBy: core.QueryOrder{
+				OrderBy: "$key",
+				Order:   "asc",
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_key")},
+				Operator: ">",
+				Right:    sqlparser.NewStrVal([]byte("k3")),
+			},
+		}
+
+		result, err := core.ExecuteQuery(query)
+
+		assert.NilError(t, err)
+		assert.Equal(t, len(result), 2, "Expected 2 results for WHERE clause on key")
+		assert.DeepEqual(t, []string{result[0].Key, result[1].Key}, []string{"k4", "k5"})
+	})
+
+	t.Run("UnsupportedOperator", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "k*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
+				Operator: "LIKE",
+				Right:    sqlparser.NewStrVal([]byte("%3")),
+			},
+		}
+
+		_, err := core.ExecuteQuery(query)
+
+		assert.ErrorContains(t, err, "unsupported operator")
+	})
+
+	t.Run("EmptyKeyRegex", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+		}
+
+		result, err := core.ExecuteQuery(query)
+
+		assert.NilError(t, err)
+		assert.Equal(t, len(result), 0, "Expected no keys to be returned for empty regex")
+	})
 }


### PR DESCRIPTION
This PR adds support for WHERE clause in DSQL.

## Key Changes
1. Updated `DSQLQuery` struct to include a `Where` field of type `sqlparser.Expr`.
2. Updated `ParseQuery` to support WHERE clauses.
4. Updated `ExecuteQuery` to evaluate WHERE clause for each row.
5. Added support for complex WHERE conditions using a recursive analyzer.
6. Implemented type-safe comparisons for string, int, and float values.
7. Added extensive test cases for both parser and executor to cover various scenarios and edge cases.

## Operator Support
- Support for basic comparison operators (=, !=, <, <=, >, >=) in WHERE clauses.
- Support for AND/OR logical operators.

## Testing
Added comprehensive test cases for parser and executor.

## Notes
- Logic needs to be extended to support JSON values once Dice supports them.