### PR TITLE
Reset datastores before every benchmark test

### DIFF
--- a/core/executerbechmark_test.go
+++ b/core/executerbechmark_test.go
@@ -27,6 +27,7 @@ func populateData(count int) {
 
 		// need to init again for each round with the overriden buffer size
 		// otherwise the watchchannel buffer size will stay as it is with the global keylimits size
+		core.ResetStore()
 		core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
 
 		dataset := []keyValue{}

--- a/core/store.go
+++ b/core/store.go
@@ -34,6 +34,10 @@ var (
 var WatchChannel chan WatchEvent
 
 func init() {
+	ResetStore()
+}
+
+func ResetStore() {
 	store = make(map[unsafe.Pointer]*Obj)
 	expires = make(map[*Obj]uint64)
 	keypool = make(map[string]unsafe.Pointer)


### PR DESCRIPTION
This PR solves the issue of constant high memory usage when running `go test -bench=. -test.benchmem executerbechmark_test.go`. 
The memory allocated to a map grows as and when you start storing data in it. When you delete data from a map, Go doesn't automatically free up the memory and keeps it allocated to the map. So when the next set of Benchmarking tests ran, it reused some of the deleted memory and the memory footprint remained the same as the last benchmark test with the high number of keys.
In order to actually free the occupied memory and allocate a new block of memory, this PR initialises the data stores in the store.go before running every benchmark test. Looks like the memory footprint reduces again before every benchmark test.

https://discord.com/channels/1034342738960855120/1264145943884992595/1271153754410061927