### PR TITLE
#244 feat: deque for [l/r][push/pop]

### DIFF
--- a/core/bytelist.go
+++ b/core/bytelist.go
@@ -42,7 +42,7 @@ func (b *byteList) newNode() *byteListNode {
 	return bn
 }
 
-func (b *byteList) newNodeWithCap(cap int) *byteListNode {
+func (b *byteList) newNodeWithCapacity(cap int) *byteListNode {
 	bn := &byteListNode{
 		buf: make([]byte, 0, cap),
 	}

--- a/core/bytelist.go
+++ b/core/bytelist.go
@@ -42,9 +42,9 @@ func (b *byteList) newNode() *byteListNode {
 	return bn
 }
 
-func (b *byteList) newNodeWithCapacity(cap int) *byteListNode {
+func (b *byteList) newNodeWithCapacity(capacity int) *byteListNode {
 	bn := &byteListNode{
-		buf: make([]byte, 0, cap),
+		buf: make([]byte, 0, capacity),
 	}
 	b.size += byteListNodeSize
 	return bn

--- a/core/bytelist.go
+++ b/core/bytelist.go
@@ -42,6 +42,14 @@ func (b *byteList) newNode() *byteListNode {
 	return bn
 }
 
+func (b *byteList) newNodeWithCap(cap int) *byteListNode {
+	bn := &byteListNode{
+		buf: make([]byte, 0, cap),
+	}
+	b.size += byteListNodeSize
+	return bn
+}
+
 func (b *byteList) append(bn *byteListNode) {
 	bn.prev = b.tail
 	if b.tail != nil {

--- a/core/commands.go
+++ b/core/commands.go
@@ -560,6 +560,30 @@ var (
 		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
+	lpushCmdMeta = DiceCmdMeta{
+		Name:  "LPUSH",
+		Info:  "LPUSH pushes values into the left side of the deque",
+		Eval:  evalLPUSH,
+		Arity: -3,
+	}
+	rpushCmdMeta = DiceCmdMeta{
+		Name:  "RPUSH",
+		Info:  "RPUSH pushes values into the right side of the deque",
+		Eval:  evalRPUSH,
+		Arity: -3,
+	}
+	lpopCmdMeta = DiceCmdMeta{
+		Name:  "LPOP",
+		Info:  "LPOP pops a value from the left side of the deque",
+		Eval:  evalLPOP,
+		Arity: 2,
+	}
+	rpopCmdMeta = DiceCmdMeta{
+		Name:  "RPOP",
+		Info:  "RPOP pops a value from the right side of the deque",
+		Eval:  evalRPOP,
+		Arity: 2,
+	}
 )
 
 func init() {
@@ -626,4 +650,8 @@ func init() {
 	diceCmds["PTTL"] = pttlCmdMeta
 	diceCmds["OBJECT"] = objectCmdMeta
 	diceCmds["TOUCH"] = touchCmdMeta
+	diceCmds["LPUSH"] = lpushCmdMeta
+	diceCmds["RPOP"] = rpopCmdMeta
+	diceCmds["RPUSH"] = rpushCmdMeta
+	diceCmds["LPOP"] = lpopCmdMeta
 }

--- a/core/dencoding/int.go
+++ b/core/dencoding/int.go
@@ -77,12 +77,12 @@ func EncodeUIntRevInPlace(x uint64, buf []byte) {
 	var i int
 	for i = 0; i < len(bitShifts); i++ {
 		buf[len(buf)-i-1] = getLSB(byte(x), bitShifts[i]) | 0b10000000 // marking the continuation bit
-		x = x >> bitShifts[i]
+		x >>= bitShifts[i]
 		if x == 0 {
 			break
 		}
 	}
-	buf[0] = buf[0] & 0b01111111 // marking the termination bit
+	buf[0] &= 0b01111111 // marking the termination bit
 }
 
 // GetEncodeUIntSize returns the size in byte the encoded varint will take
@@ -95,9 +95,8 @@ func GetEncodeUIntSize(x uint64) uint64 {
 		return 3
 	} else if x < 268435455 {
 		return 4
-	} else {
-		return 5
 	}
+	return 5
 }
 
 // DecodeUIntRev decodes the varint encoded by EncodeUIntRev[InPlace]
@@ -106,7 +105,7 @@ func DecodeUIntRev(vint []byte) uint64 {
 	var v uint64 = 0
 	for i = 0; i < len(vint); i++ {
 		b := getLSB(vint[len(vint)-i-1], 7)
-		v = v | uint64(b)<<(7*i)
+		v |= uint64(b) << (7 * i)
 	}
 	return v
 }

--- a/core/dencoding/int.go
+++ b/core/dencoding/int.go
@@ -100,7 +100,7 @@ func GetEncodeUIntSize(x uint64) uint64 {
 	}
 }
 
-// DecodeInt decodes the varint encoded by EncodeUIntRev[InPlace]
+// DecodeUIntRev decodes the varint encoded by EncodeUIntRev[InPlace]
 func DecodeUIntRev(vint []byte) uint64 {
 	var i int
 	var v uint64 = 0

--- a/core/deque.go
+++ b/core/deque.go
@@ -1,0 +1,457 @@
+package core
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/dicedb/dice/core/dencoding"
+)
+
+var ErrDequeEmpty = errors.New("deque is empty")
+
+type DequeI interface {
+	LPush(string)
+	RPush(string)
+	LPop() (string, error)
+	RPop() (string, error)
+	LPushInt(int64)
+}
+
+type DequeBasic struct {
+	Length int64
+	buf    []byte
+}
+
+func NewBasicDeque() *DequeBasic {
+	l := &DequeBasic{
+		Length: 0,
+	}
+	return l
+}
+
+// LPush pushes `x` into the the left side of the Deque.
+func (q *DequeBasic) LPush(x string) {
+	// enc + data + backlen
+	xb := EncodeDeqEntry(x)
+
+	if cap(q.buf)-len(q.buf) < len(xb) {
+		newArr := make([]byte, len(q.buf)+len(xb), (len(q.buf)+len(xb))*2)
+		copy(newArr[len(xb):], q.buf)
+		copy(newArr, xb)
+		q.buf = newArr
+	} else {
+		q.buf = q.buf[:len(xb)+len(q.buf)]
+		copy(q.buf[len(xb):], q.buf)
+		copy(q.buf, xb)
+	}
+
+	q.Length++
+}
+
+// RPush pushes `x` into the right side of the Deque
+func (q *DequeBasic) RPush(x string) {
+	// enc + data + backlen
+	xb := EncodeDeqEntry(x)
+	q.buf = append(q.buf, xb...)
+	q.Length++
+}
+
+// RPop pops an element from the right side of the Deque.
+func (q *DequeBasic) RPop() (string, error) {
+	if q.Length == 0 {
+		return "", ErrDequeEmpty
+	}
+
+	backlenStartIdx := len(q.buf) - 1
+	for q.buf[backlenStartIdx]&0x80 != 0 {
+		backlenStartIdx--
+	}
+	backlen := dencoding.DecodeUIntRev(q.buf[backlenStartIdx:])
+
+	entryStartIdx := backlenStartIdx - int(backlen)
+	x, _ := DecodeDeqEntry(q.buf[entryStartIdx:backlenStartIdx])
+
+	q.buf = q.buf[:entryStartIdx]
+	q.Length--
+
+	return x, nil
+}
+
+// RPop pops an element from the left side of the Deque.
+func (q *DequeBasic) LPop() (string, error) {
+	if q.Length == 0 {
+		return "", ErrDequeEmpty
+	}
+
+	x, entryLen := DecodeDeqEntry(q.buf)
+
+	copy(q.buf, q.buf[entryLen:])
+	q.buf = q.buf[:len(q.buf)-entryLen]
+	q.Length--
+
+	return x, nil
+}
+
+func (q *DequeBasic) LPushInt(x int64) {
+	// enc + data + backlen
+	xb := EncodeDeqInt(x)
+
+	if cap(q.buf)-len(q.buf) < len(xb) {
+		newArr := make([]byte, len(q.buf)+len(xb), (len(q.buf)+len(xb))*2)
+		copy(newArr[len(xb):], q.buf)
+		copy(newArr, xb)
+		q.buf = newArr
+	} else {
+		q.buf = q.buf[:len(xb)+len(q.buf)]
+		copy(q.buf[len(xb):], q.buf)
+		copy(q.buf, xb)
+	}
+
+	q.Length++
+}
+
+const (
+	minDequeNodeSize = 256
+)
+
+type Deque struct {
+	Length  int64
+	list    *byteList
+	leftIdx int
+}
+
+func NewDeque() *Deque {
+	return &Deque{
+		Length:  0,
+		list:    newByteList(minDequeNodeSize),
+		leftIdx: 0,
+	}
+}
+
+func (q *Deque) LPush(x string) {
+	// enc + data + backlen
+	entrySize := int(GetEncodeDeqEntrySize(x))
+	head := q.list.head
+
+	if q.leftIdx >= entrySize {
+		q.leftIdx -= entrySize
+		EncodeDeqEntryInPlace(x, head.buf[q.leftIdx:q.leftIdx+entrySize])
+	} else if q.leftIdx > 0 {
+		newBuf := make([]byte, entrySize, entrySize+minDequeNodeSize-q.leftIdx)
+		EncodeDeqEntryInPlace(x, newBuf[0:entrySize])
+		newBuf = append(newBuf, head.buf[q.leftIdx:]...)
+		head.buf = newBuf
+		q.leftIdx = 0
+	} else {
+		if entrySize > minDequeNodeSize {
+			head = q.list.newNodeWithCap(entrySize)
+		} else {
+			head = q.list.newNode()
+		}
+		q.list.prepend(head)
+		head.buf = head.buf[:cap(head.buf)]
+		q.leftIdx = len(head.buf) - entrySize
+		EncodeDeqEntryInPlace(x, head.buf[q.leftIdx:])
+	}
+
+	q.Length++
+}
+
+func (q *Deque) RPush(x string) {}
+
+func (q *Deque) LPop() (string, error) {
+	return "", ErrDequeEmpty
+}
+
+func (q *Deque) RPop() (string, error) {
+	if q.Length == 0 {
+		return "", ErrDequeEmpty
+	}
+
+	tail := q.list.tail
+	backlenStartIdx := len(tail.buf) - 1
+	for tail.buf[backlenStartIdx]&0x80 != 0 {
+		backlenStartIdx--
+	}
+	backlen := dencoding.DecodeUIntRev(tail.buf[backlenStartIdx:])
+
+	entryStartIdx := backlenStartIdx - int(backlen)
+	x, _ := DecodeDeqEntry(tail.buf[entryStartIdx:backlenStartIdx])
+
+	tail.buf = tail.buf[:entryStartIdx]
+	if entryStartIdx == q.leftIdx {
+		q.list.delete(tail)
+		q.leftIdx = 0
+	}
+	q.Length--
+
+	return x, nil
+}
+
+func (q *Deque) LPushInt(x int64) {
+	// enc + data + backlen
+	entrySize := int(GetEncodeDeqIntSize(x))
+	// entrySize := len(x)
+	head := q.list.head
+
+	if q.leftIdx >= entrySize {
+		q.leftIdx -= entrySize
+		EncodeDeqIntInPlace(x, head.buf[q.leftIdx:])
+		// copy(head.buf[q.leftIdx:], x)
+	} else if q.leftIdx > 0 {
+		newBuf := make([]byte, entrySize, entrySize+minDequeNodeSize-q.leftIdx)
+		EncodeDeqIntInPlace(x, newBuf)
+		// copy(newBuf, x)
+		newBuf = append(newBuf, head.buf[q.leftIdx:]...)
+		head.buf = newBuf
+		q.leftIdx = 0
+	} else {
+		if entrySize > minDequeNodeSize {
+			head = q.list.newNodeWithCap(entrySize)
+		} else {
+			head = q.list.newNode()
+		}
+		q.list.prepend(head)
+		head.buf = head.buf[:cap(head.buf)]
+		q.leftIdx = len(head.buf) - entrySize
+		EncodeDeqIntInPlace(x, head.buf[q.leftIdx:])
+		// copy(head.buf[q.leftIdx:], x)
+	}
+
+	q.Length++
+}
+
+// EncodeDeqEntry encode `x` as an entry of Deque. An entry represents as enc + data + backlen
+// References: redis lpEncodeString, lpEncodeIntegerGetType.
+func EncodeDeqEntry(x string) []byte {
+	v, err := strconv.ParseInt(x, 10, 64)
+	if err != nil {
+		return EncodeDeqStr(x)
+	} else {
+		return EncodeDeqInt(v)
+	}
+}
+
+func EncodeDeqStr(x string) []byte {
+	var buf []byte
+	var backlen uint64
+	strLen := uint64(len(x))
+	if strLen <= 63 {
+		// 6 bit string
+		backlen = 1 + strLen
+		backlenSize := dencoding.GetEncodeUIntSize(backlen)
+		buf = make([]byte, 1, backlen+backlenSize)
+		buf[0] = 0x80 | byte(strLen)
+	} else if strLen <= 4095 {
+		// 12 bit string
+		backlen = 2 + strLen
+		backlenSize := dencoding.GetEncodeUIntSize(backlen)
+		buf = make([]byte, 2, backlen+backlenSize)
+		buf[0] = 0xE0 | byte(strLen>>8)
+		buf[1] = byte(strLen)
+	} else {
+		// 32 bit string
+		backlen = 5 + strLen
+		backlenSize := dencoding.GetEncodeUIntSize(backlen)
+		buf = make([]byte, 5, backlen+backlenSize)
+		buf[0] = 0xF0
+		buf[1] = byte(strLen)
+		buf[2] = byte(strLen >> 8)
+		buf[3] = byte(strLen >> 16)
+		buf[4] = byte(strLen >> 24)
+	}
+	buf = append(buf, x...)
+	buf = buf[:cap(buf)]
+	dencoding.EncodeUIntRevInPlace(backlen, buf[backlen:])
+	return buf
+}
+
+func EncodeDeqInt(v int64) []byte {
+	var buf []byte
+	if 0 <= v && v <= 127 {
+		// 7 bit uint
+		buf = make([]byte, 2)
+		buf[0] = byte(v)
+	} else if v >= -4096 && v <= 4095 {
+		// 13 bit int
+		buf = make([]byte, 3)
+		buf[0], buf[1] = byte(0xC0|((v>>8)&0x1F)), byte(v)
+	} else if v >= -32768 && v <= 32767 {
+		// 16 bit int
+		buf = make([]byte, 4)
+		buf[0], buf[1], buf[2] = byte(0xF1), byte(v), byte(v>>8)
+	} else if v >= -8388608 && v <= 8388607 {
+		// 24 bit int
+		buf = make([]byte, 5)
+		buf[0], buf[1], buf[2], buf[3] = byte(0xF2), byte(v), byte(v>>8), byte(v>>16)
+	} else if v >= -2147483648 && v <= 2147483647 {
+		// 32 bit int
+		buf = make([]byte, 6)
+		buf[0], buf[1], buf[2], buf[3], buf[4] = byte(0xF3), byte(v), byte(v>>8), byte(v>>16), byte(v>>24)
+	} else {
+		// 64 bit int
+		buf = make([]byte, 10)
+		buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8] =
+			byte(0xF4), byte(v), byte(v>>8), byte(v>>16), byte(v>>24), byte(v>>32), byte(v>>40), byte(v>>48), byte(v>>56)
+	}
+	buf[len(buf)-1] = byte(len(buf) - 1)
+	return buf
+}
+
+func EncodeDeqEntryInPlace(x string, buf []byte) {
+	v, err := strconv.ParseInt(x, 10, 64)
+	if err != nil {
+		EncodeDeqStrInPlace(x, buf)
+	} else {
+		EncodeDeqIntInPlace(v, buf)
+	}
+}
+
+func EncodeDeqStrInPlace(x string, buf []byte) {
+	var enclen uint64
+	strLen := uint64(len(x))
+	if strLen <= 63 {
+		// 6 bit string
+		enclen = 1
+		buf[0] = 0x80 | byte(strLen)
+	} else if strLen <= 4095 {
+		// 12 bit string
+		enclen = 2
+		buf[0] = 0xE0 | byte(strLen>>8)
+		buf[1] = byte(strLen)
+	} else {
+		// 32 bit string
+		enclen = 5
+		buf[0] = 0xF0
+		buf[1] = byte(strLen)
+		buf[2] = byte(strLen >> 8)
+		buf[3] = byte(strLen >> 16)
+		buf[4] = byte(strLen >> 24)
+	}
+	copy(buf[enclen:], x)
+	dencoding.EncodeUIntRevInPlace(enclen+strLen, buf[enclen+strLen:])
+}
+
+func EncodeDeqIntInPlace(v int64, buf []byte) {
+	if 0 <= v && v <= 127 {
+		// 7 bit uint
+		buf[0] = byte(v)
+	} else if v >= -4096 && v <= 4095 {
+		// 13 bit int
+		buf[0], buf[1] = byte(0xC0|((v>>8)&0x1F)), byte(v)
+	} else if v >= -32768 && v <= 32767 {
+		// 16 bit int
+		buf[0], buf[1], buf[2] = byte(0xF1), byte(v), byte(v>>8)
+	} else if v >= -8388608 && v <= 8388607 {
+		// 24 bit int
+		buf[0], buf[1], buf[2], buf[3] = byte(0xF2), byte(v), byte(v>>8), byte(v>>16)
+	} else if v >= -2147483648 && v <= 2147483647 {
+		// 32 bit int
+		buf[0], buf[1], buf[2], buf[3], buf[4] = byte(0xF3), byte(v), byte(v>>8), byte(v>>16), byte(v>>24)
+	} else {
+		// 64 bit int
+		buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8] =
+			byte(0xF4), byte(v), byte(v>>8), byte(v>>16), byte(v>>24), byte(v>>32), byte(v>>40), byte(v>>48), byte(v>>56)
+	}
+	buf[len(buf)-1] = byte(len(buf) - 1)
+}
+
+func GetEncodeDeqEntrySize(x string) uint64 {
+	v, err := strconv.ParseInt(x, 10, 64)
+	if err != nil {
+		return GetEncodeDeqStrSize(x)
+	} else {
+		return GetEncodeDeqIntSize(v)
+	}
+}
+
+func GetEncodeDeqStrSize(x string) uint64 {
+	var enclen uint64
+	strLen := uint64(len(x))
+	if strLen <= 63 {
+		enclen = 1
+	} else if strLen <= 4095 {
+		enclen = 2
+	} else {
+		enclen = 5
+	}
+	return enclen + strLen + dencoding.GetEncodeUIntSize(enclen+strLen)
+}
+
+func GetEncodeDeqIntSize(v int64) uint64 {
+	if 0 <= v && v <= 127 {
+		return 2
+	} else if v >= -4096 && v <= 4095 {
+		return 3
+	} else if v >= -32768 && v <= 32767 {
+		return 4
+	} else if v >= -8388608 && v <= 8388607 {
+		return 5
+	} else if v >= -2147483648 && v <= 2147483647 {
+		return 6
+	} else {
+		return 10
+	}
+}
+
+// DecodeDeqEntry decode `xb` started from index 0, returns the decoded `x` and the
+// overall length of enc + data + backlen
+func DecodeDeqEntry(xb []byte) (string, int) {
+	var val int64
+	var bit int
+	var len int
+	if xb[0]&0x80 == 0 {
+		// 7 bit uint
+		val = int64(xb[0] & 0x7F)
+		bit = 8
+		len = 2
+	} else if xb[0]&0xE0 == 0xC0 {
+		// 13 bit int
+		val = (int64(xb[0]&0x1F) << 8) | int64(xb[1])
+		bit = 13
+		len = 3
+	} else if xb[0]&0xFF == 0xF1 {
+		// 16 bit int
+		val = int64(xb[1]) | int64(xb[2])<<8
+		bit = 16
+		len = 4
+	} else if xb[0]&0xFF == 0xF2 {
+		// 24 bit int
+		val = int64(xb[1]) | int64(xb[2])<<8 | int64(xb[3])<<16
+		bit = 24
+		len = 5
+	} else if xb[0]&0xFF == 0xF3 {
+		// 32 bit int
+		val = int64(xb[1]) | int64(xb[2])<<8 | int64(xb[3])<<16 | int64(xb[4])<<24
+		bit = 32
+		len = 6
+	} else if xb[0]&0xFF == 0xF4 {
+		// 64 bit int
+		val = int64(xb[1]) | int64(xb[2])<<8 | int64(xb[3])<<16 | int64(xb[4])<<24 | int64(xb[5])<<32 | int64(xb[6])<<40 | int64(xb[7])<<48 | int64(xb[8])<<56
+		bit = 64
+		len = 10
+	} else if xb[0]&0xC0 == 0x80 {
+		// 6 bit string
+		strLen := xb[0] & 0x3F
+		backlenlen := dencoding.GetEncodeUIntSize(uint64(1 + strLen))
+		return string(xb[1 : 1+strLen]), 1 + int(strLen) + int(backlenlen)
+	} else if xb[0]&0xF0 == 0xE0 {
+		// 12 bit string
+		strLen := (int64(xb[0]&0xF) << 8) | int64(xb[1])
+		backlenlen := dencoding.GetEncodeUIntSize(uint64(2 + strLen))
+		return string(xb[2 : 2+strLen]), 2 + int(strLen) + int(backlenlen)
+	} else if xb[0]&0xFF == 0xF0 {
+		// 32 bit string
+		strLen := int64(xb[1]) | (int64(xb[2]) << 8) | (int64(xb[3]) << 16) | (int64(xb[4]) << 24)
+		backlenlen := dencoding.GetEncodeUIntSize(uint64(5 + strLen))
+		return string(xb[5 : 5+strLen]), 5 + int(strLen) + int(backlenlen)
+	} else {
+		// for recognizing badly encoding case instead of panicing
+		val = 12345678900000000 + int64(xb[0])
+		bit = 64
+	}
+
+	val <<= 64 - bit
+	val >>= 64 - bit
+	return strconv.FormatInt(val, 10), len
+}

--- a/core/deque_test.go
+++ b/core/deque_test.go
@@ -11,34 +11,35 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-var randGenerator *rand.Rand
+var deqRandGenerator *rand.Rand
 
-func init() {
+func deqTestInit() {
 	randSeed := time.Now().UnixNano()
-	randGenerator = rand.New(rand.NewSource(randSeed))
+	deqRandGenerator = rand.New(rand.NewSource(randSeed))
 	fmt.Printf("rand seed: %v", randSeed)
 }
 
-var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':,.<>/?~.|")
+var deqRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':,.<>/?~.|")
 
-func randStr(n int) string {
+func deqRandStr(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = runes[randGenerator.Intn(len(runes))]
+		b[i] = deqRunes[deqRandGenerator.Intn(len(deqRunes))]
 	}
 	return string(b)
 }
 
 func TestDeqEncodeEntryString(t *testing.T) {
+	deqTestInit()
 	testCases := []string{
-		randStr(1),                // min 6 bit string
-		randStr(10),               // 6 bit string
-		randStr((1 << 6) - 1),     // max 6 bit string
-		randStr(1 << 6),           // min 12 bit string
-		randStr(2024),             // 12 bit string
-		randStr((1 << 12) - 1),    // max 12 bit string
-		randStr(1 << 12),          // min 32 bit string
-		randStr((1 << 20) - 1000), // 32 bit string
+		deqRandStr(1),                // min 6 bit string
+		deqRandStr(10),               // 6 bit string
+		deqRandStr((1 << 6) - 1),     // max 6 bit string
+		deqRandStr(1 << 6),           // min 12 bit string
+		deqRandStr(2024),             // 12 bit string
+		deqRandStr((1 << 12) - 1),    // max 12 bit string
+		deqRandStr(1 << 12),          // min 32 bit string
+		deqRandStr((1 << 20) - 1000), // 32 bit string
 		// randStr((1 << 32) - 1),   // max 32 bit string, maybe too huge to test..
 
 		"0",                    // min 7 bit uint

--- a/core/deque_test.go
+++ b/core/deque_test.go
@@ -16,7 +16,7 @@ func init() {
 	randGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
-var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':\",.<>/?~.|")
+var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':,.<>/?~.|")
 
 func randStr(n int) string {
 	b := make([]rune, n)
@@ -81,12 +81,6 @@ func dequeLPushIntStrMany(howmany int, deq core.DequeI, b *testing.B) {
 	}
 }
 
-func dequeLPushIntMany(howmany int, deq core.DequeI, b *testing.B) {
-	for i := 0; i < howmany; i++ {
-		deq.LPushInt(int64(i))
-	}
-}
-
 func BenchmarkBasicDequeRPush20(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		dequeRPushIntStrMany(20, core.NewBasicDeque(), b)
@@ -138,11 +132,5 @@ func BenchmarkDequeLPush200(b *testing.B) {
 func BenchmarkDequeLPush2000(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		dequeLPushIntStrMany(2000, core.NewDeque(), b)
-	}
-}
-
-func BenchmarkDequeLPushInt2000(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		dequeLPushIntMany(2000, core.NewDeque(), b)
 	}
 }

--- a/core/deque_test.go
+++ b/core/deque_test.go
@@ -10,8 +10,10 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+var randGenerator *rand.Rand
+
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	randGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':\",.<>/?~.|")
@@ -19,7 +21,7 @@ var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&
 func randStr(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = runes[rand.Intn(len(runes))]
+		b[i] = runes[randGenerator.Intn(len(runes))]
 	}
 	return string(b)
 }

--- a/core/deque_test.go
+++ b/core/deque_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"fmt"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -13,7 +14,9 @@ import (
 var randGenerator *rand.Rand
 
 func init() {
-	randGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randSeed := time.Now().UnixNano()
+	randGenerator = rand.New(rand.NewSource(randSeed))
+	fmt.Printf("rand seed: %v", randSeed)
 }
 
 var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':,.<>/?~.|")

--- a/core/deque_test.go
+++ b/core/deque_test.go
@@ -1,0 +1,146 @@
+package core_test
+
+import (
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dicedb/dice/core"
+	"gotest.tools/v3/assert"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':\",.<>/?~.|")
+
+func randStr(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = runes[rand.Intn(len(runes))]
+	}
+	return string(b)
+}
+
+func TestDeqEncodeEntryString(t *testing.T) {
+	testCases := []string{
+		randStr(1),                // min 6 bit string
+		randStr(10),               // 6 bit string
+		randStr((1 << 6) - 1),     // max 6 bit string
+		randStr(1 << 6),           // min 12 bit string
+		randStr(2024),             // 12 bit string
+		randStr((1 << 12) - 1),    // max 12 bit string
+		randStr(1 << 12),          // min 32 bit string
+		randStr((1 << 20) - 1000), // 32 bit string
+		// randStr((1 << 32) - 1),   // max 32 bit string, maybe too huge to test..
+
+		"0",                    // min 7 bit uint
+		"28",                   // 7 bit uint
+		"127",                  // max 7 bit uint
+		"-4096",                // min 13 bit int
+		"2024",                 // + 13 bit int
+		"-2024",                // - 13 bit int
+		"4095",                 // max 13 bit int
+		"-32768",               // min 16 bit int
+		"15384",                // + 16 bit int
+		"-15384",               // - 16 bit int
+		"32767",                // max 16 bit int
+		"-8388608",             // min 24 bit int
+		"4193301",              // + 24 bit int
+		"-4193301",             // - 24 bit int
+		"8388607",              // max 24 bit int
+		"-2147483648",          // min 32 bit int
+		"1073731765",           // + 32 bit int
+		"-1073731765",          // - 32 bit int
+		"2147483647",           // max 32 bit int
+		"-9223372036854775808", // min 64 bit int
+		"4611686018427287903",  // + 64 bit int
+		"-4611686018427287903", // - 64 bit int
+		"9223372036854775807",  // max 64 bit int
+	}
+
+	for _, tc := range testCases {
+		x, _ := core.DecodeDeqEntry(core.EncodeDeqEntry(tc))
+		assert.Equal(t, tc, x)
+	}
+}
+
+func dequeRPushIntStrMany(howmany int, deq core.DequeI, b *testing.B) {
+	for i := 0; i < howmany; i++ {
+		deq.RPush(strconv.FormatInt(int64(i), 10))
+	}
+}
+
+func dequeLPushIntStrMany(howmany int, deq core.DequeI, b *testing.B) {
+	for i := 0; i < howmany; i++ {
+		deq.LPush(strconv.FormatInt(int64(i), 10))
+	}
+}
+
+func dequeLPushIntMany(howmany int, deq core.DequeI, b *testing.B) {
+	for i := 0; i < howmany; i++ {
+		deq.LPushInt(int64(i))
+	}
+}
+
+func BenchmarkBasicDequeRPush20(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeRPushIntStrMany(20, core.NewBasicDeque(), b)
+	}
+}
+
+func BenchmarkBasicDequeRPush200(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeRPushIntStrMany(200, core.NewBasicDeque(), b)
+	}
+}
+
+func BenchmarkBasicDequeRPush2000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeRPushIntStrMany(2000, core.NewBasicDeque(), b)
+	}
+}
+
+func BenchmarkDequeRPush20(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeRPushIntStrMany(20, core.NewDeque(), b)
+	}
+}
+
+func BenchmarkDequeRPush200(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeRPushIntStrMany(200, core.NewDeque(), b)
+	}
+}
+
+func BenchmarkDequeRPush2000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeRPushIntStrMany(2000, core.NewDeque(), b)
+	}
+}
+
+func BenchmarkDequeLPush20(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeLPushIntStrMany(20, core.NewDeque(), b)
+	}
+}
+
+func BenchmarkDequeLPush200(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeLPushIntStrMany(200, core.NewDeque(), b)
+	}
+}
+
+func BenchmarkDequeLPush2000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeLPushIntStrMany(2000, core.NewDeque(), b)
+	}
+}
+
+func BenchmarkDequeLPushInt2000(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		dequeLPushIntMany(2000, core.NewDeque(), b)
+	}
+}

