### PR TITLE
#161: Adds JSONPath Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 require (
 	github.com/charmbracelet/log v0.4.0
 	github.com/dicedb/go-dice v0.0.0-20240717053902-2a3e67c8bda0
+	github.com/ohler55/ojg v1.23.0
 	github.com/twmb/murmur3 v1.1.8
-	github.com/valyala/fastjson v1.6.4
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 )

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
+github.com/ohler55/ojg v1.23.0 h1:xjJasLaKf4dKkyJq0CNXQMRdL7F1172tms885aPKcS0=
+github.com/ohler55/ojg v1.23.0/go.mod h1:gQhDVpQLqrmnd2eqGAvJtn+NfKoYJbe/A4Sj3/Vro4o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -41,8 +43,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
-github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
-github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/dicedb/dice/testutils"

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -1,8 +1,10 @@
 package tests
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/dicedb/dice/testutils"
 	"gotest.tools/v3/assert"
 )
 
@@ -15,6 +17,7 @@ func TestJSONOperations(t *testing.T) {
 	specialCharsJSON := `{"key":"value with spaces","emoji":"😀"}`
 	unicodeJSON := `{"unicode":"こんにちは世界"}`
 	escapedCharsJSON := `{"escaped":"\"quoted\", \\backslash\\ and /forward/slash"}`
+	complexJSON := `{"inventory":{"mountain_bikes":[{"id":"bike:1","model":"Phoebe","price":1920,"specs":{"material":"carbon","weight":13.1},"colors":["black","silver"]},{"id":"bike:2","model":"Quaoar","price":2072,"specs":{"material":"aluminium","weight":7.9},"colors":["black","white"]},{"id":"bike:3","model":"Weywot","price":3264,"specs":{"material":"alloy","weight":13.8}}],"commuter_bikes":[{"id":"bike:4","model":"Salacia","price":1475,"specs":{"material":"aluminium","weight":16.6},"colors":["black","silver"]},{"id":"bike:5","model":"Mimas","price":3941,"specs":{"material":"alloy","weight":11.6}}]}}`
 
 	testCases := []struct {
 		name     string
@@ -68,7 +71,7 @@ func TestJSONOperations(t *testing.T) {
 			name:     "Set Invalid JSON",
 			setCmd:   `JSON.SET invalid $ {invalid:json}`,
 			getCmd:   ``,
-			expected: "ERR invalid JSON",
+			expected: "ERR invalid JSON: invalid character 'i' looking for beginning of object key string",
 		},
 		{
 			name:     "Set JSON with Wrong Number of Arguments",
@@ -112,6 +115,42 @@ func TestJSONOperations(t *testing.T) {
 			getCmd:   `JSON.GET escaped`,
 			expected: escapedCharsJSON,
 		},
+		{
+			name:     "Set and Get Complex JSON",
+			setCmd:   `JSON.SET inventory $ ` + complexJSON,
+			getCmd:   `JSON.GET inventory`,
+			expected: complexJSON,
+		},
+		{
+			name:     "Get Nested Array",
+			setCmd:   `JSON.SET inventory $ ` + complexJSON,
+			getCmd:   `JSON.GET inventory $.inventory.mountain_bikes[*].model`,
+			expected: `["Phoebe","Quaoar","Weywot"]`,
+		},
+		{
+			name:     "Get Nested Object",
+			setCmd:   `JSON.SET inventory $ ` + complexJSON,
+			getCmd:   `JSON.GET inventory $.inventory.mountain_bikes[0].specs`,
+			expected: `{"material":"carbon","weight":13.1}`,
+		},
+		{
+			name:     "Get All Prices",
+			setCmd:   `JSON.SET inventory $ ` + complexJSON,
+			getCmd:   `JSON.GET inventory $..price`,
+			expected: `[1475,3941,1920,2072,3264]`,
+		},
+		{
+			name:     "Set Nested Value",
+			setCmd:   `JSON.SET inventory $.inventory.mountain_bikes[0].price 2000`,
+			getCmd:   `JSON.GET inventory $.inventory.mountain_bikes[0].price`,
+			expected: `2000`,
+		},
+		{
+			name:     "Set Multiple Nested Values",
+			setCmd:   `JSON.SET inventory $.inventory.*[?(@.price<2000)].price 1500`,
+			getCmd:   `JSON.GET inventory $..price`,
+			expected: `[1500,3941,2000,2072,3264]`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -127,8 +166,57 @@ func TestJSONOperations(t *testing.T) {
 
 			if tc.getCmd != "" {
 				result := fireCommand(conn, tc.getCmd)
-				assert.DeepEqual(t, tc.expected, result)
+				if testutils.IsJSONResponse(result.(string)) {
+					testutils.AssertJSONEqual(t, tc.expected, result.(string))
+				} else {
+					assert.Equal(t, tc.expected, result)
+				}
 			}
+		})
+	}
+}
+
+func TestUnsupportedJSONPathPatterns(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+	complexJSON := `{"inventory":{"mountain_bikes":[{"id":"bike:1","model":"Phoebe","price":1920,"specs":{"material":"carbon","weight":13.1},"colors":["black","silver"]},{"id":"bike:2","model":"Quaoar","price":2072,"specs":{"material":"aluminium","weight":7.9},"colors":["black","white"]},{"id":"bike:3","model":"Weywot","price":3264,"specs":{"material":"alloy","weight":13.8}}],"commuter_bikes":[{"id":"bike:4","model":"Salacia","price":1475,"specs":{"material":"aluminium","weight":16.6},"colors":["black","silver"]},{"id":"bike:5","model":"Mimas","price":3941,"specs":{"material":"alloy","weight":11.6}}]}}`
+
+	setupCmd := `JSON.SET bikes:inventory $ ` + complexJSON
+	result := fireCommand(conn, setupCmd)
+	assert.Equal(t, "OK", result)
+
+	testCases := []struct {
+		name     string
+		command  string
+		expected string
+	}{
+		{
+			name:     "Regex in JSONPath",
+			command:  `JSON.GET bikes:inventory '$..[?(@.specs.material =~ "(?i)al")].model'`,
+			expected: "ERR invalid JSONPath",
+		},
+		{
+			name:     "Using @ for referencing other fields",
+			command:  `JSON.GET bikes:inventory '$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model'`,
+			expected: "ERR invalid JSONPath",
+		},
+		{
+			name:     "Complex condition with multiple comparisons",
+			command:  `JSON.GET bikes:inventory '$..mountain_bikes[?(@.price < 3000 && @.specs.weight < 10)]'`,
+			expected: "ERR invalid JSONPath",
+		},
+		{
+			name:     "Get all colors",
+			command:  `JSON.GET bikes:inventory '$..[*].colors'`,
+			expected: "ERR invalid JSONPath",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := fireCommand(conn, tc.command)
+			fmt.Println(result)
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -215,7 +215,6 @@ func TestUnsupportedJSONPathPatterns(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := fireCommand(conn, tc.command)
-			fmt.Println(result)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/testutils/json.go
+++ b/testutils/json.go
@@ -1,0 +1,45 @@
+package testutils
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func IsJSONResponse(s string) bool {
+	return (len(s) > 0 && (s[0] == '{' || s[0] == '['))
+}
+
+func AssertJSONEqual(t *testing.T, expected, actual string) {
+	var expectedJSON, actualJSON interface{}
+
+	err := json.Unmarshal([]byte(expected), &expectedJSON)
+	assert.NilError(t, err, "Failed to unmarshal expected JSON")
+
+	err = json.Unmarshal([]byte(actual), &actualJSON)
+	assert.NilError(t, err, "Failed to unmarshal actual JSON")
+
+	if !reflect.DeepEqual(NormalizeJSON(expectedJSON), NormalizeJSON(actualJSON)) {
+		t.Errorf("JSON not equal.\nExpected: %s\nActual: %s", expected, actual)
+	}
+}
+
+func NormalizeJSON(v interface{}) interface{} {
+	switch v := v.(type) {
+	case map[string]interface{}:
+		nm := make(map[string]interface{})
+		for k, v := range v {
+			nm[k] = NormalizeJSON(v)
+		}
+		return nm
+	case []interface{}:
+		for i, e := range v {
+			v[i] = NormalizeJSON(e)
+		}
+		return v
+	default:
+		return v
+	}
+}


### PR DESCRIPTION
@JyotinderSingh I have used https://github.com/ohler55/ojg for jsonpath support, after having tried multiple different ones.

Support for pretty much all [redis JSONPATH](https://redis.io/docs/latest/develop/data-types/json/path) operations is available, except for the following:
```
> JSON.GET bikes:inventory '$..[?(@.specs.material =~ "(?i)al")].model'
> JSON.SET bikes:inventory $.inventory.mountain_bikes[0].regex_pat '"(?i)al"'
> JSON.SET bikes:inventory $.inventory.mountain_bikes[1].regex_pat '"(?i)al"'
> JSON.SET bikes:inventory $.inventory.mountain_bikes[2].regex_pat '"(?i)al"'
> JSON.GET bikes:inventory '$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model' 
```

You can find a comprehensive testing script [here](https://gist.github.com/Maveric-k07/e59b3d8f8f43e889c9762bcff968ac36)

I have removed fastjson for now, the marshalling wasn't compatible with `ojp` ; working on getting that working. 