### PR TITLE
#198: Adding unit tests for eval.go file

### DIFF
--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -1,28 +1,84 @@
 package core
 
 import (
+	"bytes"
 	"errors"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/bytedance/sonic"
 	"gotest.tools/v3/assert"
 )
 
 type testCase struct {
-	input  []string
-	output []byte
+	setup     func()
+	input     []string
+	output    []byte
+	validator func(output []byte)
+}
+
+func setupTest() {
+	store = make(map[unsafe.Pointer]*Obj)
+	keypool = make(map[string]unsafe.Pointer)
+	expires = make(map[*Obj]uint64)
+	KeyspaceStat[0] = make(map[string]int)
+}
+
+func teardownTest() {
+	store = nil
+	keypool = nil
+	expires = nil
 }
 
 func TestEval(t *testing.T) {
 	testCases := map[string]func(*testing.T){
-		"SET":  testEvalSET,
-		"MSET": testEvalMSET,
+		"MSET":    testEvalMSET,
+		"PING":    testEvalPING,
+		"HELLO":   testEvalHELLO,
+		"SET":     testEvalSET,
+		"GET":     testEvalGET,
+		"JSONGET": testEvalJSONGET,
+		"JSONSET": testEvalJSONSET,
+		"TTL":     testEvalTTL,
+		"DEL":     testEvalDel,
 	}
 
 	for name, testFunc := range testCases {
 		t.Run(name, testFunc)
 	}
+}
+
+func testEvalPING(t *testing.T) {
+	tests := map[string]testCase{
+		"nil value":            {input: nil, output: []byte("+PONG\r\n")},
+		"empty args":           {input: []string{}, output: []byte("+PONG\r\n")},
+		"one value":            {input: []string{"HEY"}, output: []byte("$3\r\nHEY\r\n")},
+		"more than one values": {input: []string{"HEY", "HELLO"}, output: []byte("-ERR wrong number of arguments for 'ping' command\r\n")},
+	}
+
+	runTests(t, tests, evalPING)
+}
+
+func testEvalHELLO(t *testing.T) {
+	response := []interface{}{
+		"proto", 2,
+		"id", serverID,
+		"mode", "standalone",
+		"role", "master",
+		"modules", []interface{}{},
+	}
+
+	tests := map[string]testCase{
+		"nil value":            {input: nil, output: Encode(response, false)},
+		"empty args":           {input: []string{}, output: Encode(response, false)},
+		"one value":            {input: []string{"HEY"}, output: Encode(response, false)},
+		"more than one values": {input: []string{"HEY", "HELLO"}, output: []byte("-ERR wrong number of arguments for 'hello' command\r\n")},
+	}
+
+	runTests(t, tests, evalHELLO)
 }
 
 func testEvalSET(t *testing.T) {
@@ -61,11 +117,292 @@ func testEvalMSET(t *testing.T) {
 	runTests(t, tests, evalMSET)
 }
 
+func testEvalGET(t *testing.T) {
+	tests := map[string]testCase{
+		"nil value": {
+			setup:  func() {},
+			input:  nil,
+			output: []byte("-ERR wrong number of arguments for 'get' command\r\n"),
+		},
+		"empty array": {
+			setup:  func() {},
+			input:  []string{},
+			output: []byte("-ERR wrong number of arguments for 'get' command\r\n"),
+		},
+		"key does not exist": {
+			setup:  func() {},
+			input:  []string{"NONEXISTENT_KEY"},
+			output: RESP_NIL,
+		},
+		"multiple arguments": {
+			setup:  func() {},
+			input:  []string{"KEY1", "KEY2"},
+			output: []byte("-ERR wrong number of arguments for 'get' command\r\n"),
+		},
+		"key exists": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+			},
+			input:  []string{"EXISTING_KEY"},
+			output: Encode("mock_value", false),
+		},
+		"key exists but expired": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+				expires[obj] = uint64(time.Now().Add(-2 * time.Minute).Unix())
+			},
+			input:  []string{"EXISTING_KEY"},
+			output: RESP_NIL,
+		},
+	}
+
+	runTests(t, tests, evalGET)
+}
+
+func testEvalJSONGET(t *testing.T) {
+	tests := map[string]testCase{
+		"nil value": {
+			setup:  func() {},
+			input:  nil,
+			output: []byte("-ERR wrong number of arguments for 'JSON.GET' command\r\n"),
+		},
+		"empty array": {
+			setup:  func() {},
+			input:  []string{},
+			output: []byte("-ERR wrong number of arguments for 'JSON.GET' command\r\n"),
+		},
+		"key does not exist": {
+			setup:  func() {},
+			input:  []string{"NONEXISTENT_KEY"},
+			output: RESP_NIL,
+		},
+		"key exists invalid value": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":2}"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+			},
+			input:  []string{"EXISTING_KEY"},
+			output: []byte("-the operation is not permitted on this type\r\n"),
+		},
+		"key exists value": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":2}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := NewObj(rootData, -1, OBJ_TYPE_JSON, OBJ_ENCODING_JSON)
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+			},
+
+			input:  []string{"EXISTING_KEY"},
+			output: []byte("$7\r\n{\"a\":2}\r\n"),
+		},
+		"key exists but expired": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+				expires[obj] = uint64(time.Now().Add(-2 * time.Minute).Unix())
+			},
+			input:  []string{"EXISTING_KEY"},
+			output: RESP_NIL,
+		},
+	}
+
+	runTests(t, tests, evalJSONGET)
+}
+
+func testEvalJSONSET(t *testing.T) {
+	tests := map[string]testCase{
+		"nil value": {
+			setup:  func() {},
+			input:  nil,
+			output: []byte("-ERR wrong number of arguments for 'JSON.SET' command\r\n"),
+		},
+		"empty array": {
+			setup:  func() {},
+			input:  []string{},
+			output: []byte("-ERR wrong number of arguments for 'JSON.SET' command\r\n"),
+		},
+		"insufficient args": {
+			setup:  func() {},
+			input:  []string{},
+			output: []byte("-ERR wrong number of arguments for 'JSON.SET' command\r\n"),
+		},
+		"invalid json path": {
+			setup:  func() {},
+			input:  []string{"doc", "$", "{\"a\":}"},
+			output: nil,
+			validator: func(output []byte) {
+				assert.Assert(t, output != nil)
+				assert.Assert(t, strings.Contains(string(output), "-ERR invalid JSON:"))
+			},
+		},
+		"valid json path": {
+			setup: func() {
+			},
+			input:  []string{"doc", "$", "{\"a\":2}"},
+			output: RESP_OK,
+		},
+	}
+
+	runTests(t, tests, evalJSONSET)
+}
+
+func testEvalTTL(t *testing.T) {
+	tests := map[string]testCase{
+		"nil value": {
+			setup:  func() {},
+			input:  nil,
+			output: []byte("-ERR wrong number of arguments for 'ttl' command\r\n"),
+		},
+		"empty array": {
+			setup:  func() {},
+			input:  []string{},
+			output: []byte("-ERR wrong number of arguments for 'ttl' command\r\n"),
+		},
+		"key does not exist": {
+			setup:  func() {},
+			input:  []string{"NONEXISTENT_KEY"},
+			output: RESP_MINUS_2,
+		},
+		"multiple arguments": {
+			setup:  func() {},
+			input:  []string{"KEY1", "KEY2"},
+			output: []byte("-ERR wrong number of arguments for 'ttl' command\r\n"),
+		},
+		"key exists expiry not set": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+			},
+			input:  []string{"EXISTING_KEY"},
+			output: RESP_MINUS_1,
+		},
+		"key exists not expired": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+				expires[obj] = uint64(time.Now().Add(2 * time.Minute).UnixMilli())
+			},
+			input: []string{"EXISTING_KEY"},
+			validator: func(output []byte) {
+				assert.Assert(t, output != nil)
+				assert.Assert(t, !bytes.Equal(output, RESP_MINUS_1))
+				assert.Assert(t, !bytes.Equal(output, RESP_MINUS_2))
+			},
+		},
+		"key exists but expired": {
+			setup: func() {
+				key := "EXISTING_EXPIRED_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+				expires[obj] = uint64(time.Now().Add(-2 * time.Minute).Unix())
+			},
+			input:  []string{"EXISTING_KEY"},
+			output: RESP_MINUS_2,
+		},
+	}
+
+	runTests(t, tests, evalTTL)
+}
+
+func testEvalDel(t *testing.T) {
+	tests := map[string]testCase{
+		"nil value": {
+			setup:  func() {},
+			input:  nil,
+			output: []byte(":0\r\n"),
+		},
+		"empty array": {
+			setup:  func() {},
+			input:  []string{},
+			output: []byte(":0\r\n"),
+		},
+		"key does not exist": {
+			setup:  func() {},
+			input:  []string{"NONEXISTENT_KEY"},
+			output: []byte(":0\r\n"),
+		},
+		"key exists": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+				KeyspaceStat[0]["keys"]++
+			},
+			input:  []string{"EXISTING_KEY"},
+			output: []byte(":1\r\n"),
+		},
+	}
+
+	runTests(t, tests, evalDEL)
+}
+
 func runTests(t *testing.T, tests map[string]testCase, evalFunc func([]string) []byte) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			setupTest()
+			defer teardownTest()
+
+			if tc.setup != nil {
+				tc.setup()
+			}
+
 			output := evalFunc(tc.input)
-			assert.Equal(t, string(tc.output), string(output))
+			if tc.validator != nil {
+				tc.validator(output)
+			} else {
+				assert.Equal(t, string(tc.output), string(output))
+			}
 		})
 	}
 }


### PR DESCRIPTION
- Adding unit tests for `eval.go` file
- Few test cases are blocked due to [GH-201](https://github.com/DiceDB/dice/issues/201), would update once issue is resolved.