### PR TITLE
#284: Add support for command `EXPIRETIME`

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -125,6 +125,14 @@ var (
 		Arity:    -3,
 		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
+	expiretimeCmdMeta = DiceCmdMeta{
+		Name: "EXPIRETIME",
+		Info: `EXPIRETIME returns the absolute Unix timestamp (since January 1, 1970) in seconds 
+		at which the given key will expire`,
+		Eval:     evalEXPIRETIME,
+		Arity:    -2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
+	}
 	helloCmdMeta = DiceCmdMeta{
 		Name:  "HELLO",
 		Info:  `HELLO always replies with a list of current server and connection properties, such as: versions, modules loaded, client ID, replication role and so forth`,
@@ -565,6 +573,7 @@ func init() {
 	diceCmds["TTL"] = ttlCmdMeta
 	diceCmds["DEL"] = delCmdMeta
 	diceCmds["EXPIRE"] = expireCmdMeta
+	diceCmds["EXPIRETIME"] = expiretimeCmdMeta
 	diceCmds["HELLO"] = helloCmdMeta
 	diceCmds["BGREWRITEAOF"] = bgrewriteaofCmdMeta
 	diceCmds["INCR"] = incrCmdMeta

--- a/core/commands.go
+++ b/core/commands.go
@@ -125,14 +125,6 @@ var (
 		Arity:    -3,
 		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
-	expiretimeCmdMeta = DiceCmdMeta{
-		Name: "EXPIRETIME",
-		Info: `EXPIRETIME returns the absolute Unix timestamp (since January 1, 1970) in seconds 
-		at which the given key will expire`,
-		Eval:     evalEXPIRETIME,
-		Arity:    -2,
-		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
-	}
 	helloCmdMeta = DiceCmdMeta{
 		Name:  "HELLO",
 		Info:  `HELLO always replies with a list of current server and connection properties, such as: versions, modules loaded, client ID, replication role and so forth`,
@@ -559,6 +551,14 @@ var (
 		Eval:     evalTOUCH,
 		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
+	expiretimeCmdMeta = DiceCmdMeta{
+		Name: "EXPIRETIME",
+		Info: `EXPIRETIME returns the absolute Unix timestamp (since January 1, 1970) in seconds 
+		at which the given key will expire`,
+		Eval:     evalEXPIRETIME,
+		Arity:    -2,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
 )
 

--- a/core/eval.go
+++ b/core/eval.go
@@ -540,7 +540,7 @@ func evalEXPIRETIME(args []string) []byte {
 		return RespMinusOne
 	}
 
-	return Encode(int(exTimeMili/1000), true)
+	return Encode(int(exTimeMili/1000), false)
 }
 
 func evalHELLO(args []string) []byte {

--- a/core/eval.go
+++ b/core/eval.go
@@ -515,6 +515,34 @@ func evalEXPIRE(args []string) []byte {
 	return RespOne
 }
 
+// evalEXPIRETIME returns the absolute Unix timestamp (since January 1, 1970) in seconds at which the given key will expire
+// args should contain only 1 value, the key
+// Returns expiration Unix timestamp in seconds.
+// Returns -1 if the key exists but has no associated expiration time.
+// Returns -2 if the key does not exist.
+func evalEXPIRETIME(args []string) []byte {
+	if len(args) != 1 {
+		return Encode(errors.New("ERR wrong number of arguments for 'expire' command"), false)
+	}
+
+	var key string = args[0]
+
+	obj := Get(key)
+
+	// -2 if key doesn't exist
+	if obj == nil {
+		return RespMinusTwo
+	}
+
+	exTimeMili, ok := getExpiry(obj)
+	// -1 if key doesn't have expiration time set
+	if !ok {
+		return RespMinusOne
+	}
+
+	return Encode(int(exTimeMili/1000), true)
+}
+
 func evalHELLO(args []string) []byte {
 	if len(args) > 1 {
 		return Encode(errors.New("ERR wrong number of arguments for 'hello' command"), false)

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -38,16 +38,17 @@ func setupTest() {
 
 func TestEval(t *testing.T) {
 	testCases := map[string]func(*testing.T){
-		"MSET":    testEvalMSET,
-		"PING":    testEvalPING,
-		"HELLO":   testEvalHELLO,
-		"SET":     testEvalSET,
-		"GET":     testEvalGET,
-		"JSONGET": testEvalJSONGET,
-		"JSONSET": testEvalJSONSET,
-		"TTL":     testEvalTTL,
-		"DEL":     testEvalDel,
-		"PERSIST": TestEvalPersist,
+		"MSET":       testEvalMSET,
+		"PING":       testEvalPING,
+		"HELLO":      testEvalHELLO,
+		"SET":        testEvalSET,
+		"GET":        testEvalGET,
+		"JSONGET":    testEvalJSONGET,
+		"JSONSET":    testEvalJSONSET,
+		"TTL":        testEvalTTL,
+		"DEL":        testEvalDel,
+		"PERSIST":    TestEvalPersist,
+		"EXPIRETIME": testEvalEXPIRETIME,
 	}
 
 	for name, testFunc := range testCases {
@@ -175,6 +176,32 @@ func testEvalGET(t *testing.T) {
 	}
 
 	runEvalTests(t, tests, evalGET)
+}
+
+func testEvalEXPIRETIME(t *testing.T) {
+	tests := map[string]evalTestCase{
+		"key does not exist": {
+			setup:  func() {},
+			input:  []string{"NONEXISTENT_KEY"},
+			output: RespMinusTwo,
+		},
+		"key exists without expary": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+			},
+			input:  []string{"EXISTING_KEY"},
+			output: RespMinusOne,
+		},
+	}
+
+	runEvalTests(t, tests, evalEXPIRETIME)
 }
 
 func testEvalJSONGET(t *testing.T) {


### PR DESCRIPTION
PR to address: Support for command `EXPIRETIME`
Link to [issue](https://github.com/DiceDB/dice/issues/284)

* EXPIRETIME returns the absolute Unix timestamp (since January 1, 1970) in seconds at which the given key will expire
* args should contain only 1 value, the key
* Returns expiration Unix timestamp in seconds.
* Returns -1 if the key exists but has no associated expiration time.
* Returns -2 if the key does not exist.

