### PR TITLE
AUTH error message made consistent with Redis

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -29,7 +29,6 @@ const (
 
 var RespNIL []byte = []byte("$-1\r\n")
 var RespOK []byte = []byte("+OK\r\n")
-var RespAuthFailure []byte = []byte("+NOAUTH\r\n")
 var RespQueued []byte = []byte("+QUEUED\r\n")
 var RespZero []byte = []byte(":0\r\n")
 var RespOne []byte = []byte(":1\r\n")
@@ -1734,7 +1733,7 @@ func EvalAndRespond(cmds RedisCmds, c *Client) {
 	for _, cmd := range cmds {
 		// Check if the command has been authenticated
 		if cmd.Cmd != AuthCmd && !c.Session.IsActive() {
-			if _, err := c.Write(RespAuthFailure); err != nil {
+			if _, err := c.Write(Encode(errors.New("NOAUTH Authentication required."), false)); err != nil {
 				log.Println("Error writing to client:", err)
 			}
 			continue

--- a/core/eval.go
+++ b/core/eval.go
@@ -1733,7 +1733,7 @@ func EvalAndRespond(cmds RedisCmds, c *Client) {
 	for _, cmd := range cmds {
 		// Check if the command has been authenticated
 		if cmd.Cmd != AuthCmd && !c.Session.IsActive() {
-			if _, err := c.Write(Encode(errors.New("NOAUTH Authentication required."), false)); err != nil {
+			if _, err := c.Write(Encode(errors.New("NOAUTH Authentication required"), false)); err != nil {
 				log.Println("Error writing to client:", err)
 			}
 			continue

--- a/core/session.go
+++ b/core/session.go
@@ -136,7 +136,7 @@ func (session *Session) Validate(username, password string) error {
 		session.Activate(user)
 		return nil
 	}
-	return fmt.Errorf("WRONGPASS invalid username-password pair or user is disabled.")
+	return fmt.Errorf("WRONGPASS invalid username-password pair or user is disabled")
 }
 
 func (session *Session) Expire() (err error) {

--- a/core/session.go
+++ b/core/session.go
@@ -136,7 +136,7 @@ func (session *Session) Validate(username, password string) error {
 		session.Activate(user)
 		return nil
 	}
-	return fmt.Errorf("ERR invalid password")
+	return fmt.Errorf("WRONGPASS invalid username-password pair or user is disabled.")
 }
 
 func (session *Session) Expire() (err error) {


### PR DESCRIPTION
The error messages for AUTH command were inconsistent to what Redis outputs. Made them consistent now.