### PR TITLE
fix:correct the JSON.SET command Arity

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -81,7 +81,7 @@ var (
 		Returns OK if successful.
 		Returns encoded error message if the number of arguments is incorrect or the JSON string is invalid.`,
 		Eval:     evalJSONSET,
-		Arity:    3,
+		Arity:    -3,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
 	jsongetCmdMeta = DiceCmdMeta{


### PR DESCRIPTION
a tiny fix

in command.go there is :
`

    jsonsetCmdMeta = DiceCmdMeta{
	      Name: "JSON.SET",
	      Info: `JSON.SET key path json-string
	      Sets a JSON value at the specified key.
	      Returns OK if successful.
	      Returns encoded error message if the number of arguments is incorrect or the JSON string is invalid.`,
	      Eval:     evalJSONSET,
	      Arity:    3,
	      KeySpecs: KeySpecs{BeginIndex: 1},

`

but we could add NX or XX so the Arity should be -3
such as below:

`

    JSON.SET user $ '{"name":"123","age":18,"language":["java","python","go"]}'

    JSON.SET user $.amount '1.26' XX
`