### PR TITLE
#222: Added Benchmark for negative number and close to MinInt64, MaxInt64

### DIFF
--- a/core/dencoding/dencoding_benchmark_test.go
+++ b/core/dencoding/dencoding_benchmark_test.go
@@ -39,3 +39,26 @@ func BenchmarkDecodeUIntConcurrent(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkMinMaxEncodeDecodeInt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var value int64
+		switch {
+		case i%3 == 0:
+			value = int64(i % math.MaxInt64) // positive numbers
+		case i%3 == 1:
+			value = -int64(i % math.MaxInt64) // negative numbers
+		default:
+			value = math.MaxInt64 - int64(i%1000) // numbers close to MaxInt64
+			if i%2000 > 1000 {
+				value = math.MinInt64 + int64(i%1000) // numbers close to MinInt64
+			}
+		}
+
+		encoded := dencoding.EncodeInt(value)
+		decoded := dencoding.DecodeInt(encoded)
+		if decoded != value {
+			b.Errorf("DecodeInt(%v) = %d; want %d", encoded, decoded, value)
+		}
+	}
+}

--- a/core/dencoding/int_test.go
+++ b/core/dencoding/int_test.go
@@ -135,26 +135,3 @@ func generateIntTestCases() []int64 {
 	}
 	return tests
 }
-
-func BenchmarkMinMaxEncodeDecodeInt(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		var value int64
-		switch {
-		case i%3 == 0:
-			value = int64(i % math.MaxInt64) // positive numbers
-		case i%3 == 1:
-			value = -int64(i % math.MaxInt64) // negative numbers
-		default:
-			value = math.MaxInt64 - int64(i%1000) // numbers close to MaxInt64
-			if i%2000 > 1000 {
-				value = math.MinInt64 + int64(i%1000) // numbers close to MinInt64
-			}
-		}
-
-		encoded := dencoding.EncodeInt(value)
-		decoded := dencoding.DecodeInt(encoded)
-		if decoded != value {
-			b.Errorf("DecodeInt(%v) = %d; want %d", encoded, decoded, value)
-		}
-	}
-}

--- a/core/dencoding/int_test.go
+++ b/core/dencoding/int_test.go
@@ -113,3 +113,26 @@ func BenchmarkEncodeDecodeInt(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkMinMaxEncodeDecodeInt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var value int64
+		switch {
+		case i%3 == 0:
+			value = int64(i % math.MaxInt64) // positive numbers
+		case i%3 == 1:
+			value = -int64(i % math.MaxInt64) // negative numbers
+		default:
+			value = math.MaxInt64 - int64(i%1000) // numbers close to MaxInt64
+			if i%2000 > 1000 {
+				value = math.MinInt64 + int64(i%1000) // numbers close to MinInt64
+			}
+		}
+
+		encoded := dencoding.EncodeInt(value)
+		decoded := dencoding.DecodeInt(encoded)
+		if decoded != value {
+			b.Errorf("DecodeInt(%v) = %d; want %d", encoded, decoded, value)
+		}
+	}
+}


### PR DESCRIPTION
- Added benchmark for negative numbers and number close to MinInt64, MaxInt64
```
=== RUN   BenchmarkMinMaxEncodeDecodeInt
BenchmarkMinMaxEncodeDecodeInt
BenchmarkMinMaxEncodeDecodeInt-12       49743938                23.24 ns/op            7 B/op          1 allocs/op
PASS
ok      github.com/dicedb/dice/core/dencoding   1.396s
```