### PR TITLE
#196: Fixed DiceDB server reconnection error.

### DIFF
--- a/core/io.go
+++ b/core/io.go
@@ -61,6 +61,12 @@ func (rp *RESPParser) DecodeOne() (interface{}, error) {
 			}
 			return nil, err
 		}
+
+		// Handle the case where no data is read but no error is returned
+		if n == 0 {
+			// This can happen if the connection is closed on the client side but not properly detected
+			return nil, errors.New("ERR possible client-side connection closure")
+		}
 	}
 
 	b, err := rp.buf.ReadByte()

--- a/core/io_test.go
+++ b/core/io_test.go
@@ -189,3 +189,18 @@ func TestDecodeOneVeryLargeMessage(t *testing.T) {
 		t.Fatalf("Expected large string, got %v", result)
 	}
 }
+
+		
+func TestDecodeOneNoDataRead(t *testing.T) {
+	mockRW := &MockReadWriter{
+		ReadChunks: [][]byte{
+			[]byte(""), // Empty read chunk
+		},
+	}
+	parser := NewRESPParser(mockRW)
+
+	_, err := parser.DecodeOne()
+	if err == nil || err.Error() != "ERR possible client-side connection closure" {
+		t.Fatalf("Expected 'ERR possible client-side connection closure' error, got %v", err)
+	}
+}


### PR DESCRIPTION

  * The changes that are included in the PR.
  - code for handling case where no data is read and no error is returned in DecodeOne function in io.go file
  - Test case for the above mentioned case in io_test.go

  * Evidence of sufficient testing. You ``MUST`` indicate the tests done, either manually or automated.
  - I ran the submitted unit test along with all the tests. They all passed
  - I checked the functionality by using "exit" and ^d command to check if I was allowed to connect to the server again. It ran successfully.