### PR TITLE
#285: Fix: STACKREFLEN and QUEUEREFLEN is not aware of the deletion of key 

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -28,12 +28,4 @@ var (
 	RequirePass string = constants.EmptyStr
 )
 
-var (
-	MaxQueueSize = 10000
-	MaxQueues    = 1000
-)
-
-var (
-	MaxStackSize = 10000
-	MaxStacks    = 1000
-)
+var MaxStacks = 1000

--- a/config/main.go
+++ b/config/main.go
@@ -27,3 +27,13 @@ var (
 	// If requirepass is set to an empty string, no authentication is required
 	RequirePass string = constants.EmptyStr
 )
+
+var (
+	MaxQueueSize = 10000
+	MaxQueues    = 1000
+)
+
+var (
+	MaxStackSize = 10000
+	MaxStacks    = 1000
+)

--- a/config/main.go
+++ b/config/main.go
@@ -28,4 +28,3 @@ var (
 	RequirePass string = constants.EmptyStr
 )
 
-var MaxStacks = 1000

--- a/core/eval.go
+++ b/core/eval.go
@@ -1109,8 +1109,12 @@ func evalQREFINS(args []string, store *Store) []byte {
 	}
 
 	obj := store.Get(args[0])
+	qr, err := NewQueueRef()
+	if err != nil {
+		return Encode(err, false)
+	}
 	if obj == nil {
-		obj = store.NewObj(NewQueueRef(), -1, ObjTypeByteList, ObjEncodingQref)
+		obj = store.NewObj(qr, -1, ObjTypeByteList, ObjEncodingQref)
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -1143,7 +1147,11 @@ func evalSTACKREFPUSH(args []string, store *Store) []byte {
 
 	obj := store.Get(args[0])
 	if obj == nil {
-		obj = store.NewObj(NewStackRef(), -1, ObjTypeByteList, ObjEncodingStackRef)
+		sr, err := NewStackRef()
+		if err != nil {
+			return Encode(err, false)
+		}
+		obj = store.NewObj(sr, -1, ObjTypeByteList, ObjEncodingStackRef)
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -1251,7 +1259,7 @@ func evalQREFLEN(args []string, store *Store) []byte {
 	}
 
 	q := obj.Value.(*QueueRef)
-	return Encode(q.qi.Length, false)
+	return Encode(q.Length(store), false)
 }
 
 // evalSTACKREFLEN returns the length of the STACKREF identified by key
@@ -1276,7 +1284,7 @@ func evalSTACKREFLEN(args []string, store *Store) []byte {
 	}
 
 	s := obj.Value.(*StackRef)
-	return Encode(s.si.Length, false)
+	return Encode(s.Length(store), false)
 }
 
 // evalQREFPEEK peeks into the QREF and returns 5 elements without popping them
@@ -1428,7 +1436,6 @@ func evalSETBIT(args []string, store *Store) []byte {
 		if response && !value {
 			byteArray.ResizeIfNecessary()
 		}
-
 		if response {
 			return Encode(int(1), true)
 		}

--- a/core/eval.go
+++ b/core/eval.go
@@ -862,11 +862,11 @@ func evalQINTINS(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQint); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	store.Put(args[0], obj)
@@ -897,11 +897,11 @@ func evalSTACKINTPUSH(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackInt); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	store.Put(args[0], obj)
@@ -928,11 +928,11 @@ func evalQINTREM(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQint); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	q := obj.Value.(*QueueInt)
@@ -961,11 +961,11 @@ func evalSTACKINTPOP(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackInt); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	s := obj.Value.(*StackInt)
@@ -992,11 +992,11 @@ func evalQINTLEN(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQint); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	q := obj.Value.(*QueueInt)
@@ -1017,11 +1017,11 @@ func evalSTACKINTLEN(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackInt); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	s := obj.Value.(*StackInt)
@@ -1052,11 +1052,11 @@ func evalQINTPEEK(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQint); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	q := obj.Value.(*QueueInt)
@@ -1087,11 +1087,11 @@ func evalSTACKINTPEEK(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackInt); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	s := obj.Value.(*StackInt)
@@ -1119,11 +1119,11 @@ func evalQREFINS(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQref); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	store.Put(args[0], obj)
@@ -1150,17 +1150,17 @@ func evalSTACKREFPUSH(args []string, store *Store) []byte {
 	if obj == nil {
 		sr, err := NewStackRef()
 		if err != nil {
-			return Encode(err, false)
+			return diceerrors.NewErrWithMessage(("ERR maximum number of stacks reached"))
 		}
 		obj = store.NewObj(sr, -1, ObjTypeByteList, ObjEncodingStackRef)
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackRef); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	store.Put(args[0], obj)
@@ -1188,11 +1188,11 @@ func evalQREFREM(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQref); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	q := obj.Value.(*QueueRef)
@@ -1221,11 +1221,11 @@ func evalSTACKREFPOP(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackRef); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	s := obj.Value.(*StackRef)
@@ -1252,11 +1252,11 @@ func evalQREFLEN(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQref); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	q := obj.Value.(*QueueRef)
@@ -1277,11 +1277,11 @@ func evalSTACKREFLEN(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackRef); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	s := obj.Value.(*StackRef)
@@ -1312,11 +1312,11 @@ func evalQREFPEEK(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQref); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	q := obj.Value.(*QueueRef)
@@ -1347,11 +1347,11 @@ func evalSTACKREFPEEK(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackRef); err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrSetType()
 	}
 
 	s := obj.Value.(*StackRef)
@@ -2352,7 +2352,7 @@ func evalFLUSHDB(args []string, store *Store) []byte {
 		flushType = strings.ToUpper(args[0])
 	}
 
-        // TODO: Update this method to work with shared-nothing multithreaded implementation
+	// TODO: Update this method to work with shared-nothing multithreaded implementation
 	switch flushType {
 	case constants.Sync, constants.Async:
 		store.ResetStore()

--- a/core/executerbechmark_test.go
+++ b/core/executerbechmark_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 var benchmarkDataSizes = []int{100, 1000, 10000, 100000, 1000000}
+var benchmarkDataSizesStackQueue = []int{100, 1000, 10000}
 var benchmarkDataSizesJSON = []int{100, 1000, 10000, 100000}
 
 var jsonList = map[string]string{

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -1,11 +1,11 @@
 package core
 
 import (
-	"errors"
 	"sync"
 	"unsafe"
 
 	"github.com/dicedb/dice/config"
+	"github.com/dicedb/dice/core/diceerrors"
 )
 
 var (
@@ -26,7 +26,7 @@ func NewQueueRef() (*QueueRef, error) {
 	muQueue.Lock()
 	defer muQueue.Unlock()
 	if QueueCount >= config.MaxQueues {
-		return nil, errors.New("ERR maximum number of queues reached")
+		return nil, diceerrors.NewErr("ERR maximum number of queues reached")
 	}
 
 	QueueCount++

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	MaxQueueSize = 10000
-	MaxQueues    = 100
+	MaxQueues    = 1000
 )
 
 var (

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -4,11 +4,8 @@ import (
 	"errors"
 	"sync"
 	"unsafe"
-)
 
-var (
-	MaxQueueSize = 10000
-	MaxQueues    = 1000
+	"github.com/dicedb/dice/config"
 )
 
 var (
@@ -28,7 +25,7 @@ type QueueElement struct {
 func NewQueueRef() (*QueueRef, error) {
 	muQueue.Lock()
 	defer muQueue.Unlock()
-	if QueueCount >= MaxQueues {
+	if QueueCount >= config.MaxQueues {
 		return nil, errors.New("ERR maximum number of queues reached")
 	}
 
@@ -48,7 +45,7 @@ func (q *QueueRef) Size(store *Store) int64 {
 func (q *QueueRef) Insert(key string, store *Store) bool {
 	var x *string
 	var ok bool
-	if q.qi.Length >= int64(MaxQueueSize) {
+	if q.qi.Length >= int64(config.MaxQueueSize) {
 		return false // Prevent inserting if the queue is at maximum capacity
 	}
 	withLocks(func() {

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -23,13 +23,12 @@ type QueueElement struct {
 }
 
 func NewQueueRef() (*QueueRef, error) {
-	muQueue.Lock()
-	defer muQueue.Unlock()
 	if QueueCount >= config.MaxQueues {
 		return nil, diceerrors.NewErr("ERR maximum number of queues reached")
 	}
-
+	muQueue.Lock()
 	QueueCount++
+	muQueue.Unlock()
 	return &QueueRef{
 		qi: NewQueueInt(),
 	}, nil

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -4,8 +4,12 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/core/diceerrors"
+)
+
+const (
+	MaxQueueSize = 10000
+	MaxQueues    = 1000
 )
 
 var (
@@ -23,7 +27,7 @@ type QueueElement struct {
 }
 
 func NewQueueRef() (*QueueRef, error) {
-	if QueueCount >= config.MaxQueues {
+	if QueueCount >= MaxQueues {
 		return nil, diceerrors.NewErr("ERR maximum number of queues reached")
 	}
 	muQueue.Lock()
@@ -44,7 +48,7 @@ func (q *QueueRef) Size(store *Store) int64 {
 func (q *QueueRef) Insert(key string, store *Store) bool {
 	var x *string
 	var ok bool
-	if q.qi.Length >= int64(config.MaxQueueSize) {
+	if q.qi.Length >= int64(MaxQueueSize) {
 		return false // Prevent inserting if the queue is at maximum capacity
 	}
 	withLocks(func() {

--- a/core/queueref.go
+++ b/core/queueref.go
@@ -12,7 +12,7 @@ var (
 )
 
 var (
-	queueCount = 0
+	QueueCount = 0
 	muQueue    sync.Mutex
 )
 
@@ -28,11 +28,11 @@ type QueueElement struct {
 func NewQueueRef() (*QueueRef, error) {
 	muQueue.Lock()
 	defer muQueue.Unlock()
-	if queueCount >= MaxQueues {
+	if QueueCount >= MaxQueues {
 		return nil, errors.New("ERR maximum number of queues reached")
 	}
 
-	queueCount++
+	QueueCount++
 	return &QueueRef{
 		qi: NewQueueInt(),
 	}, nil

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 func TestQueueRef(t *testing.T) {
-	qr := core.NewQueueRef()
+	qr, err := core.NewQueueRef()
+	if err != nil {
+		t.Fatal(err)
+	}
 	store := core.NewStore()
 
 	if _, err := qr.Remove(store); err != core.ErrQueueEmpty {
@@ -66,7 +69,10 @@ func TestQueueRef(t *testing.T) {
 
 // Test for removing from queue with single non-expired keys
 func TestRemoveSingleNonExpiredKeys(t *testing.T) {
-	qr := core.NewQueueRef()
+	qr, err := core.NewQueueRef()
+	if err != nil {
+		t.Fatal(err)
+	}
 	store := core.NewStore()
 	val := 10
 	store.Put("key1", store.NewObj(val, -1, core.ObjTypeString, core.ObjEncodingInt))
@@ -77,7 +83,10 @@ func TestRemoveSingleNonExpiredKeys(t *testing.T) {
 
 // Test for removing from queue with multiple non-expired keys
 func TestRemoveMultipleNonExpiredKeys(t *testing.T) {
-	qr := core.NewQueueRef()
+	qr, err := core.NewQueueRef()
+	if err != nil {
+		t.Fatal(err)
+	}
 	store := core.NewStore()
 	val := [3]int{10, 20, 30}
 	store.Put("key1", store.NewObj(val[0], -1, core.ObjTypeString, core.ObjEncodingInt))
@@ -97,7 +106,10 @@ func TestRemoveExpiredBeforeNonExpire(t *testing.T) {
 	store := core.NewStore()
 	mockTime := &utils.MockClock{CurrTime: time.Now()}
 	utils.CurrentTime = mockTime
-	qr := core.NewQueueRef()
+	qr, err := core.NewQueueRef()
+	if err != nil {
+		t.Fatal(err)
+	}
 	val := [3]int{10, 20}
 	store.Put("key1", store.NewObj(val[0], 1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key1", store)
@@ -113,7 +125,10 @@ func TestRemoveMultipleExpiredBeforeNonExpire(t *testing.T) {
 	store := core.NewStore()
 	mockTime := &utils.MockClock{CurrTime: time.Now()}
 	utils.CurrentTime = mockTime
-	qr := core.NewQueueRef()
+	qr, err := core.NewQueueRef()
+	if err != nil {
+		t.Fatal(err)
+	}
 	val := [3]int{10, 20, 30}
 	store.Put("key1", store.NewObj(val[0], 1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key1", store)
@@ -122,7 +137,7 @@ func TestRemoveMultipleExpiredBeforeNonExpire(t *testing.T) {
 	store.Put("key3", store.NewObj(val[2], -1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key3", store)
 	mockTime.SetTime(time.Now().Add(2 * time.Millisecond))
-	fmt.Printf("Queue size : %d\n", qr.Length())
+	fmt.Printf("Queue size : %d\n", qr.Length(store))
 	qe, err := qr.Remove(store)
 	assert.Check(t, err == nil || qe.Obj.Value == val[2], fmt.Sprintf("test for removing mulitple expired key before non-expired failed , Expected : %d, Got %d\n", val[2], qe.Obj.Value))
 }
@@ -132,7 +147,10 @@ func TestRemoveAllExpired(t *testing.T) {
 	store := core.NewStore()
 	mockTime := &utils.MockClock{CurrTime: time.Now()}
 	utils.CurrentTime = mockTime
-	qr := core.NewQueueRef()
+	qr, err := core.NewQueueRef()
+	if err != nil {
+		t.Fatal(err)
+	}
 	val := [3]int{10, 20, 30}
 	store.Put("key1", store.NewObj(val[0], 1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key1", store)
@@ -142,8 +160,82 @@ func TestRemoveAllExpired(t *testing.T) {
 	qr.Insert("key3", store)
 	mockTime.SetTime(time.Now().Add(2 * time.Millisecond))
 	// remove from empty queue
-	_, err := qr.Remove(store)
+	_, err = qr.Remove(store)
 	assert.Equal(t, err, core.ErrQueueEmpty, fmt.Sprintf("test for removing from empty queue failed Expected : %s, Got : %s\n", core.ErrQueueEmpty, err))
+}
+
+func TestQueueRefMaxConstraints(t *testing.T) {
+	config.KeysLimit = 20000000
+	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
+	maxQueue := 100
+	maxElements := 10000
+
+	qr, err := core.NewQueueRef()
+	if err != nil {
+		t.Errorf("error creating QueueRef: %v", err)
+	}
+	store := core.NewStore()
+	for i := 0; i < maxElements; i++ {
+		key := fmt.Sprintf("key%d", i)
+		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
+		if !qr.Insert(key, store) {
+			t.Errorf("insert failed on element %d, expected successful insert", i)
+		}
+	}
+
+	keyOverflow := "key_overflow"
+	store.Put(keyOverflow, store.NewObj(9999, -1, core.ObjTypeString, core.ObjEncodingInt))
+	if qr.Insert(keyOverflow, store) {
+		t.Errorf("insert succeeded on element %d, expected failure due to maxElements limit", maxElements)
+	}
+
+	for i := 0; i < maxQueue-1; i++ {
+		_, err := core.NewQueueRef()
+		if err != nil {
+			t.Errorf("error creating QueueRef: %v", err)
+		}
+	}
+
+	_, err = core.NewQueueRef()
+	if err == nil {
+		t.Errorf("expected error creating QueueRef, got %v", err)
+	}
+}
+
+func TestQueueRefLen(t *testing.T) {
+	store := core.NewStore()
+
+	qr, err := core.NewQueueRef()
+	if err != nil {
+		t.Fatalf("error creating queue: %v", err)
+	}
+	mockTime := &utils.MockClock{CurrTime: time.Now()}
+	utils.CurrentTime = mockTime
+
+	store.Put("key1", store.NewObj(10, -1, core.ObjTypeString, core.ObjEncodingInt))
+	qr.Insert("key1", store)
+
+	store.Put("key2", store.NewObj(20, 10, core.ObjTypeString, core.ObjEncodingInt))
+	qr.Insert("key2", store)
+
+	store.Put("key3", store.NewObj(30, -1, core.ObjTypeString, core.ObjEncodingInt))
+	qr.Insert("key3", store)
+
+	store.Put("key4", store.NewObj(40, -1, core.ObjTypeString, core.ObjEncodingInt))
+	qr.Insert("key4", store)
+
+	mockTime.SetTime(time.Now().Add(10 * time.Millisecond))
+	store.Del("key3")
+
+	store.Put("key5", store.NewObj(50, -1, core.ObjTypeString, core.ObjEncodingInt))
+	qr.Insert("key5", store)
+
+	length := qr.Length(store)
+
+	expectedLength := int64(3)
+	if length != expectedLength {
+		t.Errorf("expected queue length %d, got %d", expectedLength, length)
+	}
 }
 
 // Benchmark queueref by inserting expired, non-expired and expired keys in order and removing them
@@ -162,12 +254,14 @@ func benchmarkQueueRefInsertAndRemove(b *testing.B) {
 		{"small", 10},
 		{"medium", 100},
 		{"large", 1000},
-		{"very large", 10000},
 	}
 
 	for _, benchmark := range benchmarkCases {
 		b.Run(fmt.Sprintf("Benchmark %s", benchmark.name), func(b *testing.B) {
-			qr := core.NewQueueRef()
+			qr, err := core.NewQueueRef()
+			if err != nil {
+				b.Fatal(err)
+			}
 			expiredCount := benchmark.nonExpiredCount / 2
 			nonExpiredCount := benchmark.nonExpiredCount
 			config.KeysLimit = benchmark.nonExpiredCount * 10
@@ -227,6 +321,6 @@ func insertKey(b *testing.B, qr *core.QueueRef, i int, expired bool, store *core
 func validateQueueEmpty(b *testing.B, qr *core.QueueRef, store *core.Store) {
 	_, err := qr.Remove(store)
 	if err != core.ErrQueueEmpty {
-		b.Fatalf("Queue not empty after benchmark. Got error: %v, Queue size: %d", err, qr.Length())
+		b.Fatalf("Queue not empty after benchmark. Got error: %v, Queue size: %d", err, qr.Length(store))
 	}
 }

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -202,7 +202,7 @@ func TestQueueRefMaxConstraints(t *testing.T) {
 
 func TestQueueRefLen(t *testing.T) {
 	store := core.NewStore()
-
+	core.QueueCount = 0
 	qr, err := core.NewQueueRef()
 	if err != nil {
 		t.Fatalf("error creating queue: %v", err)

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -167,15 +167,13 @@ func TestRemoveAllExpired(t *testing.T) {
 func TestQueueRefMaxConstraints(t *testing.T) {
 	config.KeysLimit = 20000000
 	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
-	maxQueue := 100
-	maxElements := 10000
 
 	qr, err := core.NewQueueRef()
 	if err != nil {
 		t.Errorf("error creating QueueRef: %v", err)
 	}
 	store := core.NewStore()
-	for i := 0; i < maxElements; i++ {
+	for i := 0; i < core.MaxQueueSize; i++ {
 		key := fmt.Sprintf("key%d", i)
 		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
 		if !qr.Insert(key, store) {
@@ -186,10 +184,10 @@ func TestQueueRefMaxConstraints(t *testing.T) {
 	keyOverflow := "key_overflow"
 	store.Put(keyOverflow, store.NewObj(9999, -1, core.ObjTypeString, core.ObjEncodingInt))
 	if qr.Insert(keyOverflow, store) {
-		t.Errorf("insert succeeded on element %d, expected failure due to maxElements limit", maxElements)
+		t.Errorf("insert succeeded on element %d, expected failure due to maxElements limit", core.MaxQueueSize)
 	}
 
-	for i := 0; i < maxQueue-1; i++ {
+	for i := 0; i < core.MaxQueues-1; i++ {
 		_, err := core.NewQueueRef()
 		if err != nil {
 			t.Errorf("error creating QueueRef: %v", err)

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -167,7 +167,7 @@ func TestRemoveAllExpired(t *testing.T) {
 func TestQueueRefMaxConstraints(t *testing.T) {
 	config.KeysLimit = 20000000
 	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
-
+	core.QueueCount = 0 // reset counter
 	qr, err := core.NewQueueRef()
 	if err != nil {
 		t.Errorf("error creating QueueRef: %v", err)

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -173,7 +173,7 @@ func TestQueueRefMaxConstraints(t *testing.T) {
 		t.Errorf("error creating QueueRef: %v", err)
 	}
 	store := core.NewStore()
-	for i := 0; i < config.MaxQueueSize; i++ {
+	for i := 0; i < core.MaxQueueSize; i++ {
 		key := fmt.Sprintf("key%d", i)
 		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
 		if !qr.Insert(key, store) {
@@ -184,10 +184,10 @@ func TestQueueRefMaxConstraints(t *testing.T) {
 	keyOverflow := "key_overflow"
 	store.Put(keyOverflow, store.NewObj(9999, -1, core.ObjTypeString, core.ObjEncodingInt))
 	if qr.Insert(keyOverflow, store) {
-		t.Errorf("insert succeeded on element %d, expected failure due to maxElements limit", config.MaxQueueSize)
+		t.Errorf("insert succeeded on element %d, expected failure due to maxElements limit", core.MaxQueueSize)
 	}
 
-	for i := 0; i < config.MaxQueues-1; i++ {
+	for i := 0; i < core.MaxQueues-1; i++ {
 		_, err := core.NewQueueRef()
 		if err != nil {
 			t.Errorf("error creating QueueRef: %v", err)

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -173,7 +173,7 @@ func TestQueueRefMaxConstraints(t *testing.T) {
 		t.Errorf("error creating QueueRef: %v", err)
 	}
 	store := core.NewStore()
-	for i := 0; i < core.MaxQueueSize; i++ {
+	for i := 0; i < config.MaxQueueSize; i++ {
 		key := fmt.Sprintf("key%d", i)
 		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
 		if !qr.Insert(key, store) {
@@ -184,10 +184,10 @@ func TestQueueRefMaxConstraints(t *testing.T) {
 	keyOverflow := "key_overflow"
 	store.Put(keyOverflow, store.NewObj(9999, -1, core.ObjTypeString, core.ObjEncodingInt))
 	if qr.Insert(keyOverflow, store) {
-		t.Errorf("insert succeeded on element %d, expected failure due to maxElements limit", core.MaxQueueSize)
+		t.Errorf("insert succeeded on element %d, expected failure due to maxElements limit", config.MaxQueueSize)
 	}
 
-	for i := 0; i < core.MaxQueues-1; i++ {
+	for i := 0; i < config.MaxQueues-1; i++ {
 		_, err := core.NewQueueRef()
 		if err != nil {
 			t.Errorf("error creating QueueRef: %v", err)

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -12,7 +12,7 @@ var (
 )
 
 var (
-	stackCount = 0
+	StackCount = 0
 	muStack    sync.Mutex
 )
 
@@ -28,11 +28,11 @@ type StackElement struct {
 func NewStackRef() (*StackRef, error) {
 	muStack.Lock()
 	defer muStack.Unlock()
-	if stackCount >= MaxStacks {
+	if StackCount >= MaxStacks {
 		return nil, errors.New("ERR maximum number of stacks reached")
 	}
 
-	stackCount++
+	StackCount++
 
 	return &StackRef{
 		si: NewStackInt(),

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -1,11 +1,11 @@
 package core
 
 import (
-	"errors"
 	"sync"
 	"unsafe"
 
 	"github.com/dicedb/dice/config"
+	"github.com/dicedb/dice/core/diceerrors"
 )
 
 var (
@@ -26,7 +26,7 @@ func NewStackRef() (*StackRef, error) {
 	muStack.Lock()
 	defer muStack.Unlock()
 	if StackCount >= config.MaxStacks {
-		return nil, errors.New("ERR maximum number of stacks reached")
+		return nil, diceerrors.NewErr("ERR maximum number of stacks reached")
 	}
 
 	StackCount++

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -8,6 +8,10 @@ import (
 	"github.com/dicedb/dice/core/diceerrors"
 )
 
+const (
+	MaxStackSize = 10000
+)
+
 var (
 	StackCount = 0
 	muStack    sync.Mutex
@@ -53,7 +57,7 @@ func (s *StackRef) Push(key string, store *Store) bool {
 	var x *string
 	var ok bool
 
-	if s.si.Length >= int64(config.MaxStackSize) {
+	if s.si.Length >= int64(MaxStackSize) {
 		return false // Prevent pushing if the stack is at maximum capacity
 	}
 

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -4,11 +4,8 @@ import (
 	"errors"
 	"sync"
 	"unsafe"
-)
 
-var (
-	MaxStackSize = 10000
-	MaxStacks    = 1000
+	"github.com/dicedb/dice/config"
 )
 
 var (
@@ -28,7 +25,7 @@ type StackElement struct {
 func NewStackRef() (*StackRef, error) {
 	muStack.Lock()
 	defer muStack.Unlock()
-	if StackCount >= MaxStacks {
+	if StackCount >= config.MaxStacks {
 		return nil, errors.New("ERR maximum number of stacks reached")
 	}
 
@@ -56,7 +53,7 @@ func (s *StackRef) Push(key string, store *Store) bool {
 	var x *string
 	var ok bool
 
-	if s.si.Length >= int64(MaxStackSize) {
+	if s.si.Length >= int64(config.MaxStackSize) {
 		return false // Prevent pushing if the stack is at maximum capacity
 	}
 

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/core/diceerrors"
 )
 
@@ -14,6 +13,7 @@ const (
 
 var (
 	StackCount = 0
+	MaxStacks  = 1000
 	muStack    sync.Mutex
 )
 
@@ -27,7 +27,7 @@ type StackElement struct {
 }
 
 func NewStackRef() (*StackRef, error) {
-	if StackCount >= config.MaxStacks {
+	if StackCount >= MaxStacks {
 		return nil, diceerrors.NewErr("ERR maximum number of stacks reached")
 	}
 

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -23,13 +23,13 @@ type StackElement struct {
 }
 
 func NewStackRef() (*StackRef, error) {
-	muStack.Lock()
-	defer muStack.Unlock()
 	if StackCount >= config.MaxStacks {
 		return nil, diceerrors.NewErr("ERR maximum number of stacks reached")
 	}
 
+	muStack.Lock()
 	StackCount++
+	muStack.Unlock()
 
 	return &StackRef{
 		si: NewStackInt(),

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	MaxStackSize = 10000
-	MaxStacks    = 100
+	MaxStacks    = 1000
 )
 
 var (

--- a/core/stackref.go
+++ b/core/stackref.go
@@ -9,11 +9,11 @@ import (
 
 const (
 	MaxStackSize = 10000
+	MaxStacks    = 1000
 )
 
 var (
 	StackCount = 0
-	MaxStacks  = 1000
 	muStack    sync.Mutex
 )
 

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -136,8 +136,6 @@ func TestStackRef(t *testing.T) {
 func TestStackRefMaxConstraints(t *testing.T) {
 	config.KeysLimit = 20000000
 	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
-	maxStack := 100
-	maxElements := 10000
 	store := core.NewStore()
 
 	sr, err := core.NewStackRef()
@@ -145,7 +143,7 @@ func TestStackRefMaxConstraints(t *testing.T) {
 		t.Errorf("error creating StackRef: %v", err)
 	}
 
-	for i := 0; i < maxElements; i++ {
+	for i := 0; i < core.MaxStackSize; i++ {
 		key := fmt.Sprintf("key%d", i)
 		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
 		if !sr.Push(key, store) {
@@ -156,10 +154,10 @@ func TestStackRefMaxConstraints(t *testing.T) {
 	keyOverflow := "key_overflow"
 	store.Put(keyOverflow, store.NewObj(9999, -1, core.ObjTypeString, core.ObjEncodingInt))
 	if sr.Push(keyOverflow, store) {
-		t.Errorf("push succeeded on element %d, expected failure due to maxElements limit", maxElements)
+		t.Errorf("push succeeded on element %d, expected failure due to maxElements limit", core.MaxStackSize)
 	}
 
-	for i := 0; i < maxStack-1; i++ {
+	for i := 0; i < core.MaxStacks-1; i++ {
 		_, err := core.NewStackRef()
 		if err != nil {
 			t.Errorf("error creating StackRef: %v", err)

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -179,14 +179,14 @@ func TestStackRefMaxConstraints(t *testing.T) {
 		t.Errorf("error creating StackRef: %v", err)
 	}
 
-	for i := 0; i < core.MaxStackSize; i++ {
+	for i := 0; i < config.MaxStackSize; i++ {
 		key := fmt.Sprintf("key%d", i)
 		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
 		if !sr.Push(key, store) {
 			t.Errorf("push failed on element %d, expected successful push", i)
 		}
 	}
-	for i := 0; i < core.MaxStacks-1; i++ {
+	for i := 0; i < config.MaxStacks-1; i++ {
 		_, err := core.NewStackRef()
 		if err != nil {
 			t.Errorf("error creating StackRef: %v", err)
@@ -205,7 +205,7 @@ func BenchmarkRemoveLargeNumberOfExpiredKeys(b *testing.B) {
 		config.KeysLimit = 20000000 // Set a high limit for benchmarking
 		core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
 		core.StackCount = 0
-		core.MaxStacks = 2000000 // Set a high limit for benchmarking
+		config.MaxStacks = 2000000 // Set a high limit for benchmarking
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -204,17 +204,15 @@ func BenchmarkRemoveLargeNumberOfExpiredKeys(b *testing.B) {
 	for _, v := range benchmarkDataSizesStackQueue {
 		config.KeysLimit = 20000000 // Set a high limit for benchmarking
 		core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
-		// core.MaxStacks = 2000000 // Set a high limit for benchmarking
-
+		var sr *core.StackRef
+		var err error
+		if sr, err = core.NewStackRef(); err != nil {
+			b.Fatal(err)
+		}
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			core.StackCount = 0
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				var sr *core.StackRef
-				var err error
-				if sr, err = core.NewStackRef(); err != nil {
-					b.Fatal(err)
-				}
 				CreateAndPushKeyToStack(sr, "initialKey", 0, -1, store)
 				for j := 1; j < v; j++ {
 					CreateAndPushKeyToStack(sr, strconv.Itoa(j), j, 0, store)

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -186,7 +186,7 @@ func TestStackRefMaxConstraints(t *testing.T) {
 			t.Errorf("push failed on element %d, expected successful push", i)
 		}
 	}
-	for i := 0; i < config.MaxStacks-1; i++ {
+	for i := 0; i < core.MaxStacks-1; i++ {
 		_, err := core.NewStackRef()
 		if err != nil {
 			t.Errorf("error creating StackRef: %v", err)
@@ -205,7 +205,7 @@ func BenchmarkRemoveLargeNumberOfExpiredKeys(b *testing.B) {
 		config.KeysLimit = 20000000 // Set a high limit for benchmarking
 		core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
 		core.StackCount = 0
-		config.MaxStacks = 2000000 // Set a high limit for benchmarking
+		core.MaxStacks = 2000000 // Set a high limit for benchmarking
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/core"
+	"github.com/dicedb/dice/server/utils"
 	"github.com/dicedb/dice/testutils"
 )
 
@@ -18,7 +20,7 @@ func CreateAndPushKeyToStack(sr *core.StackRef, key string, value int, expDurati
 
 func TestStackRef(t *testing.T) {
 	store := core.NewStore()
-	sr := core.NewStackRef()
+	sr, _ := core.NewStackRef()
 
 	if _, err := sr.Pop(store); err != core.ErrStackEmpty {
 		t.Error("popping from an empty stackref should return an empty stack error")
@@ -66,7 +68,7 @@ func TestStackRef(t *testing.T) {
 		t.Error("iterating through the stackref should return the elements in the order they were pushed. Expected:", expectedVals, ", got: ", observedVals)
 	}
 
-	sr2 := core.NewStackRef()
+	sr2, _ := core.NewStackRef()
 	obj1 := store.NewObj(10, -1, core.ObjTypeString, core.ObjEncodingInt)
 	store.Put("key1", obj1)
 	sr2.Push("key1", store)
@@ -131,16 +133,95 @@ func TestStackRef(t *testing.T) {
 
 }
 
+func TestStackRefMaxConstraints(t *testing.T) {
+	config.KeysLimit = 20000000
+	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
+	maxStack := 100
+	maxElements := 10000
+	store := core.NewStore()
+
+	sr, err := core.NewStackRef()
+	if err != nil {
+		t.Errorf("error creating StackRef: %v", err)
+	}
+
+	for i := 0; i < maxElements; i++ {
+		key := fmt.Sprintf("key%d", i)
+		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
+		if !sr.Push(key, store) {
+			t.Errorf("push failed on element %d, expected successful push", i)
+		}
+	}
+
+	keyOverflow := "key_overflow"
+	store.Put(keyOverflow, store.NewObj(9999, -1, core.ObjTypeString, core.ObjEncodingInt))
+	if sr.Push(keyOverflow, store) {
+		t.Errorf("push succeeded on element %d, expected failure due to maxElements limit", maxElements)
+	}
+
+	for i := 0; i < maxStack-1; i++ {
+		_, err := core.NewStackRef()
+		if err != nil {
+			t.Errorf("error creating StackRef: %v", err)
+		}
+	}
+
+	_, err = core.NewStackRef()
+	if err == nil {
+		t.Errorf("expected error creating StackRef, got %v", err)
+	}
+}
+func TestStackRefLen(t *testing.T) {
+	store := core.NewStore()
+
+	sr, err := core.NewStackRef()
+	if err != nil {
+		t.Fatalf("error creating stack: %v", err)
+	}
+	mockTime := &utils.MockClock{CurrTime: time.Now()}
+	utils.CurrentTime = mockTime
+
+	store.Put("key1", store.NewObj(10, -1, core.ObjTypeString, core.ObjEncodingInt))
+	sr.Push("key1", store)
+
+	store.Put("key2", store.NewObj(20, 10, core.ObjTypeString, core.ObjEncodingInt))
+	sr.Push("key2", store)
+
+	store.Put("key3", store.NewObj(30, -1, core.ObjTypeString, core.ObjEncodingInt))
+	sr.Push("key3", store)
+
+	store.Put("key4", store.NewObj(40, -1, core.ObjTypeString, core.ObjEncodingInt))
+	sr.Push("key4", store)
+
+	mockTime.SetTime(time.Now().Add(10 * time.Millisecond))
+	store.Del("key3")
+
+	store.Put("key5", store.NewObj(50, -1, core.ObjTypeString, core.ObjEncodingInt))
+	sr.Push("key5", store)
+
+	length := sr.Length(store)
+
+	expectedLength := int64(3)
+	if length != expectedLength {
+		t.Errorf("expected stack length %d, got %d", expectedLength, length)
+	}
+
+}
+
 func BenchmarkRemoveLargeNumberOfExpiredKeys(b *testing.B) {
 	store := core.NewStore()
-	for _, v := range benchmarkDataSizes {
+	for _, v := range benchmarkDataSizesStackQueue {
 		config.KeysLimit = 20000000 // Set a high limit for benchmarking
 		core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
-
+		core.MaxStacks = 2000000 // Set a high limit for benchmarking
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				sr := core.NewStackRef()
+				var sr *core.StackRef
+				var err error
+				if sr, err = core.NewStackRef(); err != nil {
+					b.Fatal(err)
+				}
 				CreateAndPushKeyToStack(sr, "initialKey", 0, -1, store)
 				for j := 1; j < v; j++ {
 					CreateAndPushKeyToStack(sr, strconv.Itoa(j), j, 0, store)

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -179,7 +179,7 @@ func TestStackRefMaxConstraints(t *testing.T) {
 		t.Errorf("error creating StackRef: %v", err)
 	}
 
-	for i := 0; i < config.MaxStackSize; i++ {
+	for i := 0; i < core.MaxStackSize; i++ {
 		key := fmt.Sprintf("key%d", i)
 		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
 		if !sr.Push(key, store) {

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -204,9 +204,10 @@ func BenchmarkRemoveLargeNumberOfExpiredKeys(b *testing.B) {
 	for _, v := range benchmarkDataSizesStackQueue {
 		config.KeysLimit = 20000000 // Set a high limit for benchmarking
 		core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
-		core.StackCount = 0
-		core.MaxStacks = 2000000 // Set a high limit for benchmarking
+		// core.MaxStacks = 2000000 // Set a high limit for benchmarking
+
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
+			core.StackCount = 0
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 				var sr *core.StackRef

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -133,35 +133,6 @@ func TestStackRef(t *testing.T) {
 
 }
 
-func TestStackRefMaxConstraints(t *testing.T) {
-	config.KeysLimit = 20000000
-	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
-	store := core.NewStore()
-	core.StackCount = 0
-	sr, err := core.NewStackRef()
-	if err != nil {
-		t.Errorf("error creating StackRef: %v", err)
-	}
-
-	for i := 0; i < core.MaxStackSize; i++ {
-		key := fmt.Sprintf("key%d", i)
-		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
-		if !sr.Push(key, store) {
-			t.Errorf("push failed on element %d, expected successful push", i)
-		}
-	}
-	for i := 0; i < core.MaxStacks-1; i++ {
-		_, err := core.NewStackRef()
-		if err != nil {
-			t.Errorf("error creating StackRef: %v", err)
-		}
-	}
-
-	_, err = core.NewStackRef()
-	if err == nil {
-		t.Errorf("expected error creating StackRef, got %v", err)
-	}
-}
 func TestStackRefLen(t *testing.T) {
 	store := core.NewStore()
 
@@ -198,12 +169,42 @@ func TestStackRefLen(t *testing.T) {
 	}
 
 }
+func TestStackRefMaxConstraints(t *testing.T) {
+	config.KeysLimit = 20000000
+	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
+	store := core.NewStore()
+	core.StackCount = 0
+	sr, err := core.NewStackRef()
+	if err != nil {
+		t.Errorf("error creating StackRef: %v", err)
+	}
+
+	for i := 0; i < core.MaxStackSize; i++ {
+		key := fmt.Sprintf("key%d", i)
+		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
+		if !sr.Push(key, store) {
+			t.Errorf("push failed on element %d, expected successful push", i)
+		}
+	}
+	for i := 0; i < core.MaxStacks-1; i++ {
+		_, err := core.NewStackRef()
+		if err != nil {
+			t.Errorf("error creating StackRef: %v", err)
+		}
+	}
+
+	_, err = core.NewStackRef()
+	if err == nil {
+		t.Errorf("expected error creating StackRef, got %v", err)
+	}
+}
 
 func BenchmarkRemoveLargeNumberOfExpiredKeys(b *testing.B) {
 	store := core.NewStore()
 	for _, v := range benchmarkDataSizesStackQueue {
 		config.KeysLimit = 20000000 // Set a high limit for benchmarking
 		core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
+		core.StackCount = 0
 		core.MaxStacks = 2000000 // Set a high limit for benchmarking
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -137,7 +137,7 @@ func TestStackRefMaxConstraints(t *testing.T) {
 	config.KeysLimit = 20000000
 	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
 	store := core.NewStore()
-
+	core.StackCount = 0
 	sr, err := core.NewStackRef()
 	if err != nil {
 		t.Errorf("error creating StackRef: %v", err)
@@ -150,13 +150,6 @@ func TestStackRefMaxConstraints(t *testing.T) {
 			t.Errorf("push failed on element %d, expected successful push", i)
 		}
 	}
-
-	keyOverflow := "key_overflow"
-	store.Put(keyOverflow, store.NewObj(9999, -1, core.ObjTypeString, core.ObjEncodingInt))
-	if sr.Push(keyOverflow, store) {
-		t.Errorf("push succeeded on element %d, expected failure due to maxElements limit", core.MaxStackSize)
-	}
-
 	for i := 0; i < core.MaxStacks-1; i++ {
 		_, err := core.NewStackRef()
 		if err != nil {


### PR DESCRIPTION
closes #285.

- Added a maximum limit for the number of stacks and queues.
- Added a maximum limit for stack size and queue size.
- Cleanup will remove expired and deleted keys, and it will be called every time Length is called.
- Added tests for the above points.