--- a/core/eval.go
+++ b/core/eval.go
@@ -2054,14 +2054,14 @@ func evalLPUSH(args []string) []byte {
 
 	obj := Get(args[0])
 	if obj == nil {
-		obj = NewObj(NewDeque(), -1, OBJ_TYPE_BYTELIST, OBJ_ENCODING_DEQUE)
+		obj = NewObj(NewDeque(), -1, ObjTypeByteList, ObjEncodingDeque)
 	}
 
-	if err := assertType(obj.TypeEncoding, OBJ_TYPE_BYTELIST); err != nil {
+	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return Encode(err, false)
 	}
 
-	if err := assertEncoding(obj.TypeEncoding, OBJ_ENCODING_DEQUE); err != nil {
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingDeque); err != nil {
 		return Encode(err, false)
 	}
 
@@ -2070,7 +2070,7 @@ func evalLPUSH(args []string) []byte {
 		obj.Value.(*Deque).LPush(args[i])
 	}
 
-	return RESP_OK
+	return RespOK
 }
 
 func evalRPUSH(args []string) []byte {
@@ -2080,14 +2080,14 @@ func evalRPUSH(args []string) []byte {
 
 	obj := Get(args[0])
 	if obj == nil {
-		obj = NewObj(NewDeque(), -1, OBJ_TYPE_BYTELIST, OBJ_ENCODING_DEQUE)
+		obj = NewObj(NewDeque(), -1, ObjTypeByteList, ObjEncodingDeque)
 	}
 
-	if err := assertType(obj.TypeEncoding, OBJ_TYPE_BYTELIST); err != nil {
+	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return Encode(err, false)
 	}
 
-	if err := assertEncoding(obj.TypeEncoding, OBJ_ENCODING_DEQUE); err != nil {
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingDeque); err != nil {
 		return Encode(err, false)
 	}
 
@@ -2096,7 +2096,7 @@ func evalRPUSH(args []string) []byte {
 		obj.Value.(*Deque).RPush(args[i])
 	}
 
-	return RESP_OK
+	return RespOK
 }
 
 func evalRPOP(args []string) []byte {
@@ -2106,14 +2106,14 @@ func evalRPOP(args []string) []byte {
 
 	obj := Get(args[0])
 	if obj == nil {
-		return RESP_NIL
+		return RespNIL
 	}
 
-	if err := assertType(obj.TypeEncoding, OBJ_TYPE_BYTELIST); err != nil {
+	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return Encode(err, false)
 	}
 
-	if err := assertEncoding(obj.TypeEncoding, OBJ_ENCODING_DEQUE); err != nil {
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingDeque); err != nil {
 		return Encode(err, false)
 	}
 
@@ -2121,7 +2121,7 @@ func evalRPOP(args []string) []byte {
 	x, err := deq.RPop()
 	if err != nil {
 		if err == ErrDequeEmpty {
-			return RESP_NIL
+			return RespNIL
 		}
 		panic(fmt.Sprintf("unknown error: %v", err))
 	}
@@ -2136,14 +2136,14 @@ func evalLPOP(args []string) []byte {
 
 	obj := Get(args[0])
 	if obj == nil {
-		return RESP_NIL
+		return RespNIL
 	}
 
-	if err := assertType(obj.TypeEncoding, OBJ_TYPE_BYTELIST); err != nil {
+	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return Encode(err, false)
 	}
 
-	if err := assertEncoding(obj.TypeEncoding, OBJ_ENCODING_DEQUE); err != nil {
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingDeque); err != nil {
 		return Encode(err, false)
 	}
 
@@ -2151,7 +2151,7 @@ func evalLPOP(args []string) []byte {
 	x, err := deq.LPop()
 	if err != nil {
 		if err == ErrDequeEmpty {
-			return RESP_NIL
+			return RespNIL
 		}
 		panic(fmt.Sprintf("unknown error: %v", err))
 	}

--- a/core/eval.go
+++ b/core/eval.go
@@ -2046,3 +2046,115 @@ func evalTOUCH(args []string) []byte {
 
 	return Encode(count, false)
 }
+
+func evalLPUSH(args []string) []byte {
+	if len(args) < 2 {
+		return Encode(errors.New("ERR invalid number of arguments for `LPUSH` command"), false)
+	}
+
+	obj := Get(args[0])
+	if obj == nil {
+		obj = NewObj(NewDeque(), -1, OBJ_TYPE_BYTELIST, OBJ_ENCODING_DEQUE)
+	}
+
+	if err := assertType(obj.TypeEncoding, OBJ_TYPE_BYTELIST); err != nil {
+		return Encode(err, false)
+	}
+
+	if err := assertEncoding(obj.TypeEncoding, OBJ_ENCODING_DEQUE); err != nil {
+		return Encode(err, false)
+	}
+
+	Put(args[0], obj)
+	for i := 1; i < len(args); i++ {
+		obj.Value.(*Deque).LPush(args[i])
+	}
+
+	return RESP_OK
+}
+
+func evalRPUSH(args []string) []byte {
+	if len(args) < 2 {
+		return Encode(errors.New("ERR invalid number of arguments for `RPUSH` command"), false)
+	}
+
+	obj := Get(args[0])
+	if obj == nil {
+		obj = NewObj(NewDeque(), -1, OBJ_TYPE_BYTELIST, OBJ_ENCODING_DEQUE)
+	}
+
+	if err := assertType(obj.TypeEncoding, OBJ_TYPE_BYTELIST); err != nil {
+		return Encode(err, false)
+	}
+
+	if err := assertEncoding(obj.TypeEncoding, OBJ_ENCODING_DEQUE); err != nil {
+		return Encode(err, false)
+	}
+
+	Put(args[0], obj)
+	for i := 1; i < len(args); i++ {
+		obj.Value.(*Deque).RPush(args[i])
+	}
+
+	return RESP_OK
+}
+
+func evalRPOP(args []string) []byte {
+	if len(args) != 1 {
+		return Encode(errors.New("ERR invalid number of arguments for `RPOP` command"), false)
+	}
+
+	obj := Get(args[0])
+	if obj == nil {
+		return RESP_NIL
+	}
+
+	if err := assertType(obj.TypeEncoding, OBJ_TYPE_BYTELIST); err != nil {
+		return Encode(err, false)
+	}
+
+	if err := assertEncoding(obj.TypeEncoding, OBJ_ENCODING_DEQUE); err != nil {
+		return Encode(err, false)
+	}
+
+	deq := obj.Value.(*Deque)
+	x, err := deq.RPop()
+	if err != nil {
+		if err == ErrDequeEmpty {
+			return RESP_NIL
+		}
+		panic(fmt.Sprintf("unknown error: %v", err))
+	}
+
+	return Encode(x, false)
+}
+
+func evalLPOP(args []string) []byte {
+	if len(args) != 1 {
+		return Encode(errors.New("ERR invalid number of arguments for `LPOP` command"), false)
+	}
+
+	obj := Get(args[0])
+	if obj == nil {
+		return RESP_NIL
+	}
+
+	if err := assertType(obj.TypeEncoding, OBJ_TYPE_BYTELIST); err != nil {
+		return Encode(err, false)
+	}
+
+	if err := assertEncoding(obj.TypeEncoding, OBJ_ENCODING_DEQUE); err != nil {
+		return Encode(err, false)
+	}
+
+	deq := obj.Value.(*Deque)
+	x, err := deq.LPop()
+	if err != nil {
+		if err == ErrDequeEmpty {
+			return RESP_NIL
+		}
+		panic(fmt.Sprintf("unknown error: %v", err))
+	}
+
+	return Encode(x, false)
+}

--- a/core/object.go
+++ b/core/object.go
@@ -23,6 +23,7 @@ var ObjEncodingQref uint8 = 1
 
 var ObjEncodingStackInt uint8 = 2
 var ObjEncodingStackRef uint8 = 3
+var ObjEncodingDeque uint8 = 4
 
 var ObjTypeBitSet uint8 = 2 << 4 // 00100000
 var ObjEncodingBF uint8 = 2      // 00000010

--- a/core/queueint_test.go
+++ b/core/queueint_test.go
@@ -85,10 +85,10 @@ func insertMany(howmany int, qi core.QueueIntI, b *testing.B) {
 	for i := 0; i < howmany; i++ {
 		qi.Insert(int64(i))
 	}
-	// obsList := qi.Iterate(howmany + 10)
-	// if len(obsList) != howmany {
-	// 	b.Errorf("queueint test failed. should have been %d but found %v", howmany, len(obsList))
-	// }
+	obsList := qi.Iterate(howmany + 10)
+	if len(obsList) != howmany {
+		b.Errorf("queueint test failed. should have been %d but found %v", howmany, len(obsList))
+	}
 }
 
 func BenchmarkInsert20(b *testing.B) {

--- a/core/queueint_test.go
+++ b/core/queueint_test.go
@@ -85,10 +85,10 @@ func insertMany(howmany int, qi core.QueueIntI, b *testing.B) {
 	for i := 0; i < howmany; i++ {
 		qi.Insert(int64(i))
 	}
-	obsList := qi.Iterate(howmany + 10)
-	if len(obsList) != howmany {
-		b.Errorf("queueint test failed. should have been %d but found %v", howmany, len(obsList))
-	}
+	// obsList := qi.Iterate(howmany + 10)
+	// if len(obsList) != howmany {
+	// 	b.Errorf("queueint test failed. should have been %d but found %v", howmany, len(obsList))
+	// }
 }
 
 func BenchmarkInsert20(b *testing.B) {

--- a/tests/deque_test.go
+++ b/tests/deque_test.go
@@ -149,6 +149,7 @@ func TestRPush(t *testing.T) {
 }
 
 func TestLPushLPop(t *testing.T) {
+	deqTestInit()
 	conn := getLocalConnection()
 	defer conn.Close()
 

--- a/tests/deque_test.go
+++ b/tests/deque_test.go
@@ -1,9 +1,12 @@
 package tests
 
 import (
+	"fmt"
 	"math/rand"
+	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 )
@@ -25,7 +28,9 @@ func randStr(n int) string {
 }
 
 func init() {
-	randGenerator = rand.New(rand.NewSource(4))
+	randSeed := time.Now().UnixNano()
+	randGenerator = rand.New(rand.NewSource(randSeed))
+	fmt.Printf("rand seed: %v", randSeed)
 	deqNormalValues = []string{
 		randStr(10),               // 6 bit string
 		randStr(256),              // 12 bit string
@@ -99,6 +104,8 @@ func TestLPush(t *testing.T) {
 			}
 		})
 	}
+
+	cleanUp(conn)
 }
 
 func TestRPush(t *testing.T) {
@@ -135,6 +142,8 @@ func TestRPush(t *testing.T) {
 			}
 		})
 	}
+
+	cleanUp(conn)
 }
 
 func TestLPushLPop(t *testing.T) {
@@ -186,6 +195,8 @@ func TestLPushLPop(t *testing.T) {
 			}
 		})
 	}
+
+	cleanUp(conn)
 }
 
 func TestLPushRPop(t *testing.T) {
@@ -237,6 +248,8 @@ func TestLPushRPop(t *testing.T) {
 			}
 		})
 	}
