### PR TITLE
#147: Add support for COMMAND GETKEYS command

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -1,18 +1,27 @@
 package core
 
 type DiceCmdMeta struct {
-	Name string
-	Info string
-	Eval func([]string) []byte
+	Name  string
+	Info  string
+	Eval  func([]string) []byte
+	Arity int // number of arguments, it is possible to use -N to say >= N
+	KeySpecs
+}
+
+type KeySpecs struct {
+	BeginIndex int
+	Step       int
+	LastKey    int
 }
 
 var (
 	diceCmds = map[string]DiceCmdMeta{}
 
 	pingCmdMeta = DiceCmdMeta{
-		Name: "PING",
-		Info: `PING returns with an encoded "PONG" If any message is added with the ping command,the message will be returned.`,
-		Eval: evalPING,
+		Name:  "PING",
+		Info:  `PING returns with an encoded "PONG" If any message is added with the ping command,the message will be returned.`,
+		Eval:  evalPING,
+		Arity: -1,
 	}
 	setCmdMeta = DiceCmdMeta{
 		Name: "SET",
@@ -24,7 +33,9 @@ var (
 		Returns encoded error response if expiry tme value in not integer
 		Returns encoded OK RESP once new entry is added
 		If the key already exists then the value will be overwritten and expiry will be discarded`,
-		Eval: evalSET,
+		Eval:     evalSET,
+		Arity:    -3,
+		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
 	getCmdMeta = DiceCmdMeta{
 		Name: "GET",
@@ -32,7 +43,9 @@ var (
 		The key should be the only param in args
 		The RESP value of the key is encoded and then returned
 		GET returns RESP_NIL if key is expired or it does not exist`,
-		Eval: evalGET,
+		Eval:     evalGET,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
 	jsonsetCmdMeta = DiceCmdMeta{
 		Name: "JSON.SET",
@@ -40,16 +53,19 @@ var (
 		Sets a JSON value at the specified key.
 		Returns OK if successful.
 		Returns encoded error message if the number of arguments is incorrect or the JSON string is invalid.`,
-		Eval: evalJSONSET,
+		Eval:     evalJSONSET,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
-
 	jsongetCmdMeta = DiceCmdMeta{
 		Name: "JSON.GET",
 		Info: `JSON.GET key [path]
 		Returns the encoded RESP value of the key, if present
 		Null reply: If the key doesn't exist or has expired.
 		Error reply: If the number of arguments is incorrect or the stored value is not a JSON type.`,
-		Eval: evalJSONGET,
+		Eval:     evalJSONGET,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
@@ -59,13 +75,17 @@ var (
 		 RESP encoded time (in secs) remaining for the key to expire
 		 RESP encoded -2 stating key doesn't exist or key is expired
 		 RESP encoded -1 in case no expiration is set on the key`,
-		Eval: evalTTL,
+		Eval:     evalTTL,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
 	delCmdMeta = DiceCmdMeta{
 		Name: "DEL",
 		Info: `DEL deletes all the specified keys in args list
 		returns the count of total deleted keys after encoding`,
-		Eval: evalDEL,
+		Eval:     evalDEL,
+		Arity:    -2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1, LastKey: -1},
 	}
 	expireCmdMeta = DiceCmdMeta{
 		Name: "EXPIRE",
@@ -74,17 +94,21 @@ var (
 		The expiry time should be in integer format; if not, it returns encoded error response
 		Returns RESP_ONE if expiry was set on the key successfully.
 		Once the time is lapsed, the key will be deleted automatically`,
-		Eval: evalEXPIRE,
+		Eval:     evalEXPIRE,
+		Arity:    -3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	helloCmdMeta = DiceCmdMeta{
-		Name: "HELLO",
-		Info: `HELLO always replies with a list of current server and connection properties, such as: versions, modules loaded, client ID, replication role and so forth`,
-		Eval: evalHELLO,
+		Name:  "HELLO",
+		Info:  `HELLO always replies with a list of current server and connection properties, such as: versions, modules loaded, client ID, replication role and so forth`,
+		Eval:  evalHELLO,
+		Arity: -1,
 	}
 	bgrewriteaofCmdMeta = DiceCmdMeta{
-		Name: "BGREWRITEAOF",
-		Info: `Instruct Dice to start an Append Only File rewrite process. The rewrite will create a small optimized version of the current Append Only File.`,
-		Eval: evalBGREWRITEAOF,
+		Name:  "BGREWRITEAOF",
+		Info:  `Instruct Dice to start an Append Only File rewrite process. The rewrite will create a small optimized version of the current Append Only File.`,
+		Eval:  evalBGREWRITEAOF,
+		Arity: 1,
 	}
 	incrCmdMeta = DiceCmdMeta{
 		Name: "INCR",
@@ -96,29 +120,35 @@ var (
 		The value for the queried key should be of integer format,
 		if not INCR returns encoded error response.
 		evalINCR returns the incremented value for the key if there are no errors.`,
-		Eval: evalINCR,
+		Eval:     evalINCR,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	infoCmdMeta = DiceCmdMeta{
 		Name: "INFO",
 		Info: `INFO creates a buffer with the info of total keys per db
 		Returns the encoded buffer as response`,
-		Eval: evalINFO,
+		Eval:  evalINFO,
+		Arity: -1,
 	}
 	clientCmdMeta = DiceCmdMeta{
-		Name: "CLIENT",
-		Info: `This is a container command for client connection commands.`,
-		Eval: evalCLIENT,
+		Name:  "CLIENT",
+		Info:  `This is a container command for client connection commands.`,
+		Eval:  evalCLIENT,
+		Arity: -2,
 	}
 	latencyCmdMeta = DiceCmdMeta{
-		Name: "LATENCY",
-		Info: `This is a container command for latency diagnostics commands.`,
-		Eval: evalLATENCY,
+		Name:  "LATENCY",
+		Info:  `This is a container command for latency diagnostics commands.`,
+		Eval:  evalLATENCY,
+		Arity: -2,
 	}
 	lruCmdMeta = DiceCmdMeta{
 		Name: "LRU",
 		Info: `LRU deletes all the keys from the LRU
 		returns encoded RESP OK`,
-		Eval: evalLRU,
+		Eval:  evalLRU,
+		Arity: 1,
 	}
 	sleepCmdMeta = DiceCmdMeta{
 		Name: "SLEEP",
@@ -126,7 +156,8 @@ var (
 		The sleep time should be the only param in args.
 		Returns error response if the time param in args is not of integer format.
 		SLEEP returns RESP_OK after sleeping for mentioned seconds`,
-		Eval: evalSLEEP,
+		Eval:  evalSLEEP,
+		Arity: 1,
 	}
 	qintinsCmdMeta = DiceCmdMeta{
 		Name: "QINTINS",
@@ -134,7 +165,9 @@ var (
 		first argument will be the key, that should be of type "QINT"
 		second argument will be the integer value
 		if the key does not exist, QINTINS will also create the integer queue`,
-		Eval: evalQINTINS,
+		Eval:     evalQINTINS,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	qintremCmdMeta = DiceCmdMeta{
 		Name: "QINTREM",
@@ -143,44 +176,57 @@ var (
 		if the key does not exist, QINTREM returns nil otherwise it
 		returns the integer value popped from the queue
 		if we remove from the empty queue, nil is returned`,
-		Eval: evalQINTREM,
+		Eval:     evalQINTREM,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	qintlenCmdMeta = DiceCmdMeta{
 		Name: "QINTLEN",
 		Info: `QINTLEN returns the length of the QINT identified by key
 		returns the integer value indicating the length of the queue
 		if the key does not exist, the response is 0`,
-		Eval: evalQINTLEN,
+		Eval:     evalQINTLEN,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	qintpeekCmdMeta = DiceCmdMeta{
 		Name: "QINTPEEK",
 		Info: `QINTPEEK peeks into the QINT and returns 5 elements without popping them
 		returns the array of integers as the response.
 		if the key does not exist, then we return an empty array`,
-		Eval: evalQINTPEEK,
+		Eval:     evalQINTPEEK,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	bfinitCmdMeta = DiceCmdMeta{
 		Name: "BFINIT",
 		Info: `BFINIT command initializes a new bloom filter and allocation it's relevant parameters based on given inputs.
 		If no params are provided, it uses defaults.`,
-		Eval: evalBFINIT,
+		Eval:     evalBFINIT,
+		Arity:    -2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	bfaddCmdMeta = DiceCmdMeta{
 		Name: "BFADD",
 		Info: `BFADD adds an element to
 		a bloom filter. If the filter does not exists, it will create a new one
 		with default parameters.`,
-		Eval: evalBFADD,
+		Eval:     evalBFADD,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	bfexistsCmdMeta = DiceCmdMeta{
-		Name: "BFEXISTS",
-		Info: `BFEXISTS checks existance of an element in a bloom filter.`,
-		Eval: evalBFEXISTS,
+		Name:     "BFEXISTS",
+		Info:     `BFEXISTS checks existance of an element in a bloom filter.`,
+		Eval:     evalBFEXISTS,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	bfinfoCmdMeta = DiceCmdMeta{
-		Name: "BFINFO",
-		Info: `BFINFO returns the parameters and metadata of an existing bloom filter.`,
-		Eval: evalBFINFO,
+		Name:  "BFINFO",
+		Info:  `BFINFO returns the parameters and metadata of an existing bloom filter.`,
+		Eval:  evalBFINFO,
+		Arity: 2,
 	}
 	qrefinsCmdMeta = DiceCmdMeta{
 		Name: "QREFINS",
@@ -190,7 +236,9 @@ var (
 		if the queue does not exist, QREFINS will also create the queueref
 		returns 1 if the key reference was inserted
 		returns 0 otherwise`,
-		Eval: evalQREFINS,
+		Eval:     evalQREFINS,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	qrefremCmdMeta = DiceCmdMeta{
 		Name: "QREFREM",
@@ -199,21 +247,27 @@ var (
 		if the key does not exist, QREFREM returns nil otherwise it
 		returns the RESP encoded value of the key reference from the queue
 		if we remove from the empty queue, nil is returned`,
-		Eval: evalQREFREM,
+		Eval:     evalQREFREM,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	qreflenCmdMeta = DiceCmdMeta{
 		Name: "QREFLEN",
 		Info: `QREFLEN returns the length of the QREF identified by key
 		returns the integer value indicating the length of the queue
 		if the key does not exist, the response is 0`,
-		Eval: evalQREFLEN,
+		Eval:     evalQREFLEN,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	qrefpeekCmdMeta = DiceCmdMeta{
 		Name: "QREFPEEK",
 		Info: `QREFPEEK peeks into the QREF and returns 5 elements without popping them
 		returns the array of resp encoded values as the response.
 		if the key does not exist, then we return an empty array`,
-		Eval: evalQREFPEEK,
+		Eval:     evalQREFPEEK,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	stackintpushCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPUSH",
@@ -221,7 +275,9 @@ var (
 		first argument will be the key, that should be of type "STACKINT"
 		second argument will be the integer value
 		if the key does not exist, STACKINTPUSH will also create the integer stack`,
-		Eval: evalSTACKINTPUSH,
+		Eval:     evalSTACKINTPUSH,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	stackintpopCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPOP",
@@ -230,21 +286,27 @@ var (
 		if the key does not exist, STACKINTPOP returns nil otherwise it
 		returns the integer value popped from the stack
 		if we remove from the empty stack, nil is returned`,
-		Eval: evalSTACKINTPOP,
+		Eval:     evalSTACKINTPOP,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	stackintlenCmdMeta = DiceCmdMeta{
 		Name: "STACKINTLEN",
 		Info: `STACKINTLEN returns the length of the STACKINT identified by key
 		returns the integer value indicating the length of the stack
 		if the key does not exist, the response is 0`,
-		Eval: evalSTACKINTLEN,
+		Eval:     evalSTACKINTLEN,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	stackintpeekCmdMeta = DiceCmdMeta{
 		Name: "STACKINTPEEK",
 		Info: `STACKINTPEEK peeks into the DINT and returns 5 elements without popping them
 		returns the array of integers as the response.
 		if the key does not exist, then we return an empty array`,
-		Eval: evalSTACKINTPEEK,
+		Eval:     evalSTACKINTPEEK,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	stackrefpushCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPUSH",
@@ -254,7 +316,9 @@ var (
 		if the stack does not exist, STACKREFPUSH will also create the stackref
 		returns 1 if the key reference was inserted
 		returns 0 otherwise`,
-		Eval: evalSTACKREFPUSH,
+		Eval:     evalSTACKREFPUSH,
+		Arity:    3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	stackrefpopCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPOP",
@@ -263,21 +327,27 @@ var (
 		if the key does not exist, STACKREFPOP returns nil otherwise it
 		returns the RESP encoded value of the key reference from the stack
 		if we remove from the empty stack, nil is returned`,
-		Eval: evalSTACKREFPOP,
+		Eval:     evalSTACKREFPOP,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	stackreflenCmdMeta = DiceCmdMeta{
 		Name: "STACKREFLEN",
 		Info: `STACKREFLEN returns the length of the STACKREF identified by key
 		returns the integer value indicating the length of the stack
 		if the key does not exist, the response is 0`,
-		Eval: evalSTACKREFLEN,
+		Eval:     evalSTACKREFLEN,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	stackrefpeekCmdMeta = DiceCmdMeta{
 		Name: "STACKREFPEEK",
 		Info: `STACKREFPEEK peeks into the STACKREF and returns 5 elements without popping them
 		returns the array of resp encoded values as the response.
 		if the key does not exist, then we return an empty array`,
-		Eval: evalSTACKREFPEEK,
+		Eval:     evalSTACKREFPEEK,
+		Arity:    2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 	// TODO: Remove this override once we support QWATCH in dice-cli.
 	subscribeCmdMeta = DiceCmdMeta{
@@ -286,7 +356,8 @@ var (
 		Every time a key in the watch list is modified, the client will be sent a response
 		containing the new value of the key along with the operation that was performed on it.
 		Contains only one argument, the key to be watched.`,
-		Eval: nil,
+		Eval:  nil,
+		Arity: 1,
 	}
 	qwatchCmdMeta = DiceCmdMeta{
 		Name: "QWATCH",
@@ -294,7 +365,8 @@ var (
 		Every time a key in the watch list is modified, the client will be sent a response
 		containing the new value of the key along with the operation that was performed on it.
 		Contains only one argument, the key to be watched.`,
-		Eval: nil,
+		Eval:  nil,
+		Arity: 1,
 	}
 	multiCmdMeta = DiceCmdMeta{
 		Name: "MULTI",
@@ -303,27 +375,32 @@ var (
 		The commands will not be executed until EXEC is triggered.
 		Once EXEC is triggered it executes all the commands in queue,
 		and closes the MULTI transaction.`,
-		Eval: evalMULTI,
+		Eval:  evalMULTI,
+		Arity: 1,
 	}
 	execCmdMeta = DiceCmdMeta{
-		Name: "EXEC",
-		Info: `EXEC executes commands in a transaction, which is initiated by MULTI`,
-		Eval: nil,
+		Name:  "EXEC",
+		Info:  `EXEC executes commands in a transaction, which is initiated by MULTI`,
+		Eval:  nil,
+		Arity: 1,
 	}
 	discardCmdMeta = DiceCmdMeta{
-		Name: "DISCARD",
-		Info: `DISCARD discards all the commands in a transaction, which is initiated by MULTI`,
-		Eval: nil,
+		Name:  "DISCARD",
+		Info:  `DISCARD discards all the commands in a transaction, which is initiated by MULTI`,
+		Eval:  nil,
+		Arity: 1,
 	}
 	abortCmdMeta = DiceCmdMeta{
-		Name: "ABORT",
-		Info: "Quit the server",
-		Eval: nil,
+		Name:  "ABORT",
+		Info:  "Quit the server",
+		Eval:  nil,
+		Arity: 1,
 	}
 	commandCmdMeta = DiceCmdMeta{
-		Name: "COMMAND <subcommand>",
-		Info: "Evaluates COMMAND <subcommand> command based on subcommand",
-		Eval: evalCommand,
+		Name:  "COMMAND <subcommand>",
+		Info:  "Evaluates COMMAND <subcommand> command based on subcommand",
+		Eval:  evalCommand,
+		Arity: -1,
 	}
 )
 

--- a/core/eval.go
+++ b/core/eval.go
@@ -949,7 +949,7 @@ func evalCommandGetKeys(args []string) []byte {
 		return Encode(errors.New("ERR invalid number of arguments specified for command"), false)
 	}
 
-	keys := make([]string, 0, len(args))
+	keys := make([]string, 0)
 	step := max(keySpecs.Step, 1)
 	lastIdx := keySpecs.BeginIndex
 	if keySpecs.LastKey != 0 {

--- a/core/eval.go
+++ b/core/eval.go
@@ -920,6 +920,8 @@ func evalCommand(args []string) []byte {
 	switch subcommand {
 	case "COUNT":
 		return evalCommandCount(nil)
+	case "GETKEYS":
+		return evalCommandGetKeys(args[1:])
 	default:
 		return Encode(fmt.Errorf("ERR unknown subcommand '%s'. Try COMMAND HELP", subcommand), false)
 	}
@@ -928,6 +930,36 @@ func evalCommand(args []string) []byte {
 // evalCommandCount returns an number of commands supported by DiceDB
 func evalCommandCount(args []string) []byte {
 	return Encode(diceCommandsCount, false)
+}
+
+func evalCommandGetKeys(args []string) []byte {
+	diceCmd, ok := diceCmds[strings.ToUpper(args[0])]
+	if !ok {
+		return Encode(errors.New("ERR invalid command specified"), false)
+	}
+
+	keySpecs := diceCmd.KeySpecs
+	if keySpecs.BeginIndex == 0 {
+		return Encode(errors.New("ERR the command has no key arguments"), false)
+	}
+
+	arity := diceCmd.Arity
+	if (arity < 0 && len(args) < -arity) ||
+		(arity >= 0 && len(args) != arity) {
+		return Encode(errors.New("ERR invalid number of arguments specified for command"), false)
+	}
+
+	keys := make([]string, 0, len(args))
+	step := max(keySpecs.Step, 1)
+	lastIdx := keySpecs.BeginIndex
+	if keySpecs.LastKey != 0 {
+		lastIdx = len(args) + keySpecs.LastKey
+	}
+	for i := keySpecs.BeginIndex; i <= lastIdx; i += step {
+		keys = append(keys, args[i])
+	}
+
+	return Encode(keys, false)
 }
 
 func executeCommand(cmd *RedisCmd, c *Client) []byte {

--- a/tests/command_getkeys_test.go
+++ b/tests/command_getkeys_test.go
@@ -1,0 +1,37 @@
+package tests
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+type commandGetKeysTestCase struct {
+	inCmd    string
+	expected interface{}
+}
+
+func TestCommandGetKeys(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	for _, tcase := range []commandGetKeysTestCase{
+		{"set 1 2 3 4", []interface{}{"1"}},
+		{"get key", []interface{}{"key"}},
+		{"ttl key", []interface{}{"key"}},
+		{"del 1 2 3 4 5 6", []interface{}{"1", "2", "3", "4", "5", "6"}},
+		{"expire key time extra", []interface{}{"key"}},
+		{"QINTINS k 1", []interface{}{"k"}},
+		{"BFINIT bloom some parameters", []interface{}{"bloom"}},
+
+		{"ping", "ERR the command has no key arguments"},
+		{"get", "ERR invalid number of arguments specified for command"},
+		{"abort", "ERR the command has no key arguments"},
+		{"NotValidCommand", "ERR invalid command specified"},
+	} {
+		cmd := tcase.inCmd
+		out := tcase.expected
+		result := fireCommand(conn, "COMMAND GETKEYS "+cmd)
+		assert.DeepEqual(t, out, result)
+	}
+}

--- a/tests/command_getkeys_test.go
+++ b/tests/command_getkeys_test.go
@@ -2,8 +2,6 @@ package tests
 
 import (
 	"testing"
-
-	"gotest.tools/v3/assert"
 )
 
 type commandGetKeysTestCase struct {
@@ -11,27 +9,37 @@ type commandGetKeysTestCase struct {
 	expected interface{}
 }
 
-func TestCommandGetKeys(t *testing.T) {
+var getKeysTestCases = []commandGetKeysTestCase{
+	{"set 1 2 3 4", []interface{}{"1"}},
+	{"get key", []interface{}{"key"}},
+	{"ttl key", []interface{}{"key"}},
+	{"del 1 2 3 4 5 6", []interface{}{"1", "2", "3", "4", "5", "6"}},
+	{"expire key time extra", []interface{}{"key"}},
+	{"QINTINS k 1", []interface{}{"k"}},
+	{"BFINIT bloom some parameters", []interface{}{"bloom"}},
+
+	{"ping", "ERR the command has no key arguments"},
+	{"get", "ERR invalid number of arguments specified for command"},
+	{"abort", "ERR the command has no key arguments"},
+	{"NotValidCommand", "ERR invalid command specified"},
+}
+
+// func TestCommandGetKeys(t *testing.T) {
+// 	conn := getLocalConnection()
+// 	defer conn.Close()
+
+// 	for _, tcase := range getKeysTestCases {
+// 		fmt.Println("done")
+// 		result := fireCommand(conn, "COMMAND GETKEYS "+tcase.inCmd)
+// 		assert.DeepEqual(t, tcase.expected, result)
+// 	}
+// }
+
+func BenchmarkGetKeysMatch(b *testing.B) {
 	conn := getLocalConnection()
-	defer conn.Close()
-
-	for _, tcase := range []commandGetKeysTestCase{
-		{"set 1 2 3 4", []interface{}{"1"}},
-		{"get key", []interface{}{"key"}},
-		{"ttl key", []interface{}{"key"}},
-		{"del 1 2 3 4 5 6", []interface{}{"1", "2", "3", "4", "5", "6"}},
-		{"expire key time extra", []interface{}{"key"}},
-		{"QINTINS k 1", []interface{}{"k"}},
-		{"BFINIT bloom some parameters", []interface{}{"bloom"}},
-
-		{"ping", "ERR the command has no key arguments"},
-		{"get", "ERR invalid number of arguments specified for command"},
-		{"abort", "ERR the command has no key arguments"},
-		{"NotValidCommand", "ERR invalid command specified"},
-	} {
-		cmd := tcase.inCmd
-		out := tcase.expected
-		result := fireCommand(conn, "COMMAND GETKEYS "+cmd)
-		assert.DeepEqual(t, out, result)
+	for _, tcase := range getKeysTestCases {
+		for i := 0; i < b.N; i++ {
+			fireCommand(conn, "COMMAND GETKEYS "+tcase.inCmd)
+		}
 	}
 }

--- a/tests/command_getkeys_test.go
+++ b/tests/command_getkeys_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 type commandGetKeysTestCase struct {
@@ -24,16 +26,15 @@ var getKeysTestCases = []commandGetKeysTestCase{
 	{"NotValidCommand", "ERR invalid command specified"},
 }
 
-// func TestCommandGetKeys(t *testing.T) {
-// 	conn := getLocalConnection()
-// 	defer conn.Close()
+func TestCommandGetKeys(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
 
-// 	for _, tcase := range getKeysTestCases {
-// 		fmt.Println("done")
-// 		result := fireCommand(conn, "COMMAND GETKEYS "+tcase.inCmd)
-// 		assert.DeepEqual(t, tcase.expected, result)
-// 	}
-// }
+	for _, tcase := range getKeysTestCases {
+		result := fireCommand(conn, "COMMAND GETKEYS "+tcase.inCmd)
+		assert.DeepEqual(t, tcase.expected, result)
+	}
+}
 
 func BenchmarkGetKeysMatch(b *testing.B) {
 	conn := getLocalConnection()


### PR DESCRIPTION
## COMMAND GETKEYS

Returns [Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of keys from a full Redis command.

### Changes
- Added arity to command meta data. This is similar to how redis checks for command length. A positive rarity will give exact argument length and negative rarity mean minimum argument length. E.g. [get](https://github.com/redis/redis/blob/unstable/src/commands/get.json) and [del](https://github.com/redis/redis/blob/unstable/src/commands/del.json)
- Added key specs to identify the keys

### Some considerations
- The metadata required for `COMMAND GETKEYS` should ideally not be coded just in the function so that we will not forget to add them when we add a new command
- Ideally, we can check arity checks before evaluating the command but I think that should be done in another PR. 
- There are some cases where there are additional checks as a negative rarity gives a minimum argument length instead of a range. E.g. [ping](https://github.com/redis/redis/blob/unstable/src/commands/ping.json), [additional checks](https://github.com/redis/redis/blob/unstable/src/server.c#L4598)

### Benchmarks

```
╰─❯ go test -bench=. -run=^BenchmarkGetKeysMatch$                                                                                                                                                                 ─╯
starting the test server on port 8739
2024/08/03 22:29:21 INFO starting an asynchronous TCP server on 0.0.0.0=8739
2024/08/03 22:29:21 INFO ready to accept connections
goos: darwin
goarch: arm64
pkg: github.com/dicedb/dice/tests
BenchmarkCountCommand-8              100         600048604 ns/op
BenchmarkGetKeysMatch-8                1        60002562417 ns/op
PASS
ok      github.com/dicedb/dice/tests    123.273s
```

closes #147 