### PR TITLE
#205: Add support for XX in SET command

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -88,10 +88,6 @@ func evalSET(args []string) []byte {
 			}
 			exDurationMs = exDurationSec * 1000
 		case "XX", "xx":
-			if i != len(args) {
-				return Encode(errors.New("ERR syntax error"), false)
-			}
-
 			// Get the key from the hash table
 			obj := Get(key)
 

--- a/core/eval.go
+++ b/core/eval.go
@@ -87,6 +87,19 @@ func evalSET(args []string) []byte {
 				return Encode(errors.New("ERR value is not an integer or out of range"), false)
 			}
 			exDurationMs = exDurationSec * 1000
+		case "XX", "xx":
+			if i != len(args) {
+				return Encode(errors.New("ERR syntax error"), false)
+			}
+
+			// Get the key from the hash table
+			obj := Get(key)
+
+			// if key does not exist, return RESP encoded nil
+			if obj == nil {
+				return RESP_NIL
+			}
+
 		default:
 			return Encode(errors.New("ERR syntax error"), false)
 		}

--- a/tests/set_test.go
+++ b/tests/set_test.go
@@ -1,10 +1,18 @@
 package tests
 
 import (
+	"fmt"
+	"net"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
+
+func deleteKeys(conn net.Conn, keysToDelete []string) {
+	for _, key := range keysToDelete {
+		fireCommand(conn, fmt.Sprintf("DEL %s", key))
+	}
+}
 
 func TestSet(t *testing.T) {
 	conn := getLocalConnection()
@@ -24,6 +32,7 @@ func TestSet(t *testing.T) {
 
 func TestSetWithXX(t *testing.T) {
 	conn := getLocalConnection()
+	deleteKeys(conn, []string{"k"})
 	for _, tcase := range []DTestCase{
 		{
 			InCmds: []string{"SET k v XX"},

--- a/tests/set_test.go
+++ b/tests/set_test.go
@@ -1,18 +1,10 @@
 package tests
 
 import (
-	"fmt"
-	"net"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
-
-func deleteKeys(conn net.Conn, keysToDelete []string) {
-	for _, key := range keysToDelete {
-		fireCommand(conn, fmt.Sprintf("DEL %s", key))
-	}
-}
 
 func TestSet(t *testing.T) {
 	conn := getLocalConnection()
@@ -32,7 +24,7 @@ func TestSet(t *testing.T) {
 
 func TestSetWithXX(t *testing.T) {
 	conn := getLocalConnection()
-	deleteKeys(conn, []string{"k"})
+	deleteTestKeys(conn, []string{"k"})
 	for _, tcase := range []DTestCase{
 		{
 			InCmds: []string{"SET k v XX"},

--- a/tests/set_test.go
+++ b/tests/set_test.go
@@ -21,3 +21,31 @@ func TestSet(t *testing.T) {
 		}
 	}
 }
+
+func TestSetWithXX(t *testing.T) {
+	conn := getLocalConnection()
+	for _, tcase := range []DTestCase{
+		{
+			InCmds: []string{"SET k v XX"},
+			Out:    []interface{}{"nil"},
+		},
+		{
+			InCmds: []string{"SET k v1", "SET k v2 XX", "GET k"},
+			Out:    []interface{}{"OK", "OK", "v2"},
+		},
+		{
+			InCmds: []string{"SET k v1", "SET k v2 XX", "SET k v3 XX", "GET k"},
+			Out:    []interface{}{"OK", "OK", "OK", "v3"},
+		},
+		{
+			InCmds: []string{"SET k v1", "SET k v2 XX", "DEL k", "GET k", "SET k v XX"},
+			Out:    []interface{}{"OK", "OK", "1", "nil", "nil"},
+		},
+	} {
+		for i := 0; i < len(tcase.InCmds); i++ {
+			cmd := tcase.InCmds[i]
+			out := tcase.Out[i]
+			assert.Equal(t, out, fireCommand(conn, cmd), "Value mismatch for cmd %s\n.", cmd)
+		}
+	}
+}

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -24,6 +24,13 @@ func getLocalConnection() net.Conn {
 	return conn
 }
 
+// deleteTestKeys is a utility to delete a list of keys before running a test
+func deleteTestKeys(conn net.Conn, keysToDelete []string) {
+	for _, key := range keysToDelete {
+		fireCommand(conn, fmt.Sprintf("DEL %s", key))
+	}
+}
+
 func getLocalSdk() *redis.Client {
 	return redis.NewClient(&redis.Options{
 		Addr: fmt.Sprintf(":%d", config.Port),


### PR DESCRIPTION
## Add **XX** Support to **SET** Command

### Description

This pull request adds support for the XX option to the SET command, similar to the XX option in Redis. The XX option sets the value of the key only if it is already present.
Solving the issue https://github.com/DiceDB/dice/issues/205

### Changes Made

1. **Implemented XX Option:**
   - Updated the SET command to handle the XX option.

2. **Unit Tests:**
   - Added unit tests for the XX option.