+
+	cleanUp(conn)
 }
 
 func TestRPushLPop(t *testing.T) {
@@ -288,6 +301,8 @@ func TestRPushLPop(t *testing.T) {
 			}
 		})
 	}
+
+	cleanUp(conn)
 }
 
 func TestRPushRPop(t *testing.T) {
@@ -339,6 +354,8 @@ func TestRPushRPop(t *testing.T) {
 			}
 		})
 	}
+
+	cleanUp(conn)
 }
 
 func TestLRPushLRPop(t *testing.T) {
@@ -374,5 +391,16 @@ func TestLRPushLRPop(t *testing.T) {
 				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
 			}
 		})
+	}
+
+	cleanUp(conn)
+}
+
+func cleanUp(conn net.Conn) {
+	for {
+		result := fireCommand(conn, "LPOP k")
+		if result == "(nil)" {
+			break
+		}
 	}
 }

--- a/tests/deque_test.go
+++ b/tests/deque_test.go
@@ -11,48 +11,48 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-var randGenerator *rand.Rand
-var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':,.<>/?~.|")
+var deqRandGenerator *rand.Rand
+var deqRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':,.<>/?~.|")
 
 var (
 	deqNormalValues []string
 	deqEdgeValues   []string
 )
 
-func randStr(n int) string {
+func deqRandStr(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = runes[randGenerator.Intn(len(runes))]
+		b[i] = deqRunes[deqRandGenerator.Intn(len(deqRunes))]
 	}
 	return string(b)
 }
 
