### PR TITLE
#278: Add support for command `DBSIZE`

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -584,6 +584,12 @@ var (
 		Eval:  evalRPOP,
 		Arity: 2,
 	}
+	dbSizeCmdMeta = DiceCmdMeta{
+		Name:  "DBSIZE",
+		Info:  `DBSIZE Return the number of keys in the database`,
+		Eval:  evalDBSIZE,
+		Arity: 1,
+	}
 )
 
 func init() {
@@ -654,4 +660,5 @@ func init() {
 	diceCmds["RPOP"] = rpopCmdMeta
 	diceCmds["RPUSH"] = rpushCmdMeta
 	diceCmds["LPOP"] = lpopCmdMeta
+	diceCmds["DBSIZE"] = dbSizeCmdMeta
 }

--- a/core/eval.go
+++ b/core/eval.go
@@ -253,6 +253,16 @@ func evalGET(args []string) []byte {
 	return Encode(obj.Value, false)
 }
 
+// evalDBSIZE returns the number of keys in the database.
+func evalDBSIZE(args []string) []byte {
+	if len(args) > 0 {
+		return Encode(errors.New("ERR wrong number of arguments for 'DBSIZE' command"), false)
+	}
+
+	// return the RESP encoded value
+	return Encode(GetDBSize(), false)
+}
+
 // evalGETDEL returns the value for the queried key in args
 // The key should be the only param in args
 // The RESP value of the key is encoded and then returned

--- a/core/resp.go
+++ b/core/resp.go
@@ -145,7 +145,7 @@ func Encode(value interface{}, isSimple bool) []byte {
 			return []byte(fmt.Sprintf("+%s\r\n", v))
 		}
 		return encodeString(v)
-	case int, int8, int16, int32, int64:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return []byte(fmt.Sprintf(":%d\r\n", v))
 	case []string:
 		var b []byte

--- a/core/store.go
+++ b/core/store.go
@@ -183,6 +183,15 @@ func Keys(p string) ([]string, error) {
 	return keys, err
 }
 
+// GetDbSize returns number of keys present in the database
+func GetDBSize() uint64 {
+	var noOfKeys uint64
+	withLocks(func() {
+		noOfKeys = uint64(len(keypool))
+	}, WithKeypoolRLock())
+	return noOfKeys
+}
+
 // Function to add a new watcher to a query.
 func AddWatcher(query DSQLQuery, clientFd int) { //nolint:gocritic
 	clients, _ := WatchList.LoadOrStore(query, &sync.Map{})


### PR DESCRIPTION
support for command `DBSIZE`

Link to [issue](https://github.com/DiceDB/dice/issues/278)

* Return the number of keys in the database.

![image](https://github.com/user-attachments/assets/67669cce-c35f-4608-9157-54a7e7a60b56)
