### PR TITLE
Memtier benchmark and load tests preset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+THREADS ?= 4 #number of threads
+CLIENTS ?= 50 #number of clients per thread
+REQUESTS ?= 10000 #number of requests per client
+DATA_SIZE ?= 32 #Object data size 
+KEY_PATTERN ?= R:R #Set:Get pattern
+RATIO ?= 1:10 #Set:Get ratio
+PORT ?= 7379 #Port for dicedb
+
 .PHONY: build test build-docker run test-one
 
 build:
@@ -23,3 +31,20 @@ unittest-one:
 
 build-docker:
 	docker build --tag dicedb/dice-server:latest --tag dicedb/dice-server:0.0.1 .
+
+run_benchmark:
+	@echo "Running memtier benchmark..."
+	memtier_benchmark \
+	 --threads=$(THREADS) \
+    --data-size=$(DATA_SIZE) \
+    --key-pattern=$(KEY_PATTERN) \
+    --clients=$(CLIENTS) \
+    --requests=$(REQUESTS) \
+	--port=$(PORT)
+	@echo "Benchmark complete."
+
+run-small-test:
+	run_benchmark THREADS=2 DATA_SIZE=512 CLIENTS=20 REQUESTS=5000
+
+run-large-test:
+	run_benchmark THREADS=8 DATA_SIZE=4096 CLIENTS=100 REQUESTS=50000


### PR DESCRIPTION
Issue: #140 

### Summary:
Added commands in makefile for running memtier benchmark and preset load tests

### Changes:
- Added run_benchmark command for running memtier benchmark
- Added run-small-test and run-large-test as preset load tests.