### PR TITLE
Fixes QWATCH response format, executor type inference logic, test cases

### DIFF
--- a/core/dsql.go
+++ b/core/dsql.go
@@ -50,6 +50,46 @@ type DSQLQuery struct {
 	Limit     int
 }
 
+func (q DSQLQuery) String() string {
+	var parts []string
+
+	// Selection
+	selectionParts := []string{}
+	if q.Selection.KeySelection {
+		selectionParts = append(selectionParts, CustomKey)
+	}
+	if q.Selection.ValueSelection {
+		selectionParts = append(selectionParts, CustomValue)
+	}
+	if len(selectionParts) > 0 {
+		parts = append(parts, fmt.Sprintf("SELECT %s", strings.Join(selectionParts, ", ")))
+	} else {
+		parts = append(parts, "SELECT *")
+	}
+
+	// KeyRegex
+	if q.KeyRegex != "" {
+		parts = append(parts, fmt.Sprintf("FROM `%s`", q.KeyRegex))
+	}
+
+	// Where
+	if q.Where != nil {
+		parts = append(parts, fmt.Sprintf("WHERE '%s'", strings.Replace(strings.Trim(sqlparser.String(q.Where), "'"), TempValue, CustomValue, -1)))
+	}
+
+	// OrderBy
+	if q.OrderBy.OrderBy != "" {
+		parts = append(parts, fmt.Sprintf("ORDER BY %s %s", q.OrderBy.OrderBy, q.OrderBy.Order))
+	}
+
+	// Limit
+	if q.Limit > 0 {
+		parts = append(parts, fmt.Sprintf("LIMIT %d", q.Limit))
+	}
+
+	return strings.Join(parts, " ")
+}
+
 // Utility functions for custom syntax handling
 func replaceCustomSyntax(sql string) string {
 	replacer := strings.NewReplacer(CustomKey, TempKey, CustomValue, TempValue)

--- a/core/eval.go
+++ b/core/eval.go
@@ -1367,12 +1367,13 @@ func evalQWATCH(args []string, c *Client, store *Store) []byte {
 	store.AddWatcher(query, c.Fd)
 
 	// Return the result of the query.
-	result, err := ExecuteQuery(query, store)
+	queryResult, err := ExecuteQuery(query, store)
 	if err != nil {
 		return Encode(err, false)
 	}
 
-	return Encode(result, false)
+	// TODO: We should return the list of all queries being watched by the client.
+	return Encode(CreatePushResponse(&query, &queryResult), false)
 }
 
 // SETBIT key offset value

--- a/core/executor.go
+++ b/core/executor.go
@@ -136,12 +136,12 @@ func compareValues(order string, valI, valJ *Obj) bool {
 			return handleMismatch()
 		}
 		return compareStringValues(order, kindI, kindJ)
-	case int:
-		kindJ, ok := valJ.Value.(int)
+	case int64:
+		kindJ, ok := valJ.Value.(int64)
 		if !ok {
 			return handleMismatch()
 		}
-		return compareIntValues(order, uint8(kindI), uint8(kindJ))
+		return compareIntValues(order, kindI, kindJ)
 	default:
 		return handleUnsupportedType()
 	}
@@ -171,7 +171,7 @@ func compareStringValues(order, valI, valJ string) bool {
 	return valI > valJ
 }
 
