### PR TITLE
fixes failing TestJSONSetWithInvalidJSON 

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -360,7 +360,7 @@ func evalJSONSET(args []string) []byte {
 
 	// Parse the JSON string
 	var jsonValue interface{}
-	if err := sonic.Unmarshal([]byte(jsonStr), &jsonValue); err != nil {
+	if err := sonic.UnmarshalString(jsonStr, &jsonValue); err != nil {
 		return Encode(fmt.Errorf("ERR invalid JSON: %v", err.Error()), false)
 	}
 

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -173,7 +173,7 @@ func TestJSONSetWithInvalidJSON(t *testing.T) {
 		{
 			name:     "Set Invalid JSON",
 			command:  `JSON.SET invalid $ {invalid:json}`,
-			expected: "ERR invalid JSON: \"Syntax error at index 1: expect a json key",
+			expected: "ERR invalid JSON",
 		},
 		{
 			name:     "Set JSON with Wrong Number of Arguments",
@@ -185,7 +185,7 @@ func TestJSONSetWithInvalidJSON(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := fireCommand(conn, tc.command)
-			assert.Check(t, strings.Contains(result.(string), tc.expected), fmt.Sprintf("Expected: %s, Got: %s", tc.expected, result))
+			assert.Check(t, strings.HasPrefix(result.(string), tc.expected), fmt.Sprintf("Expected: %s, Got: %s", tc.expected, result))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #272 
- uses strings.HasPrefix to verify invalid json error
- uses sonic.UnmarshalString; giving better performance

Average time test1000 iteration on simple, nested and complex json objects as in [json_test.go](https://github.com/DiceDB/dice/blob/master/tests/json_test.go)

```
1st trial
Simple JSON - Avg Unmarshal: 4.742µs, Avg UnmarshalString: 2.676µs
Nested JSON - Avg Unmarshal: 6.311µs, Avg UnmarshalString: 4.724µs
Complex JSON - Avg Unmarshal: 24.45µs, Avg UnmarshalString: 22.57µs

2nd trial
Simple JSON - Avg Unmarshal: 2.961µs, Avg UnmarshalString: 3.19µs
Nested JSON - Avg Unmarshal: 7.009µs, Avg UnmarshalString: 4.521µs
Complex JSON - Avg Unmarshal: 24.977µs, Avg UnmarshalString: 24.551µs
```
@JyotinderSingh 