### PR TITLE
#283: Add support for command EXPIREAT

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -560,6 +560,17 @@ var (
 		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
 	}
+	expireatCmdMeta = DiceCmdMeta{
+		Name: "EXPIREAT",
+		Info: `EXPIREAT sets a expiry time(in unix-time-seconds) on the specified key in args
+		args should contain 2 values, key and the expiry time to be set for the key
+		The expiry time should be in integer format; if not, it returns encoded error response
+		Returns RespOne if expiry was set on the key successfully.
+		Once the time is lapsed, the key will be deleted automatically`,
+		Eval:     evalEXPIREAT,
+		Arity:    -3,
+		KeySpecs: KeySpecs{BeginIndex: 1, Step: 1},
+	}
 )
 
 func init() {
@@ -574,6 +585,7 @@ func init() {
 	diceCmds["DEL"] = delCmdMeta
 	diceCmds["EXPIRE"] = expireCmdMeta
 	diceCmds["EXPIRETIME"] = expiretimeCmdMeta
+	diceCmds["EXPIREAT"] = expireatCmdMeta
 	diceCmds["HELLO"] = helloCmdMeta
 	diceCmds["BGREWRITEAOF"] = bgrewriteaofCmdMeta
 	diceCmds["INCR"] = incrCmdMeta

--- a/core/eval.go
+++ b/core/eval.go
@@ -542,6 +542,35 @@ func evalEXPIRETIME(args []string) []byte {
 	return Encode(int(exTimeMili/1000), false)
 }
 
+// evalEXPIREAT sets a expiry time(in unix-time-seconds) on the specified key in args
+// args should contain 2 values, key and the expiry time to be set for the key
+// The expiry time should be in integer format; if not, it returns encoded error response
+// Returns RespOne if expiry was set on the key successfully.
+// Once the time is lapsed, the key will be deleted automatically
+func evalEXPIREAT(args []string) []byte {
+	if len(args) <= 1 {
+		return Encode(errors.New("ERR wrong number of arguments for 'expireat' command"), false)
+	}
+
+	var key string = args[0]
+	exUnixTimeSec, err := strconv.ParseInt(args[1], 10, 64)
+	if err != nil {
+		return Encode(errors.New("ERR value is not an integer or out of range"), false)
+	}
+
+	obj := Get(key)
+
+	// 0 if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments
+	if obj == nil {
+		return RespZero
+	}
+
+	setUnixTimeExpiry(obj, exUnixTimeSec)
+
+	// 1 if the timeout was set.
+	return RespOne
+}
+
 func evalHELLO(args []string) []byte {
 	if len(args) > 1 {
 		return Encode(errors.New("ERR wrong number of arguments for 'hello' command"), false)

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -50,6 +50,7 @@ func TestEval(t *testing.T) {
 		"DEL":        testEvalDel,
 		"PERSIST":    TestEvalPersist,
 		"EXPIRETIME": testEvalEXPIRETIME,
+		"EXPIREAT":   testEvalEXPIREAT,
 	}
 
 	for name, testFunc := range testCases {
@@ -221,6 +222,35 @@ func testEvalEXPIRETIME(t *testing.T) {
 	}
 
 	runEvalTests(t, tests, evalEXPIRETIME)
+}
+
+func testEvalEXPIREAT(t *testing.T) {
+	tests := map[string]evalTestCase{
+		"wrong number of args": {
+			input:  []string{"KEY1"},
+			output: []byte("-ERR wrong number of arguments for 'expireat' command\r\n"),
+		},
+		"key does not exist": {
+			input:  []string{"NONEXISTENT_KEY", "1723961346"},
+			output: RespZero,
+		},
+		"key exists": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store[unsafe.Pointer(obj)] = obj
+				keypool[key] = unsafe.Pointer(obj)
+			},
+			input:  []string{"EXISTING_KEY", "1723961346"},
+			output: RespOne,
+		},
+	}
+
+	runEvalTests(t, tests, evalEXPIREAT)
 }
 
 func testEvalJSONGET(t *testing.T) {

--- a/core/store.go
+++ b/core/store.go
@@ -307,6 +307,13 @@ func setExpiry(obj *Obj, expDurationMs int64) {
 	expires[obj] = uint64(utils.GetCurrentTime().UnixMilli()) + uint64(expDurationMs)
 }
 
+// setUnixTimeExpiry sets the expiry time for an object.
+// This method is not thread-safe. It should be called within a lock.
+func setUnixTimeExpiry(obj *Obj, exUnixTimeSec int64) {
+	// convert unix-time-seconds to unix-time-milliseconds
+	expires[obj] = uint64(exUnixTimeSec * 1000)
+}
+
 // Helper function to count clients
 func countClients(clients *sync.Map) int {
 	count := 0


### PR DESCRIPTION
PR to address: Support for command EXPIREAT
Link to https://github.com/DiceDB/dice/issues/283

EXPIREAT sets a expiry time(in unix-time-seconds) on the specified key in args
args should contain 2 values, key and the expiry time to be set for the key
The expiry time should be in integer format; if not, it returns encoded error response
Returns RespOne if expiry was set on the key successfully.
Once the time is lapsed, the key will be deleted automatically