### PR TITLE
#359: Fix type casting logic for SET command.

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -204,6 +204,8 @@ func evalSET(args []string, store *Store) []byte {
 		storedValue, _ = strconv.ParseInt(value, 10, 64)
 	case ObjEncodingEmbStr, ObjEncodingRaw:
 		storedValue = value
+	default:
+		return Encode(fmt.Errorf("ERR unsupported encoding: %d", oEnc), false)
 	}
 
 	// putting the k and value in a Hash Table
@@ -273,7 +275,7 @@ func evalGET(args []string, store *Store) []byte {
 		return Encode(errors.New("ERR expected string but got another type"), false)
 
 	default:
-		return Encode(errors.New("ERR unsupported encoding"), false)
+		return Encode(fmt.Errorf("ERR unsupported encoding: %d", oEnc), false)
 	}
 }
 

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -92,6 +92,7 @@ func testEvalSET(t *testing.T, store *Store) {
 		"empty array":                     {input: []string{}, output: []byte("-ERR wrong number of arguments for 'set' command\r\n")},
 		"one value":                       {input: []string{"KEY"}, output: []byte("-ERR wrong number of arguments for 'set' command\r\n")},
 		"key val pair":                    {input: []string{"KEY", "VAL"}, output: RespOK},
+		"key val pair with int val":       {input: []string{"KEY", "123456"}, output: RespOK},
 		"key val pair and expiry key":     {input: []string{"KEY", "VAL", constants.Px}, output: []byte("-ERR syntax error\r\n")},
 		"key val pair and EX no val":      {input: []string{"KEY", "VAL", constants.Ex}, output: []byte("-ERR syntax error\r\n")},
 		"key val pair and valid EX":       {input: []string{"KEY", "VAL", constants.Ex, "2"}, output: RespOK},

--- a/tests/set_test.go
+++ b/tests/set_test.go
@@ -25,9 +25,14 @@ func TestSet(t *testing.T) {
 			expected: []interface{}{"OK", "v"},
 		},
 		{
+			name:     "Set and Get Integer Value",
+			commands: []string{"SET k 123456789", "GET k"},
+			expected: []interface{}{"OK", int64(123456789)},
+		},
+		{
 			name:     "Overwrite Existing Key",
-			commands: []string{"SET k v1", "SET k v2", "GET k"},
-			expected: []interface{}{"OK", "OK", "v2"},
+			commands: []string{"SET k v1", "SET k 5", "GET k"},
+			expected: []interface{}{"OK", "OK", int64(5)},
 		},
 	}
 


### PR DESCRIPTION
## Summary
Fixes the type casting logic for SET and GET operations. Presently all values are stored and retrieved as strings. This PR fixes this behavior by introducing type type-casting logic into the eval flow.

## Further work
The same needs to be done for other methods which set and get values.

## Testing
Added new test cases and modified few existing ones to cover this functionality.