### PR TITLE
Added stubbed time for tests

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/core/bit"
 	"github.com/dicedb/dice/internal/constants"
+	"github.com/dicedb/dice/server/utils"
 	"github.com/ohler55/ojg/jp"
 )
 
@@ -170,7 +171,7 @@ func evalSET(args []string) []byte {
 			if arg == constants.Exat {
 				exDuration *= 1000
 			}
-			exDurationMs = exDuration - time.Now().UnixMilli()
+			exDurationMs = exDuration - utils.GetCurrentTime().UnixMilli()
 			// If the expiry time is in the past, set exDurationMs to 0
 			// This will be used to signal immediate expiration
 			if exDurationMs < 0 {
@@ -466,7 +467,7 @@ func evalTTL(args []string) []byte {
 
 	// compute the time remaining for the key to expire and
 	// return the RESP encoded form of it
-	durationMs := exp - uint64(time.Now().UnixMilli())
+	durationMs := exp - uint64(utils.GetCurrentTime().UnixMilli())
 
 	return Encode(int64(durationMs/1000), false)
 }
@@ -1829,7 +1830,7 @@ func evalCOPY(args []string) []byte {
 	exp, ok := getExpiry(sourceObj)
 	var exDurationMs int64 = -1
 	if ok {
-		exDurationMs = int64(exp - uint64(time.Now().UnixMilli()))
+		exDurationMs = int64(exp - uint64(utils.GetCurrentTime().UnixMilli()))
 	}
 
 	Put(destinationKey, copyObj)
@@ -1917,7 +1918,7 @@ func evalGETEX(args []string) []byte {
 			if arg == constants.Exat {
 				exDuration *= 1000
 			}
-			exDurationMs = exDuration - time.Now().UnixMilli()
+			exDurationMs = exDuration - utils.GetCurrentTime().UnixMilli()
 			// If the expiry time is in the past, set exDurationMs to 0
 			// This will be used to signal immediate expiration
 			if exDurationMs < 0 {
@@ -1975,7 +1976,7 @@ func evalPTTL(args []string) []byte {
 
 	// compute the time remaining for the key to expire and
 	// return the RESP encoded form of it
-	durationMs := exp - uint64(time.Now().UnixMilli())
+	durationMs := exp - uint64(utils.GetCurrentTime().UnixMilli())
 	return Encode(int64(durationMs), false)
 }
 

--- a/core/eviction.go
+++ b/core/eviction.go
@@ -1,9 +1,8 @@
 package core
 
 import (
-	"time"
-
 	"github.com/dicedb/dice/config"
+	"github.com/dicedb/dice/server/utils"
 )
 
 // Evicts the first key it found while iterating the map
@@ -38,7 +37,7 @@ func evictAllkeysRandom() {
  *  The approximated LRU algorithm
  */
 func getCurrentClock() uint32 {
-	return uint32(time.Now().Unix()) & 0x00FFFFFF
+	return uint32(utils.GetCurrentTime().Unix()) & 0x00FFFFFF
 }
 
 func getIdleTime(lastAccessedAt uint32) uint32 {

--- a/core/expire.go
+++ b/core/expire.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"time"
 	"unsafe"
+
+	"github.com/dicedb/dice/server/utils"
 )
 
 func hasExpired(obj *Obj) bool {
@@ -10,7 +11,7 @@ func hasExpired(obj *Obj) bool {
 	if !ok {
 		return false
 	}
-	return exp <= uint64(time.Now().UnixMilli())
+	return exp <= uint64(utils.GetCurrentTime().UnixMilli())
 }
 
 func getExpiry(obj *Obj) (uint64, bool) {

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/core"
+	"github.com/dicedb/dice/server/utils"
 	"github.com/dicedb/dice/testutils"
 	"gotest.tools/v3/assert"
 )
@@ -90,19 +91,23 @@ func TestRemoveMultipleNonExpiredKeys(t *testing.T) {
 
 // Test for removing from queue with expired keys before non-expired
 func TestRemoveExpiredBeforeNonExpire(t *testing.T) {
+	mockTime := &utils.MockClock{CurrTime: time.Now()}
+	utils.CurrentTime = mockTime
 	qr := core.NewQueueRef()
 	val := [3]int{10, 20}
 	core.Put("key1", core.NewObj(val[0], 1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key1")
 	core.Put("key2", core.NewObj(val[1], -1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key2")
-	time.Sleep(2 * time.Millisecond)
+	mockTime.SetTime(time.Now().Add(2 * time.Millisecond))
 	qe, err := qr.Remove()
 	assert.Check(t, err == nil || qe.Obj.Value == val[1], fmt.Sprintf("test for removing expired key before non-expired failed , Expected : %d, Got : %d\n", val[1], qe.Obj.Value))
 }
 
 // Test for removing from queue with multiple expired keys before non-expired
 func TestRemoveMultipleExpiredBeforeNonExpire(t *testing.T) {
+	mockTime := &utils.MockClock{CurrTime: time.Now()}
+	utils.CurrentTime = mockTime
 	qr := core.NewQueueRef()
 	val := [3]int{10, 20, 30}
 	core.Put("key1", core.NewObj(val[0], 1, core.ObjTypeString, core.ObjEncodingInt))
@@ -111,7 +116,7 @@ func TestRemoveMultipleExpiredBeforeNonExpire(t *testing.T) {
 	qr.Insert("key2")
 	core.Put("key3", core.NewObj(val[2], -1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key3")
-	time.Sleep(2 * time.Millisecond)
+	mockTime.SetTime(time.Now().Add(2 * time.Millisecond))
 	fmt.Printf("Queue size : %d\n", qr.Length())
 	qe, err := qr.Remove()
 	assert.Check(t, err == nil || qe.Obj.Value == val[2], fmt.Sprintf("test for removing mulitple expired key before non-expired failed , Expected : %d, Got %d\n", val[2], qe.Obj.Value))
@@ -119,6 +124,8 @@ func TestRemoveMultipleExpiredBeforeNonExpire(t *testing.T) {
 
 // Test for removing from queue with all expired keys
 func TestRemoveAllExpired(t *testing.T) {
+	mockTime := &utils.MockClock{CurrTime: time.Now()}
+	utils.CurrentTime = mockTime
 	qr := core.NewQueueRef()
 	val := [3]int{10, 20, 30}
 	core.Put("key1", core.NewObj(val[0], 1, core.ObjTypeString, core.ObjEncodingInt))
@@ -127,7 +134,7 @@ func TestRemoveAllExpired(t *testing.T) {
 	qr.Insert("key2")
 	core.Put("key3", core.NewObj(val[2], 1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key3")
-	time.Sleep(2 * time.Millisecond)
+	mockTime.SetTime(time.Now().Add(2 * time.Millisecond))
 	// remove from empty queue
 	_, err := qr.Remove()
 	assert.Equal(t, err, core.ErrQueueEmpty, fmt.Sprintf("test for removing from empty queue failed Expected : %s, Got : %s\n", core.ErrQueueEmpty, err))
@@ -139,6 +146,9 @@ func BenchmarkQueueRef(b *testing.B) {
 }
 
 func benchmarkQueueRefInsertAndRemove(b *testing.B) {
+	mockTime := &utils.MockClock{CurrTime: time.Now()}
+	utils.CurrentTime = mockTime
+
 	qr := core.NewQueueRef()
 	expiredCount := b.N / 2
 	nonExpiredCount := b.N
@@ -162,7 +172,7 @@ func benchmarkQueueRefInsertAndRemove(b *testing.B) {
 
 	b.StopTimer()
 	// Allow expired keys to expire
-	time.Sleep(2 * time.Millisecond)
+	mockTime.SetTime(time.Now().Add(2 * time.Millisecond))
 	b.StartTimer()
 
 	// Remove only non-expired number of keys (expired keys will be auto-removed)

--- a/core/session.go
+++ b/core/session.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/internal/constants"
+	"github.com/dicedb/dice/server/utils"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -88,10 +89,10 @@ func (user *User) SetPassword(password string) (err error) {
 
 func NewSession() (session *Session) {
 	session = &Session{
-		ID: uint64(time.Now().UTC().Unix()),
+		ID: uint64(utils.GetCurrentTime().UTC().Unix()),
 
-		CreatedAt:      time.Now(),
-		LastAccessedAt: time.Now(),
+		CreatedAt:      utils.GetCurrentTime(),
+		LastAccessedAt: utils.GetCurrentTime(),
 
 		Status: SessionStatusPending,
 	}
@@ -104,7 +105,7 @@ func (session *Session) IsActive() (isActive bool) {
 	}
 	isActive = session.Status == SessionStatusActive
 	if isActive {
-		session.LastAccessedAt = time.Now().UTC()
+		session.LastAccessedAt = utils.GetCurrentTime().UTC()
 	}
 	return
 }
@@ -112,8 +113,8 @@ func (session *Session) IsActive() (isActive bool) {
 func (session *Session) Activate(user *User) {
 	session.User = user
 	session.Status = SessionStatusActive
-	session.CreatedAt = time.Now().UTC()
-	session.LastAccessedAt = time.Now().UTC()
+	session.CreatedAt = utils.GetCurrentTime().UTC()
+	session.LastAccessedAt = utils.GetCurrentTime().UTC()
 }
 
 func (session *Session) Validate(username, password string) error {

--- a/core/session_test.go
+++ b/core/session_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/internal/constants"
+	"github.com/dicedb/dice/server/utils"
 )
 
 func TestNewUsers(t *testing.T) {
@@ -80,6 +81,9 @@ func TestNewSession(t *testing.T) {
 }
 
 func TestSessionIsActive(t *testing.T) {
+	mockTime := &utils.MockClock{CurrTime: time.Now()}
+	utils.CurrentTime = mockTime
+
 	config.RequirePass = "testpassword"
 	session := NewSession()
 	if session.IsActive() {
@@ -92,7 +96,8 @@ func TestSessionIsActive(t *testing.T) {
 	}
 
 	oldLastAccessed := session.LastAccessedAt
-	time.Sleep(time.Millisecond) // Ensure some time passes
+	mockTime.SetTime(time.Now().Add(time.Duration(5 * time.Millisecond)))
+
 	session.IsActive()
 	if !session.LastAccessedAt.After(oldLastAccessed) {
 		t.Error("IsActive() should update LastAccessedAt")

--- a/core/store.go
+++ b/core/store.go
@@ -3,10 +3,10 @@ package core
 import (
 	"path"
 	"sync"
-	"time"
 	"unsafe"
 
 	"github.com/dicedb/dice/config"
+	"github.com/dicedb/dice/server/utils"
 )
 
 type WatchEvent struct {
@@ -304,7 +304,7 @@ func GetDel(k string) *Obj {
 // setExpiry sets the expiry time for an object.
 // This method is not thread-safe. It should be called within a lock.
 func setExpiry(obj *Obj, expDurationMs int64) {
-	expires[obj] = uint64(time.Now().UnixMilli()) + uint64(expDurationMs)
+	expires[obj] = uint64(utils.GetCurrentTime().UnixMilli()) + uint64(expDurationMs)
 }
 
 // Helper function to count clients

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -14,10 +14,11 @@ import (
 	"github.com/dicedb/dice/core"
 	"github.com/dicedb/dice/core/iomultiplexer"
 	"github.com/dicedb/dice/internal/constants"
+	"github.com/dicedb/dice/server/utils"
 )
 
 var cronFrequency time.Duration = 1 * time.Second
-var lastCronExecTime time.Time = time.Now()
+var lastCronExecTime time.Time = utils.GetCurrentTime()
 
 const EngineStatusWAITING int32 = 1 << 1
 const EngineStatusBUSY int32 = 1 << 2
@@ -181,7 +182,7 @@ func RunAsyncTCPServer(serverFD int, wg *sync.WaitGroup) {
 	for atomic.LoadInt32(&eStatus) != EngineStatusSHUTTINGDOWN {
 		if time.Now().After(lastCronExecTime.Add(cronFrequency)) {
 			core.DeleteExpiredKeys()
-			lastCronExecTime = time.Now()
+			lastCronExecTime = utils.GetCurrentTime()
 		}
 
 		// Say, the Engine triggered SHUTTING down when the control flow is here ->

--- a/server/utils/time.go
+++ b/server/utils/time.go
@@ -1,0 +1,33 @@
+package utils
+
+import "time"
+
+type (
+	Clock interface {
+		Now() time.Time
+	}
+	RealClock struct{}
+	MockClock struct {
+		CurrTime time.Time
+	}
+)
+
+var (
+	CurrentTime Clock = RealClock{}
+)
+
+func (RealClock) Now() time.Time {
+	return time.Now()
+}
+
+func (mc MockClock) Now() time.Time {
+	return mc.CurrTime
+}
+
+func (mc *MockClock) SetTime(t time.Time) {
+	mc.CurrTime = t
+}
+
+func GetCurrentTime() time.Time {
+	return CurrentTime.Now()
+}


### PR DESCRIPTION
The PR introduces an abstraction around the `time.Now()` method to allow different treatment of the variable based on the environment `GetCurrentTime()` is used in.
Using the `MockClock`, tests would be able to progress the time manually without having to actually having to sleep for the duration.
This would speed up the tests which are currently relying on the time.Sleep functionality. 