### PR TITLE
#183: Support for signed integer dencoding

### DIFF
--- a/core/dencoding/int.go
+++ b/core/dencoding/int.go
@@ -49,3 +49,15 @@ func DecodeUInt(vint []byte) uint64 {
 	}
 	return v
 }
+
+// EncodeInt encodes the signed 64 bit integer value into a varint
+// and returns an array of bytes (little endian encoded)
+func EncodeInt(x int64) []byte {
+	return EncodeUInt(uint64((x << 1) ^ (x >> 63)))
+}
+
+// DecodeInt decodes the array of bytes and returns a signed 64 bit integer
+func DecodeInt(vint []byte) int64 {
+	ux := DecodeUInt(vint)
+	return int64((ux >> 1) ^ uint64((int64(ux)<<63)>>63))
+}

--- a/core/dencoding/int_test.go
+++ b/core/dencoding/int_test.go
@@ -1,13 +1,14 @@
 package dencoding_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/dicedb/dice/core/dencoding"
 	"github.com/dicedb/dice/testutils"
 )
 
-func TestDencodingInt(t *testing.T) {
+func TestDencodingUInt(t *testing.T) {
 	var tests []uint64
 
 	tests = append(tests, 0)
@@ -47,6 +48,68 @@ func TestDencodingInt(t *testing.T) {
 		obs := dencoding.EncodeUInt(uint64(k))
 		if !testutils.EqualByteSlice(obs, v) {
 			t.Errorf("dencoding for integer value %d failed. should be: %d, but found %d\n", k, v, obs)
+		}
+	}
+}
+
+func TestDencodingInt(t *testing.T) {
+	var tests []int64
+
+	tests = append(tests, 0)
+	for i := 0; i < 64; i++ {
+		tests = append(tests, 1<<i)
+		tests = append(tests, (1<<i)-1)
+		tests = append(tests, (1<<i)+1)
+		tests = append(tests, -1<<i)
+		tests = append(tests, -(1<<i)-1)
+		tests = append(tests, -(1<<i)+1)
+	}
+
+	for _, v := range tests {
+		if v != dencoding.DecodeInt(dencoding.EncodeInt(v)) {
+			t.Errorf("dencoding failed for value: %d\n", v)
+		}
+	}
+
+	for k, v := range map[int64]int{
+		0:   1,
+		127: 2,
+		128: 2,
+		129: 2,
+	} {
+		b := dencoding.EncodeInt(int64(k))
+		if len(b) != v {
+			t.Errorf("dencoding for integer value %d failed. encoded length should be: %d, but found %d\n", k, v, len(b))
+		}
+	}
+
+	for k, v := range map[int][]byte{
+		0:    {0x00},
+		1:    {0x02},
+		-1:   {0x01},
+		63:   {0x7E},
+		-64:  {0x7F},
+		64:   {0x80, 0x01},
+		-65:  {0x81, 0x01},
+		127:  {0xFE, 0x01},
+		128:  {0x80, 0x02},
+		-128: {0xFF, 0x01},
+		-129: {0x81, 0x02},
+	} {
+		obs := dencoding.EncodeInt(int64(k))
+		if !testutils.EqualByteSlice(obs, v) {
+			t.Errorf("dencoding for integer value %d failed. should be: %d, but found %d\n", k, v, obs)
+		}
+	}
+}
+
+func BenchmarkEncodeDecodeInt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		value := int64(i % math.MaxInt64)
+		encoded := dencoding.EncodeInt(value)
+		decoded := dencoding.DecodeInt(encoded)
+		if decoded != value {
+			b.Errorf("DecodeInt(%v) = %d; want %d", encoded, decoded, value)
 		}
 	}
 }


### PR DESCRIPTION
- Added support for signed integer encoding, this would allow us to support signed integer stacks and queues.
- Added unit tests to validate correctness.
```
=== RUN   TestDencodingInt
--- PASS: TestDencodingInt (0.00s)
PASS
ok      github.com/dicedb/dice/core/dencoding   0.215s
```
- Added the benchmarks
```
=== RUN   BenchmarkEncodeDecodeInt
BenchmarkEncodeDecodeInt
BenchmarkEncodeDecodeInt-12     69471247                16.97 ns/op            3 B/op          1 allocs/op
PASS
ok      github.com/dicedb/dice/core/dencoding   1.627s
```