### PR TITLE
Feature added support for TOUCH and OBJECT IDLETIME

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -535,6 +535,23 @@ var (
 		Arity:    2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	objectCmdMeta = DiceCmdMeta{
+		Name: "OBJECT",
+		Info: `OBJECT subcommand [arguments [arguments ...]]
+		OBJECT command is used to inspect the internals of the Redis objects.`,
+		Eval:     evalOBJECT,
+		Arity:    -2,
+		KeySpecs: KeySpecs{BeginIndex: 2},
+	}
+	touchCmdMeta = DiceCmdMeta{
+		Name: "TOUCH",
+		Info: `TOUCH key1 key2 ... key_N
+		Alters the last access time of a key(s).
+		A key is ignored if it does not exist.`,
+		Eval:     evalTOUCH,
+		Arity:    -2,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 )
 
 func init() {
@@ -598,4 +615,6 @@ func init() {
 	diceCmds["RENAME"] = renameCmdMeta
 	diceCmds["GETEX"] = getexCmdMeta
 	diceCmds["PTTL"] = pttlCmdMeta
+	diceCmds["OBJECT"] = objectCmdMeta
+	diceCmds["TOUCH"] = touchCmdMeta
 }

--- a/core/eval.go
+++ b/core/eval.go
@@ -1978,3 +1978,43 @@ func evalPTTL(args []string) []byte {
 	durationMs := exp - uint64(time.Now().UnixMilli())
 	return Encode(int64(durationMs), false)
 }
+
+func evalObjectIdleTime(key string) []byte {
+	obj := GetNoTouch(key)
+	if obj == nil {
+		return RespNIL
+	}
+
+	return Encode(int64(getIdleTime(obj.LastAccessedAt)), true)
+}
+
+func evalOBJECT(args []string) []byte {
+	if len(args) < 2 {
+		return Encode(errors.New("ERR wrong number of arguments for 'object' command"), false)
+	}
+
+	subcommand := strings.ToUpper(args[0])
+	key := args[1]
+
+	switch subcommand {
+	case "IDLETIME":
+		return evalObjectIdleTime(key)
+	default:
+		return Encode(errors.New("ERR syntax error"), false)
+	}
+}
+
+func evalTOUCH(args []string) []byte {
+	if len(args) == 0 {
+		return Encode(errors.New("ERR wrong number of arguments for 'touch' command"), false)
+	}
+
+	count := 0
+	for _, key := range args {
+		if Get(key) != nil {
+			count++
+		}
+	}
+
+	return Encode(count, false)
+}

--- a/tests/object_test.go
+++ b/tests/object_test.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestObjectCommand(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []struct {
+		name        string
+		commands    []string
+		expected    []interface{}
+		assert_type []string
+		delay       []time.Duration
+	}{
+		{
+			name:        "Object Idletime",
+			commands:    []string{"SET foo bar", "OBJECT IDLETIME foo", "OBJECT IDLETIME foo", "TOUCH foo", "OBJECT IDLETIME foo"},
+			expected:    []interface{}{"OK", int64(2), int64(3), int64(1), int64(0)},
+			assert_type: []string{"equal", "assert", "assert", "equal", "assert"},
+			delay:       []time.Duration{0, 2 * time.Second, 3 * time.Second, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			deleteTestKeys([]string{"foo"})
+			for i, cmd := range tc.commands {
+				if tc.delay[i] != 0 {
+					time.Sleep(tc.delay[i])
+				}
+				result := fireCommand(conn, cmd)
+				if tc.assert_type[i] == "equal" {
+					assert.DeepEqual(t, tc.expected[i], result)
+				} else {
+					assert.Assert(t, result.(int64) >= tc.expected[i].(int64), "Expected %v to be less than or equal to %v", result, tc.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/tests/touch_test.go
+++ b/tests/touch_test.go
@@ -1,0 +1,60 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestTouch(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []struct {
+		name        string
+		commands    []string
+		expected    []interface{}
+		assert_type []string
+		delay       []time.Duration
+	}{
+		{
+			name:        "Touch Simple Value",
+			commands:    []string{"SET foo bar", "OBJECT IDLETIME foo", "TOUCH foo", "OBJECT IDLETIME foo"},
+			expected:    []interface{}{"OK", int64(2), int64(1), int64(0)},
+			assert_type: []string{"equal", "assert", "equal", "assert"},
+			delay:       []time.Duration{0, 2 * time.Second, 0, 0},
+		},
+		{
+			name:        "Touch Multiple Existing Keys",
+			commands:    []string{"SET foo bar", "SET foo1 bar", "TOUCH foo foo1"},
+			expected:    []interface{}{"OK", "OK", int64(2)},
+			assert_type: []string{"equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0},
+		},
+		{
+			name:        "Touch Multiple Existing and Non-Existing Keys",
+			commands:    []string{"SET foo bar", "TOUCH foo foo1"},
+			expected:    []interface{}{"OK", int64(1)},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			deleteTestKeys([]string{"foo", "foo1"})
+			for i, cmd := range tc.commands {
+				if tc.delay[i] != 0 {
+					time.Sleep(tc.delay[i])
+				}
+				result := fireCommand(conn, cmd)
+				if tc.assert_type[i] == "equal" {
+					assert.DeepEqual(t, tc.expected[i], result)
+				} else {
+					assert.Assert(t, result.(int64) >= tc.expected[i].(int64), "Expected %v to be less than or equal to %v", result, tc.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
* The changes that are included in the PR.
Added support for the `TOUCH` command as per Redis and `OBJECT IDLETIME key` as per Redis.
Added tests for both commands in tests folder.

* Design document, if any.

* Information on any implementation choices that were made.
The reason to implement  `OBJECT IDLETIME key`, standalone from other subcommands is due to no support for ref and freq for keys and object for now. However, I assumed that having `object idletime` is essential to verify the effect of `TOUCH` command. In addition to this, I have carefully structured `OBJECT` for extension for subcommands in the future.

* Evidence of sufficient testing. You MUST indicate the tests done, either manually or automated.
Added new tests