### PR TITLE
Added support for QUNWATCH command

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -405,6 +405,13 @@ var (
 		Eval:  nil,
 		Arity: 1,
 	}
+	qUnwatchCmdMeta = DiceCmdMeta{
+		Name: "QUNWATCH",
+		Info: `Unsubscribes or QUnwatches the client from the given key's watch session.
+		It removes the key from the watch list for the caller client.`,
+		Eval:  nil,
+		Arity: 1,
+	}
 	multiCmdMeta = DiceCmdMeta{
 		Name: "MULTI",
 		Info: `MULTI marks the start of the transaction for the client.
@@ -657,6 +664,7 @@ func init() {
 	diceCmds["STACKREFPEEK"] = stackrefpeekCmdMeta
 	diceCmds["SUBSCRIBE"] = subscribeCmdMeta
 	diceCmds["QWATCH"] = qwatchCmdMeta
+	diceCmds["QUNWATCH"] = qUnwatchCmdMeta
 	diceCmds["MULTI"] = multiCmdMeta
 	diceCmds["EXEC"] = execCmdMeta
 	diceCmds["DISCARD"] = discardCmdMeta

--- a/tests/qunwatch_test.go
+++ b/tests/qunwatch_test.go
@@ -1,0 +1,82 @@
+package tests
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/dicedb/dice/core"
+	"github.com/dicedb/dice/internal/constants"
+	"gotest.tools/v3/assert"
+)
+
+// need to test the following here:
+// qwatch should work as expected (which is covered in qwatch cases)
+// after a subscribe, and a few updates, unwatch should remove the subscriber from the watch list
+
+func TestQWatchUnwatch(t *testing.T) {
+	publisher := getLocalConnection()
+	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
+
+	// Cleanup Store to remove any existing keys from other qwatch tests
+	// The cleanup is done both on the start and finish just to keep the order of tests run agnostic
+	for _, tc := range qWatchTestCases {
+		fireCommand(publisher, fmt.Sprintf("DEL match:100:user:%d", tc.userID))
+	}
+	defer func() {
+		publisher.Close()
+		for _, sub := range subscribers {
+			sub.Close()
+		}
+	}()
+
+	// Subscribe to the watch query
+	respParsers := make([]*core.RESPParser, len(subscribers))
+
+	for i, sub := range subscribers {
+		rp := fireCommandAndGetRESPParser(sub, "QWATCH \""+qWatchQuery+"\"")
+		respParsers[i] = rp
+
+		// Check if the response is OK
+		resp, err := rp.DecodeOne()
+		assert.NilError(t, err)
+		assert.Equal(t, 3, len(resp.([]interface{})))
+	}
+
+	// Make updates to the store
+	runQWatchScenarios(t, publisher, respParsers)
+
+	// Unwatch the query on two of the subscribers
+	for _, sub := range subscribers[0:2] {
+		rp := fireCommandAndGetRESPParser(sub, "QUNWATCH \""+qWatchQuery+"\"")
+		resp, err := rp.DecodeOne()
+		assert.NilError(t, err)
+		assert.Equal(t, "OK", resp)
+	}
+
+	// qwatch scenarios on the third subscriber should continue to run as expected
+	// AND
+	// continue from the qwatch scenarios that ran previously
+	fireCommand(publisher, "SET match:100:user:1 62")
+	resp, err := respParsers[2].DecodeOne()
+	assert.NilError(t, err)
+	expectedUpdate := []interface{}{[]interface{}{"match:100:user:5", int64(70)}, []interface{}{"match:100:user:1", int64(62)}, []interface{}{"match:100:user:0", int64(60)}}
+	assert.DeepEqual(t, []interface{}{constants.Qwatch, qWatchQuery, expectedUpdate}, resp)
+
+	fireCommand(publisher, "SET match:100:user:5 75")
+	resp, err = respParsers[2].DecodeOne()
+	assert.NilError(t, err)
+	expectedUpdate = []interface{}{[]interface{}{"match:100:user:5", int64(75)}, []interface{}{"match:100:user:1", int64(62)}, []interface{}{"match:100:user:0", int64(60)}}
+	assert.DeepEqual(t, []interface{}{constants.Qwatch, qWatchQuery, expectedUpdate}, resp)
+
+	fireCommand(publisher, "SET match:100:user:0 80")
+	resp, err = respParsers[2].DecodeOne()
+	assert.NilError(t, err)
+	expectedUpdate = []interface{}{[]interface{}{"match:100:user:0", int64(80)}, []interface{}{"match:100:user:5", int64(75)}, []interface{}{"match:100:user:1", int64(62)}}
+	assert.DeepEqual(t, []interface{}{constants.Qwatch, qWatchQuery, expectedUpdate}, resp)
+
+	// Cleanup Store for next tests
+	for _, tc := range qWatchTestCases {
+		fireCommand(publisher, fmt.Sprintf("DEL match:100:user:%d", tc.userID))
+	}
+}


### PR DESCRIPTION
Added support for `QUNWATCH`. Closes #394 

Attaching a demo gif of how things work with the persistent connection.
**NOTE: I have changed my local dice-cli and will be adding comments in the PR open for the same here https://github.com/DiceDB/cli/pull/2 for compatibility**

![qunwatch](https://github.com/user-attachments/assets/d43f8620-a701-481d-a6af-915d2244c477)

P.S. sorry for the quality, wanted to keep it light 