-func init() {
+func deqTestInit() {
 	randSeed := time.Now().UnixNano()
-	randGenerator = rand.New(rand.NewSource(randSeed))
+	deqRandGenerator = rand.New(rand.NewSource(randSeed))
 	fmt.Printf("rand seed: %v", randSeed)
 	deqNormalValues = []string{
-		randStr(10),               // 6 bit string
-		randStr(256),              // 12 bit string
-		randStr((1 << 13) - 1000), // 32 bit string
-		"28",                      // 7 bit uint
-		"2024",                    // + 13 bit int
-		"-2024",                   // - 13 bit int
-		"15384",                   // + 16 bit int
-		"-15384",                  // - 16 bit int
-		"4193301",                 // + 24 bit int
-		"-4193301",                // - 24 bit int
-		"1073731765",              // + 32 bit int
-		"-1073731765",             // - 32 bit int
-		"4611686018427287903",     // + 64 bit int
-		"-4611686018427287903",    // - 64 bit int
+		deqRandStr(10),               // 6 bit string
+		deqRandStr(256),              // 12 bit string
+		deqRandStr((1 << 13) - 1000), // 32 bit string
+		"28",                         // 7 bit uint
+		"2024",                       // + 13 bit int
+		"-2024",                      // - 13 bit int
+		"15384",                      // + 16 bit int
+		"-15384",                     // - 16 bit int
+		"4193301",                    // + 24 bit int
+		"-4193301",                   // - 24 bit int
+		"1073731765",                 // + 32 bit int
+		"-1073731765",                // - 32 bit int
+		"4611686018427287903",        // + 64 bit int
+		"-4611686018427287903",       // - 64 bit int
 	}
 	deqEdgeValues = []string{
-		randStr(1),             // min 6 bit string
-		randStr((1 << 6) - 1),  // max 6 bit string
-		randStr(1 << 6),        // min 12 bit string
-		randStr((1 << 12) - 1), // max 12 bit string
-		randStr(1 << 12),       // min 32 bit string
+		deqRandStr(1),             // min 6 bit string
+		deqRandStr((1 << 6) - 1),  // max 6 bit string
+		deqRandStr(1 << 6),        // min 12 bit string
+		deqRandStr((1 << 12) - 1), // max 12 bit string
+		deqRandStr(1 << 12),       // min 32 bit string
 		// randStr((1 << 32) - 1),   // max 32 bit string, maybe too huge to test..
 
 		"0",                    // min 7 bit uint
@@ -71,6 +71,7 @@ func init() {
 }
 
 func TestLPush(t *testing.T) {
+	deqTestInit()
 	conn := getLocalConnection()
 	defer conn.Close()
 
@@ -105,10 +106,11 @@ func TestLPush(t *testing.T) {
 		})
 	}
 
-	cleanUp(conn)
+	deqCleanUp(conn, "k")
 }
 
 func TestRPush(t *testing.T) {
+	deqTestInit()
 	conn := getLocalConnection()
 	defer conn.Close()
 
@@ -143,7 +145,7 @@ func TestRPush(t *testing.T) {
 		})
 	}
 
