### PR TITLE
JSON.SET NX|XX invalid options handling

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -307,11 +307,17 @@ func evalJSONSET(args []string) []byte {
 	for i := 3; i < len(args); i++ {
 		switch args[i] {
 		case "NX", "nx":
+			if i != len(args)-1 {
+				return Encode(errors.New("ERR syntax error"), false)
+			}
 			obj := Get(key)
 			if obj != nil {
 				return RESP_NIL
 			}
 		case "XX", "xx":
+			if i != len(args)-1 {
+				return Encode(errors.New("ERR syntax error"), false)
+			}
 			obj := Get(key)
 			if obj == nil {
 				return RESP_NIL

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -265,6 +265,14 @@ func TestJSONSetWithNXAndXX(t *testing.T) {
 			commands: []string{"JSON.SET user $ " + user2 + " NX", "JSON.SET user $ " + user1 + " NX", "JSON.GET user"},
 			expected: []interface{}{"OK", "(nil)", user2},
 		},
+		{
+			commands: []string{"JSON.SET user $ " + user2 + " NX NX", "JSON.SET user $ " + user2 + " NX XX", "JSON.SET user $ " + user2 + " NX Abcd", "JSON.SET user $ " + user2 + " NX "},
+			expected: []interface{}{"ERR syntax error", "ERR syntax error", "ERR syntax error", "(nil)"},
+		},
+		{
+			commands: []string{"JSON.SET user $ " + user2 + " XX XX", "JSON.SET user $ " + user2 + " XX NX", "JSON.SET user $ " + user2 + " XX Abcd", "JSON.SET user $ " + user2 + " XX "},
+			expected: []interface{}{"ERR syntax error", "ERR syntax error", "ERR syntax error", "OK"},
+		},
 	}
 
 	for _, tcase := range testCases {


### PR DESCRIPTION
**Description** : JSON.SET NX|XX invalid options handling added. In the future if we need to add more options after NX|XX then this logic needs to be updated, for now we are assuming that NX|XX is last option in JSON.SET command.

**Reference Pr** : https://github.com/DiceDB/dice/pull/228

**Testing** : Added tests for various invalid combinations of nx and xx json.set commands.