### PR TITLE
#201: Fix for expired key crash

### DIFF
--- a/core/store.go
+++ b/core/store.go
@@ -91,9 +91,11 @@ func Get(k string) *Obj {
 	v := store[ptr]
 	if v != nil {
 		if hasExpired(v) {
+			keypoolMutex.RUnlock()
 			storeMutex.RUnlock()
 			Del(k)
 			storeMutex.RLock()
+			keypoolMutex.RLock()
 			return nil
 		}
 		v.LastAccessedAt = getCurrentClock()

--- a/tests/get_test.go
+++ b/tests/get_test.go
@@ -1,0 +1,24 @@
+package tests
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGet(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+	for _, tcase := range []DTestCase{
+		{
+			InCmds: []string{"SET k v EX 4", "GET k", "SLEEP 5", "GET k"},
+			Out:    []interface{}{"OK", "v", "OK", "(nil)"},
+		},
+	} {
+		for i := 0; i < len(tcase.InCmds); i++ {
+			cmd := tcase.InCmds[i]
+			out := tcase.Out[i]
+			assert.Equal(t, out, fireCommand(conn, cmd), "Value mismatch for cmd %s\n.", cmd)
+		}
+	}
+}

--- a/tests/get_test.go
+++ b/tests/get_test.go
@@ -2,20 +2,31 @@ package tests
 
 import (
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 )
 
+type DDelayTestCase struct {
+	InCmds []string
+	Out    []interface{}
+	Delay  []time.Duration
+}
+
 func TestGet(t *testing.T) {
 	conn := getLocalConnection()
 	defer conn.Close()
-	for _, tcase := range []DTestCase{
+	for _, tcase := range []DDelayTestCase{
 		{
-			InCmds: []string{"SET k v EX 4", "GET k", "SLEEP 5", "GET k"},
-			Out:    []interface{}{"OK", "v", "OK", "(nil)"},
+			InCmds: []string{"SET k v EX 4", "GET k", "GET k"},
+			Out:    []interface{}{"OK", "v", "(nil)"},
+			Delay:  []time.Duration{0, 0, 5 * time.Second},
 		},
 	} {
 		for i := 0; i < len(tcase.InCmds); i++ {
+			if tcase.Delay[i] > 0 {
+				time.Sleep(tcase.Delay[i])
+			}
 			cmd := tcase.InCmds[i]
 			out := tcase.Out[i]
 			assert.Equal(t, out, fireCommand(conn, cmd), "Value mismatch for cmd %s\n.", cmd)


### PR DESCRIPTION
In file store.go, func Del(k) requires both locks to delete the key, however,  in Get(k), we were releasing only one. This fix implements releasing both locks before calling Del(k) and acquiring both locks again.
Tested manually on local:
<img width="402" alt="image" src="https://github.com/user-attachments/assets/fa25c587-a556-4d4f-8488-c7ce6c8c5063">
