### PR TITLE
#298: Acquire write lock for GET call

### DIFF
--- a/core/store.go
+++ b/core/store.go
@@ -97,7 +97,7 @@ func getHelper(k string, touch bool) *Obj {
 				v.LastAccessedAt = getCurrentClock()
 			}
 		}
-	}, WithStoreRLock(), WithKeypoolRLock())
+	}, WithStoreLock(), WithKeypoolLock())
 	return v
 }
 


### PR DESCRIPTION
https://github.com/DiceDB/dice/issues/298 

The GET call may perform deletion or touch, which should be done under write locks.