### PR TITLE
Closes #277 Support for COPY command

### DIFF
--- a/core/bloom.go
+++ b/core/bloom.go
@@ -202,6 +202,38 @@ func (b *Bloom) exists(value string) ([]byte, error) {
 	return RESP_ONE, nil
 }
 
+// function creates a deep copy of the Bloom struct
+func (b *Bloom) DeepCopy() *Bloom {
+	if b == nil {
+		return nil
+	}
+
+	// Copy the BloomOpts
+	copyOpts := &BloomOpts{
+		errorRate: b.opts.errorRate,
+		capacity:  b.opts.capacity,
+		bits:      b.opts.bits,
+		bpe:       b.opts.bpe,
+		hashFns:   make([]hash.Hash64, len(b.opts.hashFns)),
+		indexes:   make([]uint64, len(b.opts.indexes)),
+	}
+
+	// Deep copy the hash functions (assuming they are shallow copyable)
+	copy(copyOpts.hashFns, b.opts.hashFns)
+
+	// Deep copy the indexes slice
+	copy(copyOpts.indexes, b.opts.indexes)
+
+	// Deep copy the bitset
+	copyBitset := make([]byte, len(b.bitset))
+	copy(copyBitset, b.bitset)
+
+	return &Bloom{
+		opts:   copyOpts,
+		bitset: copyBitset,
+	}
+}
+
 // updateIndexes updates the list with indexes where bits are supposed to be
 // set (to 1) or read in/from the underlying array. It uses the set hash function
 // against the given `value` and caps the index with the total number of bits.

--- a/core/bytearray.go
+++ b/core/bytearray.go
@@ -87,6 +87,19 @@ func (b *ByteArray) ResizeIfNecessary() *ByteArray {
 	return b
 }
 