-	cleanUp(conn)
+	deqCleanUp(conn, "k")
 }
 
 func TestLPushLPop(t *testing.T) {
@@ -196,10 +198,11 @@ func TestLPushLPop(t *testing.T) {
 		})
 	}
 
-	cleanUp(conn)
+	deqCleanUp(conn, "k")
 }
 
 func TestLPushRPop(t *testing.T) {
+	deqTestInit()
 	conn := getLocalConnection()
 	defer conn.Close()
 
@@ -249,10 +252,11 @@ func TestLPushRPop(t *testing.T) {
 		})
 	}
 
-	cleanUp(conn)
+	deqCleanUp(conn, "k")
 }
 
 func TestRPushLPop(t *testing.T) {
+	deqTestInit()
 	conn := getLocalConnection()
 	defer conn.Close()
 
@@ -302,10 +306,11 @@ func TestRPushLPop(t *testing.T) {
 		})
 	}
 
-	cleanUp(conn)
+	deqCleanUp(conn, "k")
 }
 
 func TestRPushRPop(t *testing.T) {
+	deqTestInit()
 	conn := getLocalConnection()
 	defer conn.Close()
 
@@ -355,10 +360,11 @@ func TestRPushRPop(t *testing.T) {
 		})
 	}
 
-	cleanUp(conn)
+	deqCleanUp(conn, "k")
 }
 
 func TestLRPushLRPop(t *testing.T) {
+	deqTestInit()
 	conn := getLocalConnection()
 	defer conn.Close()
 
@@ -393,12 +399,12 @@ func TestLRPushLRPop(t *testing.T) {
 		})
 	}
 
