### PR TITLE
fixed readBulkString to handle RESP_NIL

### DIFF
--- a/core/resp.go
+++ b/core/resp.go
@@ -77,6 +77,11 @@ func readBulkString(c io.ReadWriter, buf *bytes.Buffer) (string, error) {
 		return "", err
 	}
 
+	//handling RESP_NIL case
+	if len == -1 {
+		return "(nil)", nil
+	}
+
 	var bytesRem int64 = len + 2 // 2 for \r\n
 	bytesRem = bytesRem - int64(buf.Len())
 	for bytesRem > 0 {

--- a/tests/set_test.go
+++ b/tests/set_test.go
@@ -13,6 +13,10 @@ func TestSet(t *testing.T) {
 			InCmds: []string{"SET k v", "GET k"},
 			Out:    []interface{}{"OK", "v"},
 		},
+		{
+			InCmds: []string{"SET k v EX 1", "SLEEP 2", "GET k"},
+			Out:    []interface{}{"OK", "OK", "(nil)"},
+		},
 	} {
 		for i := 0; i < len(tcase.InCmds); i++ {
 			cmd := tcase.InCmds[i]


### PR DESCRIPTION
Fixes: Issue #213 
### Changes
- Added a corner case for handling `RESP_NIL`

### Tests

- Added a test case in `tests/set_test.go` where the expected output for a command in `RESP_NIL`
