### PR TITLE
feat: [GH-203] Add support for PXAT in SET command

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -58,9 +58,11 @@ func evalPING(args []string) []byte {
 // args can also contain multiple options -
 //
 //	EX or ex which will set the expiry time(in secs) for the key
+//	PXAT or PX which will the specified Unix time at which the key will expire, in milliseconds (a positive integer).
+//	XX orr xx which will only set the key if it already exists.
 //
 // Returns encoded error response if at least a <key, value> pair is not part of args
-// Returns encoded error response if expiry tme value in not integer
+// Returns encoded error response if expiry time value in not integer
 // Returns encoded OK RESP once new entry is added
 // If the key already exists then the value will be overwritten and expiry will be discarded
 func evalSET(args []string) []byte {
@@ -87,6 +89,29 @@ func evalSET(args []string) []byte {
 				return Encode(errors.New("ERR value is not an integer or out of range"), false)
 			}
 			exDurationMs = exDurationSec * 1000
+
+		case "PXAT", "pxat":
+			i++
+			if i == len(args) {
+				return Encode(errors.New("ERR syntax error"), false)
+			}
+
+			exDurationUnixMs, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil {
+				return Encode(errors.New("ERR value is not an integer or out of range"), false)
+			}
+
+			if exDurationUnixMs < 0 {
+				return Encode(errors.New("ERR invalid expire time in 'set' command"), false)
+			}
+
+			exDurationMs = exDurationUnixMs - time.Now().UnixMilli()
+			// If the expiry time is in the past, set exDurationMs to 0
+			// This will be used to signal immediate expiration
+			if exDurationMs < 0 {
+				exDurationMs = 0
+			}
+
 		case "XX", "xx":
 			// Get the key from the hash table
 			obj := Get(key)
@@ -95,7 +120,6 @@ func evalSET(args []string) []byte {
 			if obj == nil {
 				return RESP_NIL
 			}
-
 		default:
 			return Encode(errors.New("ERR syntax error"), false)
 		}

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"gotest.tools/v3/assert"
+	"strconv"
+	"testing"
+	"time"
+)
+
+type testCase struct {
+	input  []string
+	output []byte
+}
+
+func TestEval(t *testing.T) {
+	testCases := map[string]func(*testing.T){
+		"SET": testEvalSET,
+	}
+
+	for name, testFunc := range testCases {
+		t.Run(name, testFunc)
+	}
+}
+
+func testEvalSET(t *testing.T) {
+	tests := map[string]testCase{
+		"nil value":                      {input: nil, output: []byte("-ERR wrong number of arguments for 'set' command\r\n")},
+		"empty array":                    {input: []string{}, output: []byte("-ERR wrong number of arguments for 'set' command\r\n")},
+		"one value":                      {input: []string{"KEY"}, output: []byte("-ERR wrong number of arguments for 'set' command\r\n")},
+		"key val pair":                   {input: []string{"KEY", "VAL"}, output: RESP_OK},
+		"key val pair and expiry key":    {input: []string{"KEY", "VAL", "PX"}, output: []byte("-ERR syntax error\r\n")},
+		"key val pair and EX no val":     {input: []string{"KEY", "VAL", "EX"}, output: []byte("-ERR syntax error\r\n")},
+		"key val pair and valid EX":      {input: []string{"KEY", "VAL", "EX", "2"}, output: RESP_OK},
+		"key val pair and invalid EX":    {input: []string{"KEY", "VAL", "EX", "invalid_expiry_val"}, output: []byte("-ERR value is not an integer or out of range\r\n")},
+		"key val pair and PXAT no val":   {input: []string{"KEY", "VAL", "PXAT"}, output: []byte("-ERR syntax error\r\n")},
+		"key val pair and invalid PXAT":  {input: []string{"KEY", "VAL", "PXAT", "invalid_expiry_val"}, output: []byte("-ERR value is not an integer or out of range\r\n")},
+		"key val pair and expired PXAT":  {input: []string{"KEY", "VAL", "PXAT", "2"}, output: RESP_OK},
+		"key val pair and negative PXAT": {input: []string{"KEY", "VAL", "PXAT", "-123456"}, output: []byte("-ERR invalid expire time in 'set' command\r\n")},
+		"key val pair and valid PXAT":    {input: []string{"KEY", "VAL", "PXAT", strconv.FormatInt(time.Now().Add(2*time.Minute).UnixMilli(), 10)}, output: RESP_OK},
+	}
+
+	runTests(t, tests, evalSET)
+}
+
+func runTests(t *testing.T, tests map[string]testCase, evalFunc func([]string) []byte) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			output := evalFunc(tc.input)
+			assert.Equal(t, string(tc.output), string(output))
+		})
+	}
+}

--- a/core/store.go
+++ b/core/store.go
@@ -45,7 +45,7 @@ func NewObj(value interface{}, expDurationMs int64, oType uint8, oEnc uint8) *Ob
 		TypeEncoding:   oType | oEnc,
 		LastAccessedAt: getCurrentClock(),
 	}
-	if expDurationMs > 0 {
+	if expDurationMs >= 0 {
 		setExpiry(obj, expDurationMs)
 	}
 	return obj


### PR DESCRIPTION
### Change Details:
- Added support for `PXAT` in `SET` command similar to the [PXAT option in Redis](https://redis.io/docs/latest/commands/set/).
- Format: ` SET key val PXAT unix-time-milliseconds`
- Added unit and integration test for the same.
- Currently there's no mechanism to handle immediate expiration for past PXAT timestamps. Hence added `setExpiry` to be set to `0 ms` when creating `NewObj`.

### Test scenarios:
- Invalid values for `PXAT` e.g: `str`, `-ve int` etc.
- Expiry of keys associated with valid UNIX ms
- Expiry of keys associated with invalid UNIX ms

<img width="795" alt="image" src="https://github.com/user-attachments/assets/9e32eab9-9d4a-4be0-90d5-1bf465634260">