+// creates a deep copy of the ByteArray
+func (b *ByteArray) DeepCopy() *ByteArray {
+	if b == nil {
+		return nil
+	}
+
+    copyArray := NewByteArray(int(b.Length))
+
+	// Copy the data from the original to the new ByteArray
+	copy(copyArray.data, b.data)
+	return copyArray
+}
+
 // population counting, counts the number of set bits in a byte
 // Using: https://en.wikipedia.org/wiki/Hamming_weight
 func popcount(x byte) byte {

--- a/core/bytearray_test.go
+++ b/core/bytearray_test.go
@@ -128,7 +128,7 @@ func TestDeepCopy(t *testing.T) {
 
 	// Verify that the copy is not nil
 	if copy == nil {
-		t.Errorf("DeepCopy() returned nil, expected a valid copy")
+		t.Fatalf("DeepCopy returned nil, expected a valid copy")
 	}
 
 	// Verify that the data slice is correctly copied

--- a/core/bytearray_test.go
+++ b/core/bytearray_test.go
@@ -113,3 +113,42 @@ func TestReverseByte(t *testing.T) {
 
 	assert.Equal(t, reversedByte, byte(0b00010100), "Reversed byte should be 0b00010100")
 }
+
+func TestDeepCopy(t *testing.T) {
+	original := NewByteArray(8)
+
+	// Mixed operations
+	original.SetBit(0, true)
+	original.SetBit(1, false)
+	original.SetBit(2, false)
+	original.SetBit(3, true)
+
+	// Create a deep copy of the ByteArray
+	copy := original.DeepCopy()
+
+	// Verify that the copy is not nil
+	if copy == nil {
+		t.Errorf("DeepCopy() returned nil, expected a valid copy")
+	}
+
+	// Verify that the data slice is correctly copied
+	assert.Equal(t, len(copy.data), len(original.data), "ByteArray DeepCopy data length mismatch")
+
+
+	for i := range original.data {
+		assert.Equal(t, copy.data[i], original.data[i], "ByteArray DeepCopy data element mismatch")
+	}
+
+	// Verify that the Length field is correctly copied
+	assert.Equal(t, copy.Length, original.Length, "ByteArray DeepCopy Length mismatch")
+
+	// Modify the copy's data to ensure it's independent of the original
+	copy.data[0] = 9
+
+    assert.Assert(t, copy.data[0] != original.data[0], "ByteArray DeepCopy did not create an independent copy, original and copy data are linked")
+
+	// Modify the original's data to ensure it doesn't affect the copy
+	original.data[1] = 8
+
+    assert.Assert(t, copy.data[1] != original.data[1], "ByteArray DeepCopy did not create an independent copy, original and copy data are linked")
+}

--- a/core/bytearray_test.go
+++ b/core/bytearray_test.go
@@ -144,11 +144,9 @@ func TestDeepCopy(t *testing.T) {
 
 	// Modify the copy's data to ensure it's independent of the original
 	copy.data[0] = 9
-
     assert.Assert(t, copy.data[0] != original.data[0], "ByteArray DeepCopy did not create an independent copy, original and copy data are linked")
 
 	// Modify the original's data to ensure it doesn't affect the copy
 	original.data[1] = 8
-
     assert.Assert(t, copy.data[1] != original.data[1], "ByteArray DeepCopy did not create an independent copy, original and copy data are linked")
 }

--- a/core/bytelist.go
+++ b/core/bytelist.go
@@ -83,3 +83,49 @@ func (b *byteList) delete(bn *byteListNode) {
 
 	b.size -= byteListNodeSize
 }
+
+// DeepCopy creates a deep copy of the byteList.
+func (b *byteList) DeepCopy() *byteList {
+	if b == nil {
+		return nil
+	}
+
+	// Create a new byteList instance using newByteList
+	copyList := newByteList(b.bufLen)
+	copyList.size = b.size
+
+	// Copy the nodes recursively starting from the head
+	if b.head != nil {
+		copyList.head = b.head.deepCopyNode(nil)
+	}
+
+	// Set the tail to the last node in the copied list
+	currentNode := copyList.head
+	for currentNode != nil {
+		if currentNode.next == nil {
+			copyList.tail = currentNode
+		}
+		currentNode = currentNode.next
+	}
+
+	return copyList
+}
+
+func (node *byteListNode) deepCopyNode(prevCopy *byteListNode) *byteListNode {
+	if node == nil {
+		return nil
+	}
+
+	// Create a copy of the current node
+	copyNode := &byteListNode{
+		buf:  append([]byte(nil), node.buf...),
+		prev: prevCopy,
+	}
+
+	// Recursively copy the next node
+	if node.next != nil {
+		copyNode.next = node.next.deepCopyNode(copyNode)
+	}
+
+	return copyNode
+}

--- a/core/bytelist_test.go
+++ b/core/bytelist_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
     "gotest.tools/v3/assert"
-    "gotest.tools/v3/assert/cmp"
 )
 
 func newNode(bl *byteList, b byte) *byteListNode {
@@ -92,7 +91,7 @@ func TestByteListDeepCopy(t *testing.T) {
 	assert.Equal(t, copy.size, original.size, "size should be the same")
 
 	// Verify that the head node data is correctly copied
-    assert.Assert(t, cmp.DeepEqual(copy.head.buf, original.head.buf), "head node buffer should be the same")
+    assert.Equal(t, copy.head.buf[0], original.head.buf[0], "head node buffer should be the same")
 
     // Verify that changes to the copy do not affect the original
     copy.head.buf[0] = 9

--- a/core/bytelist_test.go
+++ b/core/bytelist_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"bytes"
 	"testing"
+    "gotest.tools/v3/assert"
+    "gotest.tools/v3/assert/cmp"
 )
 
 func newNode(bl *byteList, b byte) *byteListNode {
@@ -65,4 +67,38 @@ func TestByteList(t *testing.T) {
 			t.Errorf("bytelist test failed. should have been %v but found %v", tc.val, r)
 		}
 	}
+}
+
+func TestByteListDeepCopy(t *testing.T) {
+    // Create an original byteList using newByteList
+	original := newByteList(4)
+	original.size = 8
+
+	node1 := original.newNode()
+	node1.buf = append(node1.buf, []byte{1, 2, 3, 4}...)
+
+	node2 := original.newNode()
+	node2.buf = append(node2.buf, []byte{5, 6, 7, 8}...)
+
+	node1.next = node2
+	node2.prev = node1
+	original.head = node1
+	original.tail = node2
+
+	copy := original.DeepCopy()
+
+	// Verify that the copy has the same bufLen and size
+	assert.Equal(t, copy.bufLen, original.bufLen, "bufLen should be the same")
+	assert.Equal(t, copy.size, original.size, "size should be the same")
+
+	// Verify that the head node data is correctly copied
+    assert.Assert(t, cmp.DeepEqual(copy.head.buf, original.head.buf), "head node buffer should be the same")
+
+    // Verify that changes to the copy do not affect the original
+    copy.head.buf[0] = 9
+	assert.Assert(t, original.head.buf[0] != copy.head.buf[0], "Original and copy head buffer should not be linked")
+
+    // Verify that changes to the original do not affect the copy
+	original.head.buf[1] = 8
+	assert.Assert(t, original.head.buf[1] != copy.head.buf[1], "Original and copy head buffer should not be linked")
 }

--- a/core/commands.go
+++ b/core/commands.go
@@ -88,7 +88,7 @@ var (
 		Name: "TTL",
 		Info: `TTL returns Time-to-Live in secs for the queried key in args
 		 The key should be the only param in args else returns with an error
-		 Returns	
+		 Returns
 		 RESP encoded time (in secs) remaining for the key to expire
 		 RESP encoded -2 stating key doesn't exist or key is expired
 		 RESP encoded -1 in case no expiration is set on the key`,
@@ -449,6 +449,12 @@ var (
 		Info: "PERSIST removes the expiration from a key",
 		Eval: evalPersist,
 	}
+	copyCmdMeta = DiceCmdMeta{
+		Name:  "COPY",
+		Info:  `COPY command copies the value stored at the source key to the destination key.`,
+		Eval:  evalCOPY,
+		Arity: -2,
+	}
 )
 
 func init() {
@@ -503,4 +509,5 @@ func init() {
 	diceCmds["BITOP"] = bitOpCmdMeta
 	diceCmds["KEYS"] = keysCmdMeta
 	diceCmds["PERSIST"] = persistCmdMeta
+	diceCmds["COPY"] = copyCmdMeta
 }

--- a/core/deep_copy.go
+++ b/core/deep_copy.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"github.com/bytedance/sonic"
+)
+
+type DeepCopyable interface {
+	DeepCopy() interface{}
+}
+
+func (obj *Obj) DeepCopy() *Obj {
+	newObj := &Obj{
+		TypeEncoding:   obj.TypeEncoding,
+		LastAccessedAt: obj.LastAccessedAt,
+	}
+
+	// Use the DeepCopyable interface to deep copy the value
+	if copier, ok := obj.Value.(DeepCopyable); ok {
+		newObj.Value = copier.DeepCopy()
+	} else {
+		// Handle types that are not DeepCopyable
+		sourceType, _ := ExtractTypeEncoding(obj)
+		switch sourceType {
+		case OBJ_TYPE_STRING:
+			sourceValue := obj.Value.(string)
+			newObj.Value = string([]byte(sourceValue))
+
+		case OBJ_TYPE_JSON:
+			sourceValue := obj.Value
+			jsonStr, err := sonic.MarshalString(sourceValue)
+			if err != nil {
+				return nil
+			}
+			var value interface{}
+			err = sonic.UnmarshalString(jsonStr, &value)
+			if err != nil {
+				return nil
+			}
+			newObj.Value = value
+
+		default:
+			return nil
+		}
+	}
+
+	return newObj
+}

--- a/core/deep_copy.go
+++ b/core/deep_copy.go
@@ -21,11 +21,11 @@ func (obj *Obj) DeepCopy() *Obj {
 		// Handle types that are not DeepCopyable
 		sourceType, _ := ExtractTypeEncoding(obj)
 		switch sourceType {
-		case OBJ_TYPE_STRING:
+		case ObjTypeString:
 			sourceValue := obj.Value.(string)
 			newObj.Value = string([]byte(sourceValue))
 
-		case OBJ_TYPE_JSON:
+		case ObjTypeJSON:
 			sourceValue := obj.Value
 			jsonStr, err := sonic.MarshalString(sourceValue)
 			if err != nil {

--- a/core/eval.go
+++ b/core/eval.go
@@ -1806,8 +1806,7 @@ func evalCOPY(args []string) []byte {
 
 	for i := 2; i < len(args); i++ {
 		arg := strings.ToUpper(args[i])
-		switch arg {
-		case "REPLACE":
+		if arg == "REPLACE" {
 			isReplace = true
 		}
 	}
@@ -1821,10 +1820,10 @@ func evalCOPY(args []string) []byte {
 		return RespZero
 	}
 
-    copyObj := sourceObj.DeepCopy()
-    if copyObj == nil {
-        return RespZero
-    }
+	copyObj := sourceObj.DeepCopy()
+	if copyObj == nil {
+		return RespZero
+	}
 
 	exp, ok := getExpiry(sourceObj)
 	var exDurationMs int64 = -1
@@ -1834,10 +1833,10 @@ func evalCOPY(args []string) []byte {
 
 	Put(destinationKey, copyObj)
 
-    if exDurationMs > 0 {
-        setExpiry(copyObj, exDurationMs)
-    }
-    return RespOne
+	if exDurationMs > 0 {
+		setExpiry(copyObj, exDurationMs)
+	}
+	return RespOne
 }
 
 // GETEX key [EX seconds | PX milliseconds | EXAT unix-time-seconds |

--- a/core/eval.go
+++ b/core/eval.go
@@ -1816,7 +1816,7 @@ func evalCOPY(args []string) []byte {
 		}
 	}
 
-	if isReplace == true {
+	if isReplace {
 		Del(destinationKey)
 	}
 

--- a/core/eval.go
+++ b/core/eval.go
@@ -1835,7 +1835,7 @@ func evalCOPY(args []string) []byte {
 		value = string(byteCopy)
 
 	case OBJ_TYPE_JSON:
-		sourceValue := sourceObj.Value.(map[string]interface{})
+		sourceValue := sourceObj.Value
 		jsonStr, err := sonic.MarshalString(sourceValue)
 		if err != nil {
 			return RESP_ZERO

--- a/core/eval.go
+++ b/core/eval.go
@@ -1833,7 +1833,7 @@ func evalCOPY(args []string) []byte {
 	exp, ok := getExpiry(sourceObj)
 	var exDurationMs int64 = -1
 	if ok {
-		exDurationMs = int64(exp)
+		exDurationMs = int64(exp - uint64(time.Now().UnixMilli()))
 	}
 
 	Put(destinationKey, copyObj)

--- a/core/eval.go
+++ b/core/eval.go
@@ -1801,7 +1801,7 @@ func evalCOPY(args []string) []byte {
 
 	sourceObj := Get(sourceKey)
 	if sourceObj == nil {
-		return RESP_ZERO
+		return RespZero
 	}
 
 	for i := 2; i < len(args); i++ {
@@ -1818,12 +1818,12 @@ func evalCOPY(args []string) []byte {
 
 	destinationObj := Get(destinationKey)
 	if destinationObj != nil {
-		return RESP_ZERO
+		return RespZero
 	}
 
     copyObj := sourceObj.DeepCopy()
     if copyObj == nil {
-        return RESP_ZERO
+        return RespZero
     }
 
 	exp, ok := getExpiry(sourceObj)
@@ -1837,7 +1837,7 @@ func evalCOPY(args []string) []byte {
     if exDurationMs > 0 {
         setExpiry(copyObj, exDurationMs)
     }
-    return RESP_ONE
+    return RespOne
 }
 
 // GETEX key [EX seconds | PX milliseconds | EXAT unix-time-seconds |
@@ -1964,13 +1964,13 @@ func evalPTTL(args []string) []byte {
 	obj := Get(key)
 
 	if obj == nil {
-		return RESP_MINUS_2
+		return RespMinusTwo
 	}
 
 	exp, isExpirySet := getExpiry(obj)
 
 	if !isExpirySet {
-		return RESP_MINUS_1
+		return RespMinusOne
 	}
 
 	// compute the time remaining for the key to expire and

--- a/core/eval.go
+++ b/core/eval.go
@@ -1666,3 +1666,41 @@ func evalPersist(args []string) []byte {
 
 	return RESP_ONE
 }
+
+func evalCOPY(args []string) []byte {
+    if len(args) < 2 {
+        return Encode(errors.New("ERR wrong number of arguments for 'copy' command"), false)
+    }
+
+    isReplace := false
+
+    sourceKey := args[0]
+    destinationKey := args[1]
+
+    sourceObj := Get(sourceKey)
+    if sourceObj == nil {
+        return RESP_ZERO
+    }
+
+	for i := 2; i < len(args); i++ {
+        arg := strings.ToUpper(args[i])
+        switch arg {
+            case "REPLACE":
+                isReplace = true
+        }
+    }
+
+    if isReplace == true {
+        Del(destinationKey)
+    }
+
+    destinationObj := Get(destinationKey)
+    if destinationObj != nil {
+        return RESP_ZERO
+    }
+
+    // TODO: replace sourceObj with deep copy opbject
+    Put(destinationKey, sourceObj)
+
+    return RESP_ONE
+}

--- a/core/queueint.go
+++ b/core/queueint.go
@@ -133,6 +133,13 @@ func (q *QueueInt) Iterate(n int) []int64 {
 	return vals
 }
 
+func (q *QueueInt) DeepCopy() *QueueInt {
+    return &QueueInt{
+		Length: q.Length,
+		list:   q.list.DeepCopy(),
+    }
+}
+
 type QueueIntLL struct {
 	list *list.List
 }

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -70,3 +70,9 @@ func (q *QueueRef) Iterate(n int) []*QueueElement {
 	}
 	return elements
 }
+
+func (q* QueueRef) DeepCopy() *QueueRef{
+    return &QueueRef{
+        qi: q.qi.DeepCopy(),
+    }
+}

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -83,5 +83,4 @@ func (q* QueueRef) DeepCopy() *QueueRef{
 // Returns the length of the queue
 func (q *QueueRef) Length() int64 {
 	return q.qi.Length
-
 }

--- a/core/stackint.go
+++ b/core/stackint.go
@@ -147,8 +147,8 @@ func (s *StackInt) Iterate(n int) []int64 {
 }
 
 func (s *StackInt) DeepCopy() *StackInt {
-    return &StackInt{
+	return &StackInt{
 		Length: s.Length,
 		list:   s.list.DeepCopy(),
-    }
+	}
 }

--- a/core/stackint.go
+++ b/core/stackint.go
@@ -145,3 +145,10 @@ func (s *StackInt) Iterate(n int) []int64 {
 
 	return vals
 }
+
+func (s *StackInt) DeepCopy() *StackInt {
+    return &StackInt{
+		Length: s.Length,
+		list:   s.list.DeepCopy(),
+    }
+}

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -72,3 +72,9 @@ func (s *StackRef) Iterate(n int) []*StackElement {
 	}
 	return elements
 }
+
+func (s *StackRef) DeepCopy() *StackRef {
+    return &StackRef{
+        si: s.si.DeepCopy(),
+    }
+}

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -48,10 +48,20 @@ func TestCopy(t *testing.T) {
 			expected: []interface{}{"OK", int64(1), `[1,2,3]`},
 		},
 		{
-			name:     "COPY with JSON simple JSON with REPLACE",
-			commands: []string{`JSON.SET k1 $ ` + simpleJSON, "COPY k1 k2 REPLACE", "JSON.GET k2"},
+			name:     "COPY with JSON simple JSON",
+			commands: []string{`JSON.SET k1 $ ` + simpleJSON, "COPY k1 k2", "JSON.GET k2"},
 			expected: []interface{}{"OK", int64(1), simpleJSON},
 		},
+        {
+            name: "COPY with no expiry",
+            commands: []string{"SET k1 v1", "COPY k1 k2", "TTL k1", "TTL k2"},
+            expected: []interface{}{"OK", int64(1), int64(-1), int64(-1)},
+        },
+        {
+            name: "COPY with expiry making sure copy expires",
+            commands: []string{"SET k1 v1 EX 5", "COPY k1 k2", "GET k1", "GET k2", "SLEEP 7", "GET k1", "GET k2"},
+            expected: []interface{}{"OK", int64(1), "v1", "v1", "OK", "(nil)", "(nil)"},
+        },
 	}
 
 	for _, tc := range testCases {

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -1,0 +1,44 @@
+package tests
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCopy(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []struct {
+		name     string
+		commands []string
+		expected []interface{}
+	}{
+		{
+			name:     "COPY when source key doesn't exist",
+			commands: []string{"COPY k3 k2"},
+			expected: []interface{}{int64(0)},
+		},
+		{
+			name:     "COPY with no REPLACE",
+			commands: []string{"SET k1 v1", "COPY k1 k2", "GET k1", "GET k2"},
+			expected: []interface{}{"OK", int64(1), "v1", "v1"},
+		},
+		{
+			name:     "COPY with REPLACE",
+			commands: []string{"SET k4 v1", "COPY k4 k5 REPLACE", "GET k4", "GET k5"},
+			expected: []interface{}{"OK", int64(1), "(nil)", "v1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			deleteTestKeys([]string{"k1", "k2", "k3", "k4", "k5"})
+			for i, cmd := range tc.commands {
+				result := fireCommand(conn, cmd)
+				assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -27,8 +27,8 @@ func TestCopy(t *testing.T) {
 		},
 		{
 			name:     "COPY with REPLACE",
-			commands: []string{"SET k4 v1", "COPY k4 k5 REPLACE", "GET k4", "GET k5"},
-			expected: []interface{}{"OK", int64(1), "(nil)", "v1"},
+            commands: []string{"SET k4 v1", "SET k5 v2", "GET k5", "COPY k4 k5 REPLACE", "GET k5"},
+			expected: []interface{}{"OK", "OK", "v2", int64(1), "v1"},
 		},
 	}
 

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -10,6 +10,8 @@ func TestCopy(t *testing.T) {
 	conn := getLocalConnection()
 	defer conn.Close()
 
+	simpleJSON := `{"name":"John","age":30}`
+
 	testCases := []struct {
 		name     string
 		commands []string
@@ -30,11 +32,31 @@ func TestCopy(t *testing.T) {
             commands: []string{"SET k4 v1", "SET k5 v2", "GET k5", "COPY k4 k5 REPLACE", "GET k5"},
 			expected: []interface{}{"OK", "OK", "v2", int64(1), "v1"},
 		},
+        {
+            name: "COPY with JSON integer",
+            commands: []string{"JSON.SET k6 $ 2", "COPY k6 k7", "JSON.GET k7"},
+            expected: []interface{}{"OK", int64(1), "2"},
+        },
+        {
+            name: "COPY with JSON boolean",
+            commands: []string{"JSON.SET k8 $ true", "COPY k8 k9", "JSON.GET k8"},
+            expected: []interface{}{"OK", int64(1), "true"},
+        },
+        {
+            name: "COPY with JSON array",
+            commands: []string{`JSON.SET k10 $ [1,2,3]`, "COPY k10 k11", "JSON.GET k11"},
+            expected: []interface{}{"OK", int64(1), `[1,2,3]`},
+        },
+        {
+            name: "COPY with JSON simple JSON with REPLACE",
+            commands: []string{`JSON.SET k12 $ ` + simpleJSON, "COPY k12 k11 REPLACE", "JSON.GET k11"},
+            expected: []interface{}{"OK", int64(1), simpleJSON},
+        },
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			deleteTestKeys([]string{"k1", "k2", "k3", "k4", "k5"})
+			deleteTestKeys([]string{"k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8", "k9", "k10", "k11"})
 			for i, cmd := range tc.commands {
 				result := fireCommand(conn, cmd)
 				assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s", cmd)

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -19,7 +19,7 @@ func TestCopy(t *testing.T) {
 	}{
 		{
 			name:     "COPY when source key doesn't exist",
-			commands: []string{"COPY k3 k2"},
+			commands: []string{"COPY k1 k2"},
 			expected: []interface{}{int64(0)},
 		},
 		{
@@ -29,34 +29,34 @@ func TestCopy(t *testing.T) {
 		},
 		{
 			name:     "COPY with REPLACE",
-            commands: []string{"SET k4 v1", "SET k5 v2", "GET k5", "COPY k4 k5 REPLACE", "GET k5"},
+			commands: []string{"SET k1 v1", "SET k2 v2", "GET k2", "COPY k1 k2 REPLACE", "GET k2"},
 			expected: []interface{}{"OK", "OK", "v2", int64(1), "v1"},
 		},
-        {
-            name: "COPY with JSON integer",
-            commands: []string{"JSON.SET k6 $ 2", "COPY k6 k7", "JSON.GET k7"},
-            expected: []interface{}{"OK", int64(1), "2"},
-        },
-        {
-            name: "COPY with JSON boolean",
-            commands: []string{"JSON.SET k8 $ true", "COPY k8 k9", "JSON.GET k8"},
-            expected: []interface{}{"OK", int64(1), "true"},
-        },
-        {
-            name: "COPY with JSON array",
-            commands: []string{`JSON.SET k10 $ [1,2,3]`, "COPY k10 k11", "JSON.GET k11"},
-            expected: []interface{}{"OK", int64(1), `[1,2,3]`},
-        },
-        {
-            name: "COPY with JSON simple JSON with REPLACE",
-            commands: []string{`JSON.SET k12 $ ` + simpleJSON, "COPY k12 k11 REPLACE", "JSON.GET k11"},
-            expected: []interface{}{"OK", int64(1), simpleJSON},
-        },
+		{
+			name:     "COPY with JSON integer",
+			commands: []string{"JSON.SET k1 $ 2", "COPY k1 k2", "JSON.GET k2"},
+			expected: []interface{}{"OK", int64(1), "2"},
+		},
+		{
+			name:     "COPY with JSON boolean",
+			commands: []string{"JSON.SET k1 $ true", "COPY k1 k2", "JSON.GET k2"},
+			expected: []interface{}{"OK", int64(1), "true"},
+		},
+		{
+			name:     "COPY with JSON array",
+			commands: []string{`JSON.SET k1 $ [1,2,3]`, "COPY k1 k2", "JSON.GET k2"},
+			expected: []interface{}{"OK", int64(1), `[1,2,3]`},
+		},
+		{
+			name:     "COPY with JSON simple JSON with REPLACE",
+			commands: []string{`JSON.SET k1 $ ` + simpleJSON, "COPY k1 k2 REPLACE", "JSON.GET k2"},
+			expected: []interface{}{"OK", int64(1), simpleJSON},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			deleteTestKeys([]string{"k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8", "k9", "k10", "k11"})
+			deleteTestKeys([]string{"k1", "k2"})
 			for i, cmd := range tc.commands {
 				result := fireCommand(conn, cmd)
 				assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s", cmd)


### PR DESCRIPTION
This PR adds support for COPY command. Redis creates a deep copy of objects before adding it to the db. I have done the same thing and have added DeepCopy functions to the different data structures in the codebase. I have also added tests for the deep copy functions.