### PR TITLE
fix:keep JSON.TYPE consistent with redis

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -348,13 +348,15 @@ func evalJSONTYPE(args []string, store *Store) []byte {
 
 	jsonData := obj.Value
 
-	// If path is root, return "object" instantly
 	if path == defaultRootPath {
 		_, err := sonic.Marshal(jsonData)
 		if err != nil {
 			return Encode(errors.New("ERR could not serialize result"), false)
 		}
-		return Encode(constants.ObjectType, false)
+		// If path is root and len(args) == 1, return "object" instantly
+		if len(args) == 1 {
+			return Encode(constants.ObjectType, false)
+		}
 	}
 
 	// Parse the JSONPath expression
@@ -365,12 +367,9 @@ func evalJSONTYPE(args []string, store *Store) []byte {
 
 	results := expr.Get(jsonData)
 	if len(results) == 0 {
-		return RespNIL
+		return RespEmptyArray
 	}
-	if len(results) == 1 {
-		jsonType := utils.GetJSONFieldType(results[0])
-		return Encode(jsonType, false)
-	}
+
 	typeList := make([]string, 0, len(results))
 	for _, result := range results {
 		jsonType := utils.GetJSONFieldType(result)

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -341,7 +341,7 @@ func testEvalJSONTYPE(t *testing.T, store *Store) {
 			},
 
 			input:  []string{"EXISTING_KEY", "$.language"},
-			output: []byte("$5\r\narray\r\n"),
+			output: []byte("*1\r\n$5\r\narray\r\n"),
 		},
 		"string type value": {
 			setup: func() {
@@ -355,7 +355,7 @@ func testEvalJSONTYPE(t *testing.T, store *Store) {
 			},
 
 			input:  []string{"EXISTING_KEY", "$.a"},
-			output: []byte("$6\r\nstring\r\n"),
+			output: []byte("*1\r\n$6\r\nstring\r\n"),
 		},
 		"boolean type value": {
 			setup: func() {
@@ -369,7 +369,7 @@ func testEvalJSONTYPE(t *testing.T, store *Store) {
 			},
 
 			input:  []string{"EXISTING_KEY", "$.flag"},
-			output: []byte("$7\r\nboolean\r\n"),
+			output: []byte("*1\r\n$7\r\nboolean\r\n"),
 		},
 		"number type value": {
 			setup: func() {
@@ -383,7 +383,7 @@ func testEvalJSONTYPE(t *testing.T, store *Store) {
 			},
 
 			input:  []string{"EXISTING_KEY", "$.price"},
-			output: []byte("$6\r\nnumber\r\n"),
+			output: []byte("*1\r\n$6\r\nnumber\r\n"),
 		},
 		"null type value": {
 			setup: func() {
@@ -397,7 +397,7 @@ func testEvalJSONTYPE(t *testing.T, store *Store) {
 			},
 
 			input:  []string{"EXISTING_KEY", "$.language"},
-			output: RespNIL,
+			output: RespEmptyArray,
 		},
 		"multi type value": {
 			setup: func() {


### PR DESCRIPTION
hello，in JSON.TYPE command. there is some inconsistency with redis [JSON.TYPE](https://redis.io/docs/latest/commands/json.type/)
In Redis JSON.TYPE, such as below:
`

     127.0.0.1:6379> JSON.SET user $ '{"name":"tom","flag":true,"high":1.75,"age":23,"test":null,"language":["java","python","go"], "parter":{"name":"jerry","flag":true}}'
     127.0.0.1:6379> JSON.TYPE user
     "object"
     127.0.0.1:6379> JSON.TYPE user $
     1) "object"
     127.0.0.1:6379> JSON.TYPE user $.name
     1) "string"
     127.0.0.1:6379> JSON.TYPE user $.test
     1) "null"
     127.0.0.1:6379> JSON.TYPE user $.language
     1) "array"
     127.0.0.1:6379> JSON.TYPE user $.name
     1) "string"
     127.0.0.1:6379> JSON.TYPE user $..name
     1) "string"
     2) "string"
     127.0.0.1:6379> JSON.TYPE user $.aaa
     (empty array)

`

we could see. in reids.  JSON.TYPE returns an array of string replies for each path. because the JSON.GET will sustain consistency with redis, so JSON.TYPE also need to do this.