-	cleanUp(conn)
+	deqCleanUp(conn, "k")
 }
 
-func cleanUp(conn net.Conn) {
+func deqCleanUp(conn net.Conn, key string) {
 	for {
-		result := fireCommand(conn, "LPOP k")
+		result := fireCommand(conn, "LPOP "+key)
 		if result == "(nil)" {
 			break
 		}

--- a/tests/deque_test.go
+++ b/tests/deque_test.go
@@ -1,0 +1,378 @@
+package tests
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+var randGenerator *rand.Rand
+var runes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_!@#$%^&*()-=+[]\\;':,.<>/?~.|")
+
+var (
+	deqNormalValues []string
+	deqEdgeValues   []string
+)
+
+func randStr(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = runes[randGenerator.Intn(len(runes))]
+	}
+	return string(b)
+}
+
+func init() {
+	randGenerator = rand.New(rand.NewSource(4))
+	deqNormalValues = []string{
+		randStr(10),               // 6 bit string
+		randStr(256),              // 12 bit string
+		randStr((1 << 13) - 1000), // 32 bit string
+		"28",                      // 7 bit uint
+		"2024",                    // + 13 bit int
+		"-2024",                   // - 13 bit int
+		"15384",                   // + 16 bit int
+		"-15384",                  // - 16 bit int
+		"4193301",                 // + 24 bit int
+		"-4193301",                // - 24 bit int
+		"1073731765",              // + 32 bit int
+		"-1073731765",             // - 32 bit int
+		"4611686018427287903",     // + 64 bit int
+		"-4611686018427287903",    // - 64 bit int
+	}
+	deqEdgeValues = []string{
+		randStr(1),             // min 6 bit string
+		randStr((1 << 6) - 1),  // max 6 bit string
+		randStr(1 << 6),        // min 12 bit string
+		randStr((1 << 12) - 1), // max 12 bit string
+		randStr(1 << 12),       // min 32 bit string
+		// randStr((1 << 32) - 1),   // max 32 bit string, maybe too huge to test..
+
+		"0",                    // min 7 bit uint
+		"127",                  // max 7 bit uint
+		"-4096",                // min 13 bit int
+		"4095",                 // max 13 bit int
+		"-32768",               // min 16 bit int
+		"32767",                // max 16 bit int
+		"-8388608",             // min 24 bit int
+		"8388607",              // max 24 bit int
+		"-2147483648",          // min 32 bit int
+		"2147483647",           // max 32 bit int
+		"-9223372036854775808", // min 64 bit int
+		"9223372036854775807",  // max 64 bit int
+	}
+}
+
+func TestLPush(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []any
+	}{
+		{
+			name:   "LPUSH",
+			cmds:   []string{"LPUSH k v", "LPUSH k v1 1 v2 2", "LPUSH k 3 3 3 v3 v3 v3"},
+			expect: []any{"OK", "OK", "OK"},
+		},
+		{
+			name:   "LPUSH normal values",
+			cmds:   []string{"LPUSH k " + strings.Join(deqNormalValues, " ")},
+			expect: []any{"OK"},
+		},
+		{
+			name:   "LPUSH edge values",
+			cmds:   []string{"LPUSH k " + strings.Join(deqEdgeValues, " ")},
+			expect: []any{"OK"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.cmds {
+				result := fireCommand(conn, cmd)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}
+
+func TestRPush(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []any
+	}{
+		{
+			name:   "RPUSH",
+			cmds:   []string{"LPUSH k v", "LPUSH k v1 1 v2 2", "LPUSH k 3 3 3 v3 v3 v3"},
+			expect: []any{"OK", "OK", "OK"},
+		},
+		{
+			name:   "RPUSH normal values",
+			cmds:   []string{"LPUSH k " + strings.Join(deqNormalValues, " ")},
+			expect: []any{"OK"},
+		},
+		{
+			name:   "RPUSH edge values",
+			cmds:   []string{"LPUSH k " + strings.Join(deqEdgeValues, " ")},
+			expect: []any{"OK"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.cmds {
+				result := fireCommand(conn, cmd)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}
+
+func TestLPushLPop(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	getPops := func(values []string) []string {
+		pops := make([]string, len(values)+1)
+		for i := 0; i < len(values)+1; i++ {
+			pops[i] = "LPOP k"
+		}
+		return pops
+	}
+	getPopExpects := func(values []string) []any {
+		expects := make([]any, len(values))
+		for i := 0; i < len(values); i++ {
+			expects[i] = values[len(values)-1-i]
+		}
+		return expects
+	}
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []any
+	}{
+		{
+			name:   "LPUSH LPOP",
+			cmds:   []string{"LPUSH k v1 1", "LPOP k", "LPOP k", "LPOP k"},
+			expect: []any{"OK", "1", "v1", "(nil)"},
+		},
+		{
+			name:   "LPUSH LPOP normal values",
+			cmds:   append([]string{"LPUSH k " + strings.Join(deqNormalValues, " ")}, getPops(deqNormalValues)...),
+			expect: append(append([]any{"OK"}, getPopExpects(deqNormalValues)...), "(nil)"),
+		},
+		{
+			name:   "LPUSH LPOP edge values",
+			cmds:   append([]string{"LPUSH k " + strings.Join(deqEdgeValues, " ")}, getPops(deqEdgeValues)...),
+			expect: append(append([]any{"OK"}, getPopExpects(deqEdgeValues)...), "(nil)"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.cmds {
+				result := fireCommand(conn, cmd)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}
+
+func TestLPushRPop(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	getPops := func(values []string) []string {
+		pops := make([]string, len(values)+1)
+		for i := 0; i < len(values)+1; i++ {
+			pops[i] = "RPOP k"
+		}
+		return pops
+	}
+	getPopExpects := func(values []string) []any {
+		expects := make([]any, len(values))
+		for i := 0; i < len(values); i++ {
+			expects[i] = values[i]
+		}
+		return expects
+	}
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []any
+	}{
+		{
+			name:   "LPUSH RPOP",
+			cmds:   []string{"LPUSH k v1 1", "RPOP k", "RPOP k", "RPOP k"},
+			expect: []any{"OK", "v1", "1", "(nil)"},
+		},
+		{
+			name:   "LPUSH RPOP normal values",
+			cmds:   append([]string{"LPUSH k " + strings.Join(deqNormalValues, " ")}, getPops(deqNormalValues)...),
+			expect: append(append([]any{"OK"}, getPopExpects(deqNormalValues)...), "(nil)"),
+		},
+		{
+			name:   "LPUSH RPOP edge values",
+			cmds:   append([]string{"LPUSH k " + strings.Join(deqEdgeValues, " ")}, getPops(deqEdgeValues)...),
+			expect: append(append([]any{"OK"}, getPopExpects(deqEdgeValues)...), "(nil)"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.cmds {
+				result := fireCommand(conn, cmd)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}
+
+func TestRPushLPop(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	getPops := func(values []string) []string {
+		pops := make([]string, len(values)+1)
+		for i := 0; i < len(values)+1; i++ {
+			pops[i] = "LPOP k"
+		}
+		return pops
+	}
+	getPopExpects := func(values []string) []any {
+		expects := make([]any, len(values))
+		for i := 0; i < len(values); i++ {
+			expects[i] = values[i]
+		}
+		return expects
+	}
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []any
+	}{
+		{
+			name:   "RPUSH LPOP",
+			cmds:   []string{"RPUSH k v1 1", "LPOP k", "LPOP k", "LPOP k"},
+			expect: []any{"OK", "v1", "1", "(nil)"},
+		},
+		{
+			name:   "RPUSH LPOP normal values",
+			cmds:   append([]string{"RPUSH k " + strings.Join(deqNormalValues, " ")}, getPops(deqNormalValues)...),
+			expect: append(append([]any{"OK"}, getPopExpects(deqNormalValues)...), "(nil)"),
+		},
+		{
+			name:   "RPUSH LPOP edge values",
+			cmds:   append([]string{"RPUSH k " + strings.Join(deqEdgeValues, " ")}, getPops(deqEdgeValues)...),
+			expect: append(append([]any{"OK"}, getPopExpects(deqEdgeValues)...), "(nil)"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.cmds {
+				result := fireCommand(conn, cmd)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}
+
+func TestRPushRPop(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	getPops := func(values []string) []string {
+		pops := make([]string, len(values)+1)
+		for i := 0; i < len(values)+1; i++ {
+			pops[i] = "RPOP k"
+		}
+		return pops
+	}
+	getPopExpects := func(values []string) []any {
+		expects := make([]any, len(values))
+		for i := 0; i < len(values); i++ {
+			expects[i] = values[len(values)-1-i]
+		}
+		return expects
+	}
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []any
+	}{
+		{
+			name:   "RPUSH RPOP",
+			cmds:   []string{"RPUSH k v1 1", "RPOP k", "RPOP k", "RPOP k"},
+			expect: []any{"OK", "1", "v1", "(nil)"},
+		},
+		{
+			name:   "RPUSH RPOP normal values",
+			cmds:   append([]string{"RPUSH k " + strings.Join(deqNormalValues, " ")}, getPops(deqNormalValues)...),
+			expect: append(append([]any{"OK"}, getPopExpects(deqNormalValues)...), "(nil)"),
+		},
+		{
+			name:   "RPUSH RPOP edge values",
+			cmds:   append([]string{"RPUSH k " + strings.Join(deqEdgeValues, " ")}, getPops(deqEdgeValues)...),
+			expect: append(append([]any{"OK"}, getPopExpects(deqEdgeValues)...), "(nil)"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.cmds {
+				result := fireCommand(conn, cmd)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}
+
+func TestLRPushLRPop(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []any
+	}{
+		{
+			name: "L/RPush L/RPop",
+			cmds: []string{
+				"RPUSH k v1000 1000", "LPUSH k v2000 2000",
+				"RPOP k", "RPOP k", "LPOP k",
+				"LPUSH k v6",
+				"RPOP k", "LPOP k", "LPOP k", "RPOP k",
+			},
+			expect: []any{
+				"OK", "OK",
+				"1000", "v1000", "2000",
+				"OK",
+				"v2000", "v6", "(nil)", "(nil)",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.cmds {
+				result := fireCommand(conn, cmd)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What's new
In this PR, I add a new backing data structure `DequeI`, and like `QueueI` there's two implementation of it:
- `QueueBasic`: use a byte slice to store the data, but it involves reallocating and copying huge block of data when growing the slice.
- `Queue`: use the `byteList` structure to store the data, giving the minimum size of every node of `byteList` to minimize down the number of memory fragments, and the size of block of memory need to allocate or copy every time is also under preciser control.

About the encoding of every element inside `Deque`, after investigation to the redis implementation of the `listpack` data structure, I make a "copy" of it in golang, element is encoded orderly as [enc, data, backlen], where backlen is for supporting decoding from the tail (or say the rightest end) of `Deque`, nothing special about this part.

# Testing
I also make some comparisons at benchmark between `Deque` and `QueueInt` about inserting/pushing integer. For fair comparison, I comment these lines in `queueint_test.go` for purely comparing the insert operation:
```golang
func insertMany(howmany int, qi core.QueueIntI, b *testing.B) {
	for i := 0; i < howmany; i++ {
		qi.Insert(int64(i))
	}
	// obsList := qi.Iterate(howmany + 10)
	// if len(obsList) != howmany {
	// 	b.Errorf("queueint test failed. should have been %d but found %v", howmany, len(obsList))
	// }
}
```
and create a `LPushInt` method specially for `Deque` to get rid of the time-consuming `strconv` (test in `QueueInt` has not this thing). here's my benchmark result:

`QueueInt`:
```
$ go test -test.bench ^BenchmarkInsert2 -benchmem
2024/08/13 11:04:49 possible cross protocol scripting attack detected. dropping the request.
Queue size : 3
goos: darwin
goarch: arm64
pkg: github.com/dicedb/dice/core
BenchmarkInsert20-8              2753487               431.8 ns/op           324 B/op         22 allocs/op
BenchmarkInsert200-8              317266              3707 ns/op             880 B/op        204 allocs/op
BenchmarkInsert2000-8              32098             37171 ns/op            8739 B/op       2032 allocs/op
PASS
ok      github.com/dicedb/dice/core     5.361s
```

`Deque`:
```
$ go test -test.bench ^BenchmarkDequeL -benchmem
2024/08/13 11:05:27 possible cross protocol scripting attack detected. dropping the request.
Queue size : 3
goos: darwin
goarch: arm64
pkg: github.com/dicedb/dice/core
BenchmarkDequeLPush20-8          2723680               480.4 ns/op           360 B/op          4 allocs/op
BenchmarkDequeLPush200-8          211389              5701 ns/op             984 B/op        106 allocs/op
BenchmarkDequeLPush2000-8          16480             74828 ns/op           19976 B/op       1969 allocs/op
BenchmarkDequeLPushInt2000-8      140133              8596 ns/op           13040 B/op         67 allocs/op
PASS
ok      github.com/dicedb/dice/core     7.326s
```

From the result, the `Insert200` and `Insert2000` beat `Push200` and `Push2000` respectively at `ns/op` and `B/op`, but the `PushInt2000` case exceeds both `Insert2000` and `Push2000` at a big scale, which we can blame on the time-consuming `strconv` as said before, inside `strconv`, a number < 100 is at the fast-path of the code, so that's also the reason `Push20` beat `Insert20`.

# TODOS
If the implementation above looks reasonable I would like to add further completion, tests and clean-up.

(Sorry for not giving a detailed design document early before the code)

