### PR TITLE
Improves JSON WHERE clause evaluation performance

### DIFF
--- a/core/dsql.go
+++ b/core/dsql.go
@@ -13,8 +13,9 @@ import (
 const (
 	CustomKey   = "$key"
 	CustomValue = "$value"
-	TempKey     = "_key"
-	TempValue   = "_value"
+	TempPrefix  = "_"
+	TempKey     = TempPrefix + "key"
+	TempValue   = TempPrefix + "value"
 )
 
 // Error definitions

--- a/core/executor.go
+++ b/core/executor.go
@@ -327,7 +327,7 @@ func inferTypeAndConvert(val interface{}) (value interface{}, valueType string, 
 //
 // However, the string conversion is expensive and we are trying to avoid it. We can assume this to be a limitation of
 // using the JSON data type.
-// TODO: handle the edge case where the integer is too large to fit in an int.
+// TODO: handle the edge case where the integer is too large for float64.
 func isInteger(f float64) bool {
 	return f == float64(int(f))
 }

--- a/core/executor.go
+++ b/core/executor.go
@@ -14,6 +14,7 @@ import (
 )
 
 var ErrNoResultsFound = errors.New("ERR No results found")
+var ErrInvalidJSONPath = errors.New("ERR invalid JSONPath")
 
 type DSQLQueryResultRow struct {
 	Key   string
@@ -35,7 +36,7 @@ func ExecuteQuery(query DSQLQuery) ([]DSQLQueryResultRow, error) {
 
 				if query.Where != nil {
 					match, evalErr := evaluateWhereClause(query.Where, row)
-					if evalErr == ErrNoResultsFound {
+					if errors.Is(evalErr, ErrNoResultsFound) {
 						continue
 					}
 					if evalErr != nil {
@@ -47,15 +48,8 @@ func ExecuteQuery(query DSQLQuery) ([]DSQLQueryResultRow, error) {
 					}
 				}
 
-				// if the row contains JSON field then convert the json object into string representation so it can be encoded
-				// before being returned to the client
-				if getEncoding(row.Value.TypeEncoding) == ObjEncodingJSON && getType(row.Value.TypeEncoding) == ObjTypeJSON {
-					marshaledData, err := sonic.Marshal(row.Value.Value)
-					if err != nil {
-						return
-					}
-
-					row.Value.Value = string(marshaledData)
+				if err := MarshalResultIfJSON(row); err != nil {
+					return
 				}
 
 				result = append(result, row)
@@ -86,6 +80,20 @@ func ExecuteQuery(query DSQLQuery) ([]DSQLQueryResultRow, error) {
 	}
 
 	return result, nil
+}
+
+func MarshalResultIfJSON(row DSQLQueryResultRow) error {
+	// if the row contains JSON field then convert the json object into string representation so it can be encoded
+	// before being returned to the client
+	if getEncoding(row.Value.TypeEncoding) == ObjEncodingJSON && getType(row.Value.TypeEncoding) == ObjTypeJSON {
+		marshaledData, err := sonic.MarshalString(row.Value.Value)
+		if err != nil {
+			return err
+		}
+
+		row.Value.Value = marshaledData
+	}
+	return nil
 }
 
 //nolint:gocritic
@@ -226,77 +234,105 @@ func evaluateComparison(expr *sqlparser.ComparisonExpr, row DSQLQueryResultRow) 
 	}
 }
 
-func getExprValueAndType(expr sqlparser.Expr, row DSQLQueryResultRow) (i interface{}, s string, e error) {
+func getExprValueAndType(expr sqlparser.Expr, row DSQLQueryResultRow) (interface{}, string, error) {
 	switch expr := expr.(type) {
 	case *sqlparser.ColName:
 		switch expr.Name.String() {
 		case TempKey:
-			return row.Key, constants.String, nil
+			return row.Key, "string", nil
 		case TempValue:
 			return getValueAndType(row.Value)
 		default:
-			return nil, constants.EmptyStr, fmt.Errorf("unknown column: %s", expr.Name.String())
+			return nil, "", fmt.Errorf("unknown column: %s", expr.Name.String())
 		}
 	case *sqlparser.SQLVal:
-		// we currently treat JSON query expression as a string value so we will need to differentiate between JSON and SQL strings
-		// We convert the $key and $value fields to _key, _value before querying. hence fields starting with _ are considered to be stored values
-		if expr.Type == sqlparser.StrVal && strings.HasPrefix(string(expr.Val), "_") && getEncoding(row.Value.TypeEncoding) == ObjEncodingJSON && getType(row.Value.TypeEncoding) == ObjTypeJSON {
-			value, valueType, err := retrieveValueFromJSON(string(expr.Val), row.Value)
-			if err != nil {
-				return nil, "", err
-			}
-
-			return value, valueType, nil
+		// we currently treat JSON query expression as a string value so we will need to differentiate between JSON and
+		// SQL strings
+		if isJSONField(expr, row.Value) {
+			return retrieveValueFromJSON(string(expr.Val), row.Value)
 		}
-		return sqlValToGoValue(expr)
+		return sqlValToGoValue(expr, row.Value)
 	default:
-		return nil, constants.EmptyStr, fmt.Errorf("unsupported expression type: %T", expr)
+		return nil, "", fmt.Errorf("unsupported expression type: %T", expr)
 	}
 }
 
-func retrieveValueFromJSON(path string, jsonData *Obj) (value interface{}, valueType string, err error) {
-	// path is in the format '$value.field1.field2'. we will remove the reference to the value object to get the json path
-	jsonPath := strings.Split(path, ".")
-
-	if len(jsonPath) == 1 {
-		return nil, "", errors.New("ERR invalid JSONPath")
+func isJSONField(expr *sqlparser.SQLVal, obj *Obj) bool {
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingJSON); err != nil {
+		return false
 	}
 
-	path = strings.Join(jsonPath[1:], ".")
+	if err := assertType(obj.TypeEncoding, ObjTypeJSON); err != nil {
+		return false
+	}
 
+	// We convert the $key and $value fields to _key, _value before querying. hence fields starting with _ are
+	//considered to be stored values
+	return expr.Type == sqlparser.StrVal &&
+		strings.HasPrefix(string(expr.Val), TempPrefix)
+}
+
+func retrieveValueFromJSON(path string, jsonData *Obj) (interface{}, string, error) {
+	// path is in the format '_value.field1.field2'. We need to remove _value reference from the prefix to get the json
+	//path.
+	jsonPath := strings.Split(path, ".")
+	if len(jsonPath) < 2 {
+		return nil, "", ErrInvalidJSONPath
+	}
+
+	path = "$." + strings.Join(jsonPath[1:], ".")
 	expr, err := jp.ParseString(path)
 	if err != nil {
-		return nil, "", errors.New("ERR invalid JSONPath")
+		return nil, "", ErrInvalidJSONPath
 	}
 
 	results := expr.Get(jsonData.Value)
-
 	if len(results) == 0 {
 		return nil, "", ErrNoResultsFound
 	}
 
-	// currently the only data types we support are integers, strings and floats
-	switch val := results[0].(type) {
-	case string:
-		return val, "string", nil
-	case float64:
-		// convert float64 into a string to differentiate between floats and integers
-		// When we unmarshal JSON data into an interface it sets all numbers as floats
-		// https://forum.golangbridge.org/t/type-problem-in-json-conversion/19420
-		// the only edge case is where user enters a floating point number with
-		// trailing zeros in the fractional part of a decimal number (e.g 10.0)
-		// then our code treats that as an integer rather than float
-		floatStr := strconv.FormatFloat(val, 'f', -1, 64)
-		if strings.Contains(floatStr, ".") {
-			return val, "float", nil
-		}
+	return inferTypeAndConvert(results[0])
+}
 
-		return int(val), "int", nil
+// inferTypeAndConvert infers the type of the value and converts it to the appropriate type. currently the only data
+// types we support are strings, floats, ints, booleans and nil.
+func inferTypeAndConvert(val interface{}) (interface{}, string, error) {
+	switch v := val.(type) {
+	case string:
+		return v, constants.String, nil
+	case float64:
+		if isInteger(v) {
+			return int(v), constants.Int, nil
+		}
+		return v, constants.Float, nil
+	case bool:
+		return v, constants.Bool, nil
+	case nil:
+		return nil, constants.Nil, nil
 	default:
-		return nil, "", fmt.Errorf("unsupported JSONPath result type: %T", results[0])
+		return nil, constants.EmptyStr, fmt.Errorf("unsupported JSONPath result type: %T", v)
 	}
 }
 
+// isInteger checks if a float is an integer. When we unmarshal JSON data into an interface it sets all numbers as
+// floats, https://forum.golangbridge.org/t/type-problem-in-json-conversion/19420.
+// This function does not handle the edge case where user enters a floating point number with trailing zeros in the
+// fractional part of a decimal number (e.g 10.0) then our code treats that as an integer rather than float.
+// One way to solve this is as follows (credit https://github.com/YahyaHaq):
+// floatStr := strconv.FormatFloat(val, 'f', -1, 64)
+// if strings.Contains(floatStr, ".") {
+// return val, "float", nil
+// }
+// return int(val), "int", nil
+//
+// However, the string conversion is expensive and we are trying to avoid it. We can assume this to be a limitation of
+// using the JSON data type.
+// TODO: handle the edge case where the integer is too large to fit in an int.
+func isInteger(f float64) bool {
+	return f == float64(int(f))
+}
+
+// getValueAndType returns the type-casted value and type of the object
 func getValueAndType(obj *Obj) (val interface{}, s string, e error) {
 	switch v := obj.Value.(type) {
 	case string:
@@ -310,7 +346,8 @@ func getValueAndType(obj *Obj) (val interface{}, s string, e error) {
 	}
 }
 
-func sqlValToGoValue(sqlVal *sqlparser.SQLVal) (val interface{}, s string, e error) {
+// sqlValToGoValue converts SQLVal to Go value, and returns the type of the value.
+func sqlValToGoValue(sqlVal *sqlparser.SQLVal, obj *Obj) (val interface{}, s string, e error) {
 	switch sqlVal.Type {
 	case sqlparser.StrVal:
 		return string(sqlVal.Val), constants.String, nil

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -1,7 +1,6 @@
 package core_test
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
@@ -396,6 +395,7 @@ var JsonDataset = []keyValue{
 }
 
 func setupJSON(t *testing.T) {
+	t.Helper()
 	for _, data := range JsonDataset {
 		core.Del(data.key)
 	}
@@ -432,8 +432,11 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 results for WHERE clause")
 		assert.Equal(t, result[0].Key, "json1")
-		fmt.Println("my values:", result[0].Value.Value)
-		assert.DeepEqual(t, result[0].Value.Value, `{"name":"Tom"}`)
+
+		var expected, actual interface{}
+		assert.NilError(t, sonic.UnmarshalString(`{"name":"Tom"}`, &expected))
+		assert.NilError(t, sonic.UnmarshalString(result[0].Value.Value.(string), &actual))
+		assert.DeepEqual(t, actual, expected)
 	})
 
 	t.Run("EmptyResult", func(t *testing.T) {
@@ -475,7 +478,11 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with floating point values")
 		assert.Equal(t, result[0].Key, "json2")
-		assert.DeepEqual(t, result[0].Value.Value, `{"name":"Bob","score":18.1}`)
+
+		var expected, actual interface{}
+		assert.NilError(t, sonic.UnmarshalString(`{"name":"Bob","score":18.1}`, &expected))
+		assert.NilError(t, sonic.UnmarshalString(result[0].Value.Value.(string), &actual))
+		assert.DeepEqual(t, actual, expected)
 	})
 
 	t.Run("WhereClauseWithInteger", func(t *testing.T) {
@@ -497,7 +504,11 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with integer values")
 		assert.Equal(t, result[0].Key, "json3")
-		assert.DeepEqual(t, result[0].Value.Value, `{"scoreInt":20}`)
+
+		var expected, actual interface{}
+		assert.NilError(t, sonic.UnmarshalString(`{"scoreInt":20}`, &expected))
+		assert.NilError(t, sonic.UnmarshalString(result[0].Value.Value.(string), &actual))
+		assert.DeepEqual(t, actual, expected)
 	})
 
 	t.Run("NestedWhereClause", func(t *testing.T) {
@@ -519,7 +530,11 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with nested json")
 		assert.Equal(t, result[0].Key, "json4")
-		assert.DeepEqual(t, result[0].Value.Value, `{"field1":{"field2":{"field3":{"score":2}}}}`)
+
+		var expected, actual interface{}
+		assert.NilError(t, sonic.UnmarshalString(`{"field1":{"field2":{"field3":{"score":2}}}}`, &expected))
+		assert.NilError(t, sonic.UnmarshalString(result[0].Value.Value.(string), &actual))
+		assert.DeepEqual(t, actual, expected)
 	})
 
 	t.Run("ComplexWhereClause", func(t *testing.T) {
@@ -541,7 +556,10 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for Complex WHERE clause expression")
 		assert.Equal(t, result[0].Key, "json5")
-		assert.DeepEqual(t, result[0].Value.Value, `{"field1":{"field2":{"field3":{"score":18}},"score2":5}}`)
-	})
 
+		var expected, actual interface{}
+		assert.NilError(t, sonic.UnmarshalString(`{"field1":{"field2":{"field3":{"score":18}},"score2":5}}`, &expected))
+		assert.NilError(t, sonic.UnmarshalString(result[0].Value.Value.(string), &actual))
+		assert.DeepEqual(t, actual, expected)
+	})
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -24,6 +24,8 @@ const (
 	String string = "string"
 	Int    string = "int"
 	Float  string = "float"
+	Bool   string = "bool"
+	Nil    string = "nil"
 
 	OperatorEquals              string = "="
 	OperatorNotEquals           string = "!="

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -240,7 +240,7 @@ func TestQwatchWithJSON(t *testing.T) {
 			assert.NilError(t, err)
 			update := v.([]interface{})
 
-			assert.Equal(t, len(expectedUpdate), len(update), "Update length mismatch")
+			assert.Equal(t, len(expectedUpdate), len(update), fmt.Sprintf("Expected update: %v, got %v", expectedUpdate, update))
 			assert.Equal(t, expectedUpdate[0].([]interface{})[0], update[0].([]interface{})[0], "Key mismatch")
 
 			var expectedJSON, actualJSON interface{}


### PR DESCRIPTION
## Improve JSON Handling in DSQL and QWATCH Tests

1. Improved type inference and conversion for JSON values, supporting boolean and null types.
2. Optimized the `isInteger` function to avoid expensive string conversions.
3. Added support for boolean and nil types in JSON fields.
4. Updated constant definitions to include boolean and null types.
5. To reduce flakiness, improve test assertions in both DSQL and QWATCH tests to compare actual JSON structures instead of string representations.