### PR TITLE
#267: Emit `WatchEvent` from `DelByPointer` function

### DIFF
--- a/core/store.go
+++ b/core/store.go
@@ -181,6 +181,9 @@ func DelByPtr(ptr unsafe.Pointer) bool {
 		delete(expires, obj)
 		delete(keypool, *((*string)(ptr)))
 		KeyspaceStat[0]["keys"]--
+
+		key := *((*string)(ptr))
+		WatchChannel <- WatchEvent{key, "DEL", obj}
 		return true
 	}
 	return false


### PR DESCRIPTION
PR to address: [issue](https://github.com/DiceDB/dice/issues/267)

Add `WatchEvent` to `DelByPointer` function