### PR TITLE
adds make target for linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,16 @@ unittest-one:
 
 build-docker:
 	docker build --tag dicedb/dice-server:latest --tag dicedb/dice-server:0.0.1 .
+
+GOLANGCI_LINT_VERSION := 1.60.1
+
+lint: check-golangci-lint
+	golangci-lint run ./...
+
+check-golangci-lint:
+	@if ! command -v golangci-lint > /dev/null || ! golangci-lint version | grep -q "$(GOLANGCI_LINT_VERSION)"; then \
+		echo "Required golangci-lint version $(GOLANGCI_LINT_VERSION) not found."; \
+		echo "Please install golangci-lint version $(GOLANGCI_LINT_VERSION) with the following command:"; \
+		echo "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.1"; \
+		exit 1; \
+	fi

--- a/core/bytelist.go
+++ b/core/bytelist.go
@@ -61,7 +61,7 @@ func (b *byteList) append(bn *byteListNode) {
 	}
 }
 
-//nolint:unused
+
 func (b *byteList) prepend(bn *byteListNode) {
 	bn.next = b.head
 	if b.head != nil {

--- a/core/executor.go
+++ b/core/executor.go
@@ -267,14 +267,14 @@ func isJSONField(expr *sqlparser.SQLVal, obj *Obj) bool {
 	}
 
 	// We convert the $key and $value fields to _key, _value before querying. hence fields starting with _ are
-	//considered to be stored values
+	// considered to be stored values
 	return expr.Type == sqlparser.StrVal &&
 		strings.HasPrefix(string(expr.Val), TempPrefix)
 }
 
 func retrieveValueFromJSON(path string, jsonData *Obj) (value interface{}, valueType string, err error) {
 	// path is in the format '_value.field1.field2'. We need to remove _value reference from the prefix to get the json
-	//path.
+	// path.
 	jsonPath := strings.Split(path, ".")
 	if len(jsonPath) < 2 {
 		return nil, "", ErrInvalidJSONPath

--- a/core/io.go
+++ b/core/io.go
@@ -71,7 +71,6 @@ func (rp *RESPParser) DecodeOne() (interface{}, error) {
 			// This can happen if the connection is closed on the client side but not properly detected
 			return nil, net.ErrClosed
 		}
-
 	}
 
 	b, err := rp.buf.ReadByte()


### PR DESCRIPTION
I have added a make target for the linter and also provides the command to install the linter as suggest by [golangci-lint](https://golangci-lint.run/welcome/install/)

running `make lint` has made the changes we see in the modified files.

Also, currently the [linter **doesn't** run](https://golangci-lint.run/usage/configuration/#run-configuration) on the `test` files as configured in the `.golangci.yaml` file:

https://github.com/Maveric-k07/dice/blob/f2b1d3ae04e84c7ae1c00af8d03e049886ac8185/.golangci.yaml#L1-L9

And when i make the `tests: true` and run `make lint`; I see the following [output](https://gist.github.com/Maveric-k07/35e4bd26d8e5a1f3a16f39f3525988fb) while modifying 17 more files with comment changes, whitespace removal etc.

![Screenshot from 2024-08-20 22-29-01](https://github.com/user-attachments/assets/b47be903-1848-4b1e-86d3-d2429ca75a35)

Let me know if we want to have the linter run on the tests as well.


PS: integration tests are failing at TestDECR so unable to verify the linter changes when `tests: true` break anything. 

@JyotinderSingh 