### PR TITLE
FIX: Removed old cases -> Added EXAT + new tests

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -187,6 +187,23 @@ func evalSET(args []string) []byte {
 			if obj != nil {
 				return RESP_NIL
 			}
+		case "EXAT", "exat":
+			i++
+			if i == len(args) {
+				return Encode(errors.New("ERR syntax error"), false)
+			}
+
+			exAt, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil {
+				return Encode(errors.New("ERR value is not an integer or out of range"), false)
+			}
+
+			currentTime := time.Now().Unix()
+			if exAt <= currentTime {
+				return Encode(errors.New("ERR invalid EXAT time in the past"), false)
+			}
+
+			exDurationMs = (exAt - currentTime) * 1000
 		default:
 			return Encode(errors.New("ERR syntax error"), false)
 		}

--- a/tests/set_test.go
+++ b/tests/set_test.go
@@ -132,13 +132,33 @@ func TestSetWithExat(t *testing.T) {
 	conn := getLocalConnection()
 	defer conn.Close()
 	Etime := strconv.FormatInt(time.Now().Unix()+10, 10)
+	BadTime := "123123"
 
-	assert.Equal(t, "OK", fireCommand(conn, "SET k v EXAT "+Etime), "Value mismatch for cmd SET k v EXAT "+Etime)
-	assert.Equal(t, "v", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
-	assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 10, "Value mismatch for cmd TTL k")
-	time.Sleep(5 * time.Second)
-	assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 5, "Value mismatch for cmd TTL k")
-	time.Sleep(5 * time.Second)
-	assert.Equal(t, "(nil)", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
-	assert.Equal(t, int64(-2), fireCommand(conn, "TTL k"), "Value mismatch for cmd TTL k")
+	t.Run("SET with EXAT",
+		func(t *testing.T) {
+			deleteTestKeys([]string{"k"})
+			assert.Equal(t, "OK", fireCommand(conn, "SET k v EXAT "+Etime), "Value mismatch for cmd SET k v EXAT "+Etime)
+			assert.Equal(t, "v", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
+			assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 10, "Value mismatch for cmd TTL k")
+			time.Sleep(5 * time.Second)
+			assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 5, "Value mismatch for cmd TTL k")
+			time.Sleep(5 * time.Second)
+			assert.Equal(t, "(nil)", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
+			assert.Equal(t, int64(-2), fireCommand(conn, "TTL k"), "Value mismatch for cmd TTL k")
+		})
+
+	t.Run("SET with invalid EXAT expires key immediately",
+		func(t *testing.T) {
+			deleteTestKeys([]string{"k"})
+			assert.Equal(t, "OK", fireCommand(conn, "SET k v EXAT "+BadTime), "Value mismatch for cmd SET k v EXAT "+BadTime)
+			assert.Equal(t, "(nil)", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
+			assert.Equal(t, int64(-2), fireCommand(conn, "TTL k"), "Value mismatch for cmd TTL k")
+		})
+
+	t.Run("SET with EXAT and PXAT returns syntax error",
+		func(t *testing.T) {
+			deleteTestKeys([]string{"k"})
+			assert.Equal(t, "ERR syntax error", fireCommand(conn, "SET k v PXAT "+Etime+" EXAT "+Etime), "Value mismatch for cmd SET k v PXAT "+Etime+" EXAT "+Etime)
+			assert.Equal(t, "(nil)", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
+		})
 }

--- a/tests/set_test.go
+++ b/tests/set_test.go
@@ -127,3 +127,18 @@ func TestSetWithOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestSetWithExat(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+	Etime := strconv.FormatInt(time.Now().Unix()+10, 10)
+
+	assert.Equal(t, "OK", fireCommand(conn, "SET k v EXAT "+Etime), "Value mismatch for cmd SET k v EXAT "+Etime)
+	assert.Equal(t, "v", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
+	assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 10, "Value mismatch for cmd TTL k")
+	time.Sleep(5 * time.Second)
+	assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 5, "Value mismatch for cmd TTL k")
+	time.Sleep(5 * time.Second)
+	assert.Equal(t, "(nil)", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
+	assert.Equal(t, int64(-2), fireCommand(conn, "TTL k"), "Value mismatch for cmd TTL k")
+}


### PR DESCRIPTION
Hi @JyotinderSingh, I tried fixing the test case by adding type in the file but the test failed due to no support for EXAT option in set. I checked the PR for this addition and found out that subsequent PRs have removed the EXAT option. Hence, the EXAT support must be added again.
For now, I removed the test case testing EXAT functionality. 
Please review.