-func compareIntValues(order string, valI, valJ uint8) bool {
+func compareIntValues(order string, valI, valJ int64) bool {
 	if order == constants.Asc {
 		return valI < valJ
 	}

--- a/core/push_response.go
+++ b/core/push_response.go
@@ -1,0 +1,11 @@
+package core
+
+import "github.com/dicedb/dice/internal/constants"
+
+func CreatePushResponse(query *DSQLQuery, result *[]DSQLQueryResultRow) (response []interface{}) {
+	response = make([]interface{}, 3, 3)
+	response[0] = constants.Qwatch
+	response[1] = query.String()
+	response[2] = *result
+	return
+}

--- a/core/push_response.go
+++ b/core/push_response.go
@@ -3,7 +3,7 @@ package core
 import "github.com/dicedb/dice/internal/constants"
 
 func CreatePushResponse(query *DSQLQuery, result *[]DSQLQueryResultRow) (response []interface{}) {
-	response = make([]interface{}, 3, 3)
+	response = make([]interface{}, 3)
 	response[0] = constants.Qwatch
 	response[1] = query.String()
 	response[2] = *result

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,3 @@ require (
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	golang.org/x/crypto v0.25.0
 )
-
-// Get go-dice from local path
-replace github.com/dicedb/go-dice => ../../../go-dice

--- a/go.mod
+++ b/go.mod
@@ -36,3 +36,6 @@ require (
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	golang.org/x/crypto v0.25.0
 )
+
+// Get go-dice from local path
+replace github.com/dicedb/go-dice => ../../../go-dice

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -41,4 +41,6 @@ const (
 	BooleanType string = "boolean"
 	NullType    string = "null"
 	UnknownType string = "unknown"
+
+	Qwatch string = "qwatch"
 )

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -63,13 +63,13 @@ func WatchKeys(ctx context.Context, wg *sync.WaitGroup) {
 				clients := value.(*sync.Map)
 
 				if core.WildCardMatch(query.KeyRegex, event.Key) {
-					result, err := core.ExecuteQuery(query, asyncStore)
+					queryResult, err := core.ExecuteQuery(query, asyncStore)
 					if err != nil {
 						log.Error(err)
 						return true // continue to next item
 					}
 
-					encodedResult := core.Encode(result, false)
+					encodedResult := core.Encode(core.CreatePushResponse(&query, &queryResult), false)
 					clients.Range(func(clientKey, _ interface{}) bool {
 						clientFd := clientKey.(int)
 						_, err := syscall.Write(clientFd, encodedResult)

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/dicedb/dice/internal/constants"
 	"net"
 	"testing"
 
@@ -19,38 +20,38 @@ type qWatchTestCase struct {
 	expectedUpdates [][]interface{}
 }
 
-var qWatchQuery = "SELECT $key, $value FROM `match:100:*` ORDER BY $value DESC LIMIT 3"
+var qWatchQuery = "SELECT $key, $value FROM `match:100:*` ORDER BY $value desc LIMIT 3"
 
 var qWatchTestCases = []qWatchTestCase{
 	{0, 11, [][]interface{}{
-		{[]interface{}{"match:100:user:0", "11"}},
+		{[]interface{}{"match:100:user:0", int64(11)}},
 	}},
 	{1, 33, [][]interface{}{
-		{[]interface{}{"match:100:user:1", "33"}, []interface{}{"match:100:user:0", "11"}},
+		{[]interface{}{"match:100:user:1", int64(33)}, []interface{}{"match:100:user:0", int64(11)}},
 	}},
 	{2, 22, [][]interface{}{
-		{[]interface{}{"match:100:user:1", "33"}, []interface{}{"match:100:user:2", "22"}, []interface{}{"match:100:user:0", "11"}},
+		{[]interface{}{"match:100:user:1", int64(33)}, []interface{}{"match:100:user:2", int64(22)}, []interface{}{"match:100:user:0", int64(11)}},
 	}},
 	{3, 0, [][]interface{}{
-		{[]interface{}{"match:100:user:1", "33"}, []interface{}{"match:100:user:2", "22"}, []interface{}{"match:100:user:0", "11"}},
+		{[]interface{}{"match:100:user:1", int64(33)}, []interface{}{"match:100:user:2", int64(22)}, []interface{}{"match:100:user:0", int64(11)}},
 	}},
 	{4, 44, [][]interface{}{
-		{[]interface{}{"match:100:user:4", "44"}, []interface{}{"match:100:user:1", "33"}, []interface{}{"match:100:user:2", "22"}},
+		{[]interface{}{"match:100:user:4", int64(44)}, []interface{}{"match:100:user:1", int64(33)}, []interface{}{"match:100:user:2", int64(22)}},
 	}},
 	{5, 50, [][]interface{}{
-		{[]interface{}{"match:100:user:5", "50"}, []interface{}{"match:100:user:4", "44"}, []interface{}{"match:100:user:1", "33"}},
+		{[]interface{}{"match:100:user:5", int64(50)}, []interface{}{"match:100:user:4", int64(44)}, []interface{}{"match:100:user:1", int64(33)}},
 	}},
 	{2, 40, [][]interface{}{
-		{[]interface{}{"match:100:user:5", "50"}, []interface{}{"match:100:user:4", "44"}, []interface{}{"match:100:user:2", "40"}},
+		{[]interface{}{"match:100:user:5", int64(50)}, []interface{}{"match:100:user:4", int64(44)}, []interface{}{"match:100:user:2", int64(40)}},
 	}},
 	{6, 55, [][]interface{}{
-		{[]interface{}{"match:100:user:6", "55"}, []interface{}{"match:100:user:5", "50"}, []interface{}{"match:100:user:4", "44"}},
+		{[]interface{}{"match:100:user:6", int64(55)}, []interface{}{"match:100:user:5", int64(50)}, []interface{}{"match:100:user:4", int64(44)}},
 	}},
 	{0, 60, [][]interface{}{
-		{[]interface{}{"match:100:user:0", "60"}, []interface{}{"match:100:user:6", "55"}, []interface{}{"match:100:user:5", "50"}},
+		{[]interface{}{"match:100:user:0", int64(60)}, []interface{}{"match:100:user:6", int64(55)}, []interface{}{"match:100:user:5", int64(50)}},
 	}},
 	{5, 70, [][]interface{}{
-		{[]interface{}{"match:100:user:5", "70"}, []interface{}{"match:100:user:0", "60"}, []interface{}{"match:100:user:6", "55"}},
+		{[]interface{}{"match:100:user:5", int64(70)}, []interface{}{"match:100:user:0", int64(60)}, []interface{}{"match:100:user:6", int64(55)}},
 	}},
 }
 
@@ -81,7 +82,7 @@ func TestQWATCH(t *testing.T) {
 
 		v, err := rp.DecodeOne()
 		assert.NilError(t, err)
-		assert.Equal(t, 0, len(v.([]interface{})))
+		assert.Equal(t, 3, len(v.([]interface{})))
 	}
 
 	runQWatchScenarios(t, publisher, respParsers)
@@ -114,6 +115,8 @@ func TestQWATCHWithSDK(t *testing.T) {
 		err := qwatch.WatchQuery(ctx, qWatchQuery)
 		assert.NilError(t, err)
 		channels[i] = qwatch.Channel()
+		//	Get the first message
+		<-channels[i]
 	}
 
 	runQWatchScenarios(t, publisher, channels)
@@ -141,7 +144,7 @@ func runQWatchScenarios(t *testing.T, publisher interface{}, receivers interface
 					v, err := rp.DecodeOne()
 					assert.NilError(t, err)
 					update := v.([]interface{})
-					assert.DeepEqual(t, expectedUpdate, update)
+					assert.DeepEqual(t, []interface{}{constants.Qwatch, qWatchQuery, expectedUpdate}, update)
 				}
 			case []<-chan *redis.QMessage:
 				// For raw connections, parse RESP responses
@@ -235,7 +238,7 @@ func TestQwatchWithJSON(t *testing.T) {
 
 		v, err := rp.DecodeOne()
 		assert.NilError(t, err)
-		assert.Equal(t, 0, len(v.([]interface{})))
+		assert.Equal(t, 3, len(v.([]interface{})))
 	}
 
 	for i, tc := range JSONTestCases {
@@ -246,7 +249,11 @@ func TestQwatchWithJSON(t *testing.T) {
 
 			v, err := rp.DecodeOne()
 			assert.NilError(t, err)
-			update := v.([]interface{})
+			response := v.([]interface{})
+			assert.Equal(t, 3, len(response))
+			assert.Equal(t, constants.Qwatch, response[0])
+
+			update := response[2].([]interface{})
 
 			assert.Equal(t, len(expectedUpdate), len(update), fmt.Sprintf("Expected update: %v, got %v", expectedUpdate, update))
 			assert.Equal(t, expectedUpdate[0].([]interface{})[0], update[0].([]interface{})[0], "Key mismatch")


### PR DESCRIPTION
## QWATCH Enhancements

This PR implements several improvements to the QWATCH functionality and adds JSON support:

## Key Changes

1. Enhanced QWATCH response format:
   - Added a `DSQLQuery.String()` method to serialize queries
   - QWATCH responses now include the query string and "qwatch" identifier - in line with what newer clients expect.
   - Updated tests to expect the new response format

2. Improved value comparison logic:
   - Changed int comparisons to use int64 for consistency
   - Updated compareIntValues function signature accordingly

3. Refactored QWATCH result encoding:
   - Created a new `CreatePushResponse` function to standardize response format
   - Updated both sync and async TCP handlers to use the new function

4. Minor improvements and fixes:
   - Fixed some type assertions and comparisons in tests

## Testing

- Updated existing QWATCH tests to accommodate new response format