### PR TITLE
Fixes in incr test and set test

### DIFF
--- a/tests/incr_test.go
+++ b/tests/incr_test.go
@@ -39,6 +39,7 @@ func TestINCR(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			deleteTestKeys([]string{"key1", "key2"})
 			for _, cmd := range tc.commands {
 				switch cmd.op {
 				case "s":

--- a/tests/set_test.go
+++ b/tests/set_test.go
@@ -131,7 +131,7 @@ func TestSetWithOptions(t *testing.T) {
 func TestSetWithExat(t *testing.T) {
 	conn := getLocalConnection()
 	defer conn.Close()
-	Etime := strconv.FormatInt(time.Now().Unix()+10, 10)
+	Etime := strconv.FormatInt(time.Now().Unix()+5, 10)
 	BadTime := "123123"
 
 	t.Run("SET with EXAT",
@@ -139,10 +139,10 @@ func TestSetWithExat(t *testing.T) {
 			deleteTestKeys([]string{"k"})
 			assert.Equal(t, "OK", fireCommand(conn, "SET k v EXAT "+Etime), "Value mismatch for cmd SET k v EXAT "+Etime)
 			assert.Equal(t, "v", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
-			assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 10, "Value mismatch for cmd TTL k")
-			time.Sleep(5 * time.Second)
 			assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 5, "Value mismatch for cmd TTL k")
-			time.Sleep(5 * time.Second)
+			time.Sleep(3 * time.Second)
+			assert.Assert(t, fireCommand(conn, "TTL k").(int64) <= 3, "Value mismatch for cmd TTL k")
+			time.Sleep(3 * time.Second)
 			assert.Equal(t, "(nil)", fireCommand(conn, "GET k"), "Value mismatch for cmd GET k")
 			assert.Equal(t, int64(-2), fireCommand(conn, "TTL k"), "Value mismatch for cmd TTL k")
 		})


### PR DESCRIPTION
Hi @JyotinderSingh, this PR fixes the following:

1. incr_test.go:  ran tests without deleting keys leading to failed test cases when all tests are run.

2. set_test.go: Delay is reduced for quicker testing.

No test cases are added. Existing unit tests and integration tests are success.

Please review