### PR TITLE
#189: Add JSON Support to where clause

### DIFF
--- a/core/executerbechmark_test.go
+++ b/core/executerbechmark_test.go
@@ -398,7 +398,7 @@ func generateBenchmarkJSONData(b *testing.B, count int, json string) {
 			b.Fatalf("Failed to unmarshal JSON: %v", err)
 		}
 
-		data[key] = core.NewObj(jsonValue, -1, core.OBJ_TYPE_JSON, core.OBJ_ENCODING_JSON)
+		data[key] = core.NewObj(jsonValue, -1, core.ObjTypeJSON, core.ObjEncodingJSON)
 	}
 	core.PutAll(data)
 }

--- a/core/executerbechmark_test.go
+++ b/core/executerbechmark_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/core"
 	"github.com/dicedb/dice/internal/constants"
@@ -11,6 +12,12 @@ import (
 )
 
 var benchmarkDataSizes = []int{100, 1000, 10000, 100000, 1000000}
+var benchmarkDataSizesJSON = []int{100, 1000, 10000, 100000}
+
+var jsonList = map[string]string{
+	"smallJSON": `{"score":10,"id":%d,"field1":{"field2":{"field3":{"score":10.36}}}}`,
+	"largeJSON": `{"score":10,"id":%d,"field1":{"field2":{"field3":{"score":10.36}}},"inventory":{"mountain_bikes":[{"id":"bike:1","model":"Phoebe","price":1920,"specs":{"material":"carbon","weight":13.1},"colors":["black","silver"]},{"id":"bike:2","model":"Quaoar","price":2072,"specs":{"material":"aluminium","weight":7.9},"colors":["black","white"]},{"id":"bike:3","model":"Weywot","price":3264,"specs":{"material":"alloy","weight":13.8}}],"commuter_bikes":[{"id":"bike:4","model":"Salacia","price":1475,"specs":{"material":"aluminium","weight":16.6},"colors":["black","silver"]},{"id":"bike:5","model":"Mimas","price":3941,"specs":{"material":"alloy","weight":11.6}}]}}`,
+}
 
 func generateBenchmarkData(count int) {
 	config.KeysLimit = 2000000 // Set a high limit for benchmarking
@@ -374,5 +381,148 @@ func BenchmarkExecuteQueryWithEmptyKeyRegex(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func generateBenchmarkJSONData(b *testing.B, count int, json string) {
+	config.KeysLimit = 2000000 // Set a high limit for benchmarking
+	core.ResetStore()
+
+	data := make(map[string]*core.Obj, count)
+	for i := 0; i < count; i++ {
+		key := fmt.Sprintf("k%d", i)
+		value := fmt.Sprintf(json, i)
+
+		var jsonValue interface{}
+		if err := sonic.UnmarshalString(value, &jsonValue); err != nil {
+			b.Fatalf("Failed to unmarshal JSON: %v", err)
+		}
+
+		data[key] = core.NewObj(jsonValue, -1, core.OBJ_TYPE_JSON, core.OBJ_ENCODING_JSON)
+	}
+	core.PutAll(data)
+}
+
+func BenchmarkExecuteQueryWithJSON(b *testing.B) {
+	for _, v := range benchmarkDataSizesJSON {
+		for jsonSize, json := range jsonList {
+			generateBenchmarkJSONData(b, v, json)
+			defer core.ResetStore()
+
+			query := core.DSQLQuery{
+				KeyRegex: "k*",
+				Selection: core.QuerySelection{
+					KeySelection:   true,
+					ValueSelection: true,
+				},
+				Where: &sqlparser.ComparisonExpr{
+					Left:     sqlparser.NewStrVal([]byte("_value.id")),
+					Operator: "=",
+					Right:    sqlparser.NewIntVal([]byte("3")),
+				},
+			}
+
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					if _, err := core.ExecuteQuery(query); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkExecuteQueryWithNestedJSON(b *testing.B) {
+	for _, v := range benchmarkDataSizesJSON {
+		for jsonSize, json := range jsonList {
+			generateBenchmarkJSONData(b, v, json)
+			defer core.ResetStore()
+
+			query := core.DSQLQuery{
+				KeyRegex: "k*",
+				Selection: core.QuerySelection{
+					KeySelection:   true,
+					ValueSelection: true,
+				},
+				Where: &sqlparser.ComparisonExpr{
+					Left:     sqlparser.NewStrVal([]byte("_value.field1.field2.field3.score")),
+					Operator: ">",
+					Right:    sqlparser.NewFloatVal([]byte("10.1")),
+				},
+			}
+
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					if _, err := core.ExecuteQuery(query); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkExecuteQueryWithJsonInLeftAndRightExpressions(b *testing.B) {
+	for _, v := range benchmarkDataSizesJSON {
+		for jsonSize, json := range jsonList {
+			generateBenchmarkJSONData(b, v, json)
+			defer core.ResetStore()
+
+			query := core.DSQLQuery{
+				KeyRegex: "k*",
+				Selection: core.QuerySelection{
+					KeySelection:   true,
+					ValueSelection: true,
+				},
+				Where: &sqlparser.ComparisonExpr{
+					Left:     sqlparser.NewStrVal([]byte("_value.id")),
+					Operator: "=",
+					Right:    sqlparser.NewStrVal([]byte("_value.score")),
+				},
+			}
+
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					if _, err := core.ExecuteQuery(query); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkExecuteQueryWithJsonNoMatch(b *testing.B) {
+	for _, v := range benchmarkDataSizesJSON {
+		for jsonSize, json := range jsonList {
+			generateBenchmarkJSONData(b, v, json)
+			defer core.ResetStore()
+
+			query := core.DSQLQuery{
+				KeyRegex: "k*",
+				Selection: core.QuerySelection{
+					KeySelection:   true,
+					ValueSelection: true,
+				},
+				Where: &sqlparser.ComparisonExpr{
+					Left:     sqlparser.NewStrVal([]byte("_value.id")),
+					Operator: "=",
+					Right:    sqlparser.NewIntVal([]byte("-1")),
+				},
+			}
+
+			b.ResetTimer()
+			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					if _, err := core.ExecuteQuery(query); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
 	}
 }

--- a/core/executor.go
+++ b/core/executor.go
@@ -49,7 +49,7 @@ func ExecuteQuery(query DSQLQuery) ([]DSQLQueryResultRow, error) {
 
 				// if the row contains JSON field then convert the json object into string representation so it can be encoded
 				// before being returned to the client
-				if getEncoding(row.Value.TypeEncoding) == OBJ_ENCODING_JSON && getType(row.Value.TypeEncoding) == OBJ_TYPE_JSON {
+				if getEncoding(row.Value.TypeEncoding) == ObjEncodingJSON && getType(row.Value.TypeEncoding) == ObjTypeJSON {
 					marshaledData, err := sonic.Marshal(row.Value.Value)
 					if err != nil {
 						return
@@ -239,7 +239,8 @@ func getExprValueAndType(expr sqlparser.Expr, row DSQLQueryResultRow) (i interfa
 		}
 	case *sqlparser.SQLVal:
 		// we currently treat JSON query expression as a string value so we will need to differentiate between JSON and SQL strings
-		if expr.Type == sqlparser.StrVal && strings.HasPrefix(string(expr.Val), "_") && getEncoding(row.Value.TypeEncoding) == OBJ_ENCODING_JSON && getType(row.Value.TypeEncoding) == OBJ_TYPE_JSON {
+		// We convert the $key and $value fields to _key, _value before querying. hence fields starting with _ are considered to be stored values
+		if expr.Type == sqlparser.StrVal && strings.HasPrefix(string(expr.Val), "_") && getEncoding(row.Value.TypeEncoding) == ObjEncodingJSON && getType(row.Value.TypeEncoding) == ObjTypeJSON {
 			value, valueType, err := retrieveValueFromJSON(string(expr.Val), row.Value)
 			if err != nil {
 				return nil, "", err

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -406,7 +406,7 @@ func setupJSON(t *testing.T) {
 			t.Fatalf("Failed to unmarshal value: %v", err)
 		}
 
-		core.Put(data.key, core.NewObj(jsonValue, -1, core.OBJ_TYPE_JSON, core.OBJ_ENCODING_JSON))
+		core.Put(data.key, core.NewObj(jsonValue, -1, core.ObjTypeJSON, core.ObjEncodingJSON))
 	}
 }
 

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -151,3 +151,93 @@ func runQWatchScenarios(t *testing.T, publisher interface{}, receivers interface
 		}
 	}
 }
+
+var JSONTestCases = []struct {
+	key             string
+	value           string
+	qwatchQuery     string
+	expectedUpdates [][]interface{}
+}{
+	{
+		key:         "match:100:user:0",
+		value:       `{"name":"Tom"}`,
+		qwatchQuery: "SELECT $key, $value FROM `match:100:user:0` WHERE '$value.name' = 'Tom'",
+		expectedUpdates: [][]interface{}{
+			{[]interface{}{"match:100:user:0", `{"name":"Tom"}`}},
+		},
+	},
+	{
+		key:         "match:100:user:1",
+		value:       `{"name":"Tom","age":24}`,
+		qwatchQuery: "SELECT $key, $value FROM `match:100:user:1` WHERE '$value.age' > 20",
+		expectedUpdates: [][]interface{}{
+			{[]interface{}{"match:100:user:1", `{"name":"Tom","age":24}`}},
+		},
+	},
+	{
+		key:         "match:100:user:2",
+		value:       `{"score":10.36}`,
+		qwatchQuery: "SELECT $key, $value FROM `match:100:user:2` WHERE '$value.score' = 10.36",
+		expectedUpdates: [][]interface{}{
+			{[]interface{}{"match:100:user:2", `{"score":10.36}`}},
+		},
+	},
+	{
+		key:         "match:100:user:3",
+		value:       `{"field1":{"field2":{"field3":{"score":10.36}}}}`,
+		qwatchQuery: "SELECT $key, $value FROM `match:100:user:3` WHERE '$value.field1.field2.field3.score' > 10.1",
+		expectedUpdates: [][]interface{}{
+			{[]interface{}{"match:100:user:3", `{"field1":{"field2":{"field3":{"score":10.36}}}}`}},
+		},
+	},
+}
+
+func TestQwatchWithJSON(t *testing.T) {
+	resetJSONTestCases()
+	publisher := getLocalConnection()
+
+	subscribers := make([]net.Conn, 0, len(JSONTestCases))
+
+	for i := 0; i < len(JSONTestCases); i++ {
+		subscribers = append(subscribers, getLocalConnection())
+	}
+
+	defer func() {
+		publisher.Close()
+		for _, sub := range subscribers {
+			sub.Close()
+		}
+	}()
+
+	respParsers := make([]*core.RESPParser, len(subscribers))
+
+	for i, testCase := range JSONTestCases {
+		rp := fireCommandAndGetRESPParser(subscribers[i], fmt.Sprintf("QWATCH \"%s\"", testCase.qwatchQuery))
+		assert.Assert(t, rp != nil)
+		respParsers[i] = rp
+
+		v, err := rp.DecodeOne()
+		assert.NilError(t, err)
+		assert.Equal(t, 0, len(v.([]interface{})))
+	}
+
+	for i, tc := range JSONTestCases {
+		fireCommand(publisher, fmt.Sprintf("JSON.SET %s $ %s", tc.key, tc.value))
+
+		for _, expectedUpdate := range tc.expectedUpdates {
+			rp := respParsers[i]
+
+			v, err := rp.DecodeOne()
+			assert.NilError(t, err)
+			update := v.([]interface{})
+
+			assert.DeepEqual(t, expectedUpdate, update)
+		}
+	}
+}
+
+func resetJSONTestCases() {
+	for _, testCase := range JSONTestCases {
+		core.Del(testCase.key)
+	}
+}


### PR DESCRIPTION
- Added JSON Support to where clause
- We can now query nested JSON fields
- Added unit and integration tests
- Performed Benchmarking, Here are the becnhmark results [JsonQueryBenchmark.txt](https://github.com/user-attachments/files/16645736/JsonQueryBenchmark.txt)
