### PR TITLE
#342: feat: add support for json.type command

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -101,7 +101,7 @@ var (
 		Returns RespNIL If the key doesn't exist.
 		Error reply: If the number of arguments is incorrect.`,
 		Eval:     evalJSONTYPE,
-		Arity:    -1,
+		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
 	ttlCmdMeta = DiceCmdMeta{

--- a/core/commands.go
+++ b/core/commands.go
@@ -94,6 +94,16 @@ var (
 		Arity:    2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	jsontypeCmdMeta = DiceCmdMeta{
+		Name: "JSON.TYPE",
+		Info: `JSON.TYPE key [path]
+		Returns string reply for each path, specified as the value's type.
+		Returns RespNIL If the key doesn't exist.
+		Error reply: If the number of arguments is incorrect.`,
+		Eval:     evalJSONTYPE,
+		Arity:    -1,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
 		Info: `TTL returns Time-to-Live in secs for the queried key in args
@@ -600,6 +610,7 @@ func init() {
 	diceCmds["MSET"] = msetCmdMeta
 	diceCmds["JSON.SET"] = jsonsetCmdMeta
 	diceCmds["JSON.GET"] = jsongetCmdMeta
+	diceCmds["JSON.TYPE"] = jsontypeCmdMeta
 	diceCmds["TTL"] = ttlCmdMeta
 	diceCmds["DEL"] = delCmdMeta
 	diceCmds["EXPIRE"] = expireCmdMeta

--- a/core/eval.go
+++ b/core/eval.go
@@ -309,6 +309,15 @@ func evalJSONTYPE(args []string) []byte {
 		return RespNIL
 	}
 
+	err := assertType(obj.TypeEncoding, ObjTypeJSON)
+	if err != nil {
+		return Encode(err, false)
+	}
+	err = assertEncoding(obj.TypeEncoding, ObjEncodingJSON)
+	if err != nil {
+		return Encode(err, false)
+	}
+
 	jsonData := obj.Value
 
 	// If path is root, return "object" instantly
@@ -317,7 +326,7 @@ func evalJSONTYPE(args []string) []byte {
 		if err != nil {
 			return Encode(errors.New("ERR could not serialize result"), false)
 		}
-		return Encode(utils.ObjectType, false)
+		return Encode(constants.ObjectType, false)
 	}
 
 	// Parse the JSONPath expression

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -32,4 +32,13 @@ const (
 	OperatorNotEqualsTo         string = "<>"
 	OperatorLessThanEqualsTo    string = "<="
 	OperatorGreaterThanEqualsTo string = ">="
+
+	ObjectType  string = "object"
+	ArrayType   string = "array"
+	StringType  string = "string"
+	IntegerType string = "integer"
+	NumberType  string = "number"
+	BooleanType string = "boolean"
+	NullType    string = "null"
+	UnknownType string = "unknown"
 )

--- a/server/utils/jsontype.go
+++ b/server/utils/jsontype.go
@@ -1,0 +1,33 @@
+package utils
+
+const (
+	ObjectType  string = "object"
+	ArrayType   string = "array"
+	StringType  string = "string"
+	IntegerType string = "integer"
+	NumberType  string = "number"
+	BooleanType string = "boolean"
+	NullType    string = "null"
+	UnknownType string = "unknown"
+)
+
+func GetJSONFieldType(v interface{}) string {
+	switch v.(type) {
+	case map[string]interface{}:
+		return ObjectType
+	case []interface{}:
+		return ArrayType
+	case string:
+		return StringType
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return IntegerType
+	case float32, float64:
+		return NumberType
+	case bool:
+		return BooleanType
+	case nil:
+		return NullType
+	default:
+		return UnknownType
+	}
+}

--- a/server/utils/jsontype.go
+++ b/server/utils/jsontype.go
@@ -1,33 +1,26 @@
 package utils
 
-const (
-	ObjectType  string = "object"
-	ArrayType   string = "array"
-	StringType  string = "string"
-	IntegerType string = "integer"
-	NumberType  string = "number"
-	BooleanType string = "boolean"
-	NullType    string = "null"
-	UnknownType string = "unknown"
+import (
+	"github.com/dicedb/dice/internal/constants"
 )
 
 func GetJSONFieldType(v interface{}) string {
 	switch v.(type) {
 	case map[string]interface{}:
-		return ObjectType
+		return constants.ObjectType
 	case []interface{}:
-		return ArrayType
+		return constants.ArrayType
 	case string:
-		return StringType
+		return constants.StringType
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return IntegerType
+		return constants.IntegerType
 	case float32, float64:
-		return NumberType
+		return constants.NumberType
 	case bool:
-		return BooleanType
+		return constants.BooleanType
 	case nil:
-		return NullType
+		return constants.NullType
 	default:
-		return UnknownType
+		return constants.UnknownType
 	}
 }

--- a/server/utils/jsontype_test.go
+++ b/server/utils/jsontype_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestGetJsonFieldType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		wantType string
+	}{
+		{
+			name:     "string test",
+			input:    "123",
+			wantType: "string",
+		},
+		{
+			name:     "integer test",
+			input:    1,
+			wantType: "integer",
+		},
+		{
+			name:     "float test",
+			input:    1.1,
+			wantType: "number",
+		},
+		{
+			name:     "boolean test",
+			input:    true,
+			wantType: "boolean",
+		},
+		{
+			name:     "nil test",
+			input:    nil,
+			wantType: "null",
+		},
+		{
+			name:     "array test",
+			input:    []interface{}{"string"},
+			wantType: "array",
+		},
+		{
+			name:     "object test",
+			input:    map[string]interface{}{},
+			wantType: "object",
+		},
+		{
+			name:     "unknown test",
+			input:    struct{}{},
+			wantType: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetJSONFieldType(tt.input)
+			if result != tt.wantType {
+				t.Errorf("GetJsonFieldType(%q) = (%v), want (%v)", tt.input, result, tt.wantType)
+			}
+		})
+	}
+}

--- a/server/utils/jsontype_test.go
+++ b/server/utils/jsontype_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"gotest.tools/v3/assert"
 	"testing"
 )
 
@@ -55,9 +56,7 @@ func TestGetJsonFieldType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetJSONFieldType(tt.input)
-			if result != tt.wantType {
-				t.Errorf("GetJsonFieldType(%q) = (%v), want (%v)", tt.input, result, tt.wantType)
-			}
+			assert.Equal(t, tt.wantType, result)
 		})
 	}
 }


### PR DESCRIPTION
Link to #342 

-  [JSON.TYPE] command return the value type that [JSON.GET] command returns.

 the json value type is similar to the redis command [JSON.TYPE] return.

- added unit-test and integration tests

