### PR TITLE
Feature added: getex command with args support for #275

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -450,8 +450,8 @@ var (
 		For each key, if the key is expired or does not exist, the response will be RESP_NIL; 
 		otherwise, the response will be the RESP value of the key.
 		`,
-		Eval: evalMGET,
-		Arity: -2,
+		Eval:     evalMGET,
+		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1, LastKey: -1},
 	}
 	persistCmdMeta = DiceCmdMeta{
@@ -494,10 +494,17 @@ var (
 		Eval: evalEXISTS,
 	}
 	renameCmdMeta = DiceCmdMeta{
-		Name:     "RENAME",
-		Info:     "Renames a key and overwrites the destination",
-		Eval:     evalRename,
-		Arity:    3,
+		Name:  "RENAME",
+		Info:  "Renames a key and overwrites the destination",
+		Eval:  evalRename,
+		Arity: 3,
+	}
+	getexCmdMeta = DiceCmdMeta{
+		Name: "GETEX",
+		Info: `Get the value of key and optionally set its expiration. 
+		GETEX is similar to GET, but is a write command with additional options.`,
+		Eval:     evalGETEX,
+		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
 )
@@ -559,4 +566,5 @@ func init() {
 	diceCmds["EXISTS"] = existsCmdMeta
 	diceCmds["DECRBY"] = decrByCmdMeta
 	diceCmds["RENAME"] = renameCmdMeta
+	diceCmds["GETEX"] = getexCmdMeta
 }

--- a/core/eval.go
+++ b/core/eval.go
@@ -1796,7 +1796,6 @@ func evalGETEX(args []string) []byte {
 		return RESP_NIL
 	}
 
-	var exDurationMs int64 = -1
 	var state exDurationState = Uninitialized
 
 	for i := 1; i < len(args); i++ {
@@ -1823,7 +1822,7 @@ func evalGETEX(args []string) []byte {
 			if arg == "EX" {
 				exDuration = exDuration * 1000
 			}
-			exDurationMs = exDuration
+			exDurationMs := exDuration
 			state = Initialized
 			setExpiry(obj, exDurationMs)
 
@@ -1847,7 +1846,7 @@ func evalGETEX(args []string) []byte {
 			if arg == "EXAT" {
 				exDuration = exDuration * 1000
 			}
-			exDurationMs = exDuration - time.Now().UnixMilli()
+			exDurationMs := exDuration - time.Now().UnixMilli()
 			// If the expiry time is in the past, set exDurationMs to 0
 			// This will be used to signal immediate expiration
 			if exDurationMs < 0 {

--- a/tests/getex_test.go
+++ b/tests/getex_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGetEx(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+	Etime5 := strconv.FormatInt(time.Now().Unix()+5, 10)
+	Etime10 := strconv.FormatInt(time.Now().Unix()+10, 10)
+
+	testCases := []struct {
+		name        string
+		commands    []string
+		expected    []interface{}
+		assert_type []string
+		delay       []time.Duration
+	}{
+		{
+			name:        "GetEx Simple Value",
+			commands:    []string{"SET foo bar", "GETEX foo", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", "bar", int64(-1)},
+			assert_type: []string{"equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name:        "GetEx Non-Existent Key",
+			commands:    []string{"GETEX foo", "TTL foo"},
+			expected:    []interface{}{"(nil)", int64(-2)},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name:        "GetEx with EX option",
+			commands:    []string{"SET foo bar", "GETEX foo", "TTL foo", "GETEX foo ex 2", "TTL foo", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(-1), "bar", int64(2), "(nil)", int64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 2 * time.Second, 0},
+		},
+		{
+			name:        "GetEx with PX option",
+			commands:    []string{"SET foo bar", "GETEX foo", "TTL foo", "GETEX foo px 2000", "TTL foo", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(-1), "bar", int64(2), "(nil)", int64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 2 * time.Second, 0},
+		},
+		{
+			name:        "GetEx with EX option and invalid value",
+			commands:    []string{"SET foo bar", "GETEX foo", "TTL foo", "GETEX foo ex -1", "TTL foo", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(-1), "ERR invalid expire time in 'getex' command", int64(-1), "bar", int64(-1)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:        "GetEx with PX option and invalid value",
+			commands:    []string{"SET foo bar", "GETEX foo", "TTL foo", "GETEX foo px -1", "TTL foo", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(-1), "ERR invalid expire time in 'getex' command", int64(-1), "bar", int64(-1)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:        "GetEx with EXAT option",
+			commands:    []string{"SET foo bar", "GETEX foo", "TTL foo", "GETEX foo exat " + Etime5, "TTL foo", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(-1), "bar", int64(5), "(nil)", int64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 5 * time.Second, 0},
+		},
+		{
+			name:        "GetEx with PXAT option",
+			commands:    []string{"SET foo bar", "GETEX foo", "TTL foo", "GETEX foo pxat " + Etime10 + "000", "TTL foo", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(-1), "bar", int64(5), "(nil)", int64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 5 * time.Second, 0},
+		},
+		{
+			name:        "GetEx with EXAT option and invalid value",
+			commands:    []string{"SET foo bar", "GETEX foo", "TTL foo", "GETEX foo exat 123123", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(-1), "bar", "(nil)", int64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:        "GetEx with PXAT option and invalid value",
+			commands:    []string{"SET foo bar", "GETEX foo", "TTL foo", "GETEX foo pxat 123123", "GETEX foo", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(-1), "bar", "(nil)", int64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:        "GetEx with Persist option",
+			commands:    []string{"SET foo bar", "GETEX foo ex 2", "TTL foo", "GETEX foo persist", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(2), "bar", int64(-1)},
+			assert_type: []string{"equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			deleteTestKeys([]string{"foo"})
+			for i, cmd := range tc.commands {
+				if tc.delay[i] > 0 {
+					time.Sleep(tc.delay[i])
+				}
+				result := fireCommand(conn, cmd)
+				if tc.assert_type[i] == "equal" {
+					assert.DeepEqual(t, tc.expected[i], result)
+				} else if tc.assert_type[i] == "assert" {
+					assert.Assert(t, result.(int64) <= tc.expected[i].(int64), "Expected %v to be less than or equal to %v", result, tc.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/tests/getex_test.go
+++ b/tests/getex_test.go
@@ -98,6 +98,27 @@ func TestGetEx(t *testing.T) {
 			assert_type: []string{"equal", "equal", "assert", "equal", "equal"},
 			delay:       []time.Duration{0, 0, 0, 0, 0},
 		},
+		{
+			name:        "GetEx with multiple expiry options",
+			commands:    []string{"SET foo bar", "GETEX foo ex 2 px 123123", "TTL foo", "GETEX foo"},
+			expected:    []interface{}{"OK", "ERR syntax error", int64(-1), "bar"},
+			assert_type: []string{"equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name:        "GetEx with persist and ex options",
+			commands:    []string{"SET foo bar", "GETEX foo ex 2", "TTL foo", "GETEX foo persist ex 2", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(2), "ERR syntax error", int64(2)},
+			assert_type: []string{"equal", "equal", "assert", "equal", "assert"},
+			delay:       []time.Duration{0, 0, 0, 0, 0},
+		},
+		{
+			name:        "GetEx with persist and px options",
+			commands:    []string{"SET foo bar", "GETEX foo px 2000", "TTL foo", "GETEX foo px 2000 persist", "TTL foo"},
+			expected:    []interface{}{"OK", "bar", int64(2), "ERR syntax error", int64(2)},
+			assert_type: []string{"equal", "equal", "assert", "equal", "assert"},
+			delay:       []time.Duration{0, 0, 0, 0, 0},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Addresses  #275 
  * The changes that are included in the PR.
- Support for GETEX Key command along with expiry options

  * Design document, if any.

  * Information on any implementation choices that were made.

  * Evidence of sufficient testing. You ``MUST`` indicate the tests done, either manually or automated.
 Added tests in tests/getex_test.go file