### PR TITLE
Protect keyspace stat operations with mutex

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -288,7 +288,7 @@ func evalDBSIZE(args []string, store *Store) []byte {
 	}
 
 	// return the RESP encoded value
-	return Encode(KeyspaceStat[0]["keys"], false)
+	return Encode(store.keyspaceStat.GetStat("keys"), false)
 }
 
 // evalGETDEL returns the value for the queried key in args
@@ -792,9 +792,7 @@ func evalINFO(args []string, store *Store) []byte {
 	var info []byte
 	buf := bytes.NewBuffer(info)
 	buf.WriteString("# Keyspace\r\n")
-	for i := range KeyspaceStat {
-		fmt.Fprintf(buf, "db%d:keys=%d,expires=0,avg_ttl=0\r\n", i, KeyspaceStat[i]["keys"])
-	}
+	fmt.Fprintf(buf, "keys=%d,expires=0,avg_ttl=0\r\n", store.keyspaceStat.GetStat("keys"))
 	return Encode(buf.String(), false)
 }
 

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -26,7 +26,7 @@ func resetStore(store *Store) {
 	store.store = nil
 	store.keypool = nil
 	store.expires = nil
-	KeyspaceStat[0] = nil
+	store.keyspaceStat = *CreateKeyspaceStat()
 }
 
 func setupTest(store *Store) {
@@ -34,7 +34,7 @@ func setupTest(store *Store) {
 	store.store = make(map[unsafe.Pointer]*Obj)
 	store.keypool = make(map[string]unsafe.Pointer)
 	store.expires = make(map[*Obj]uint64)
-	KeyspaceStat[0] = make(map[string]int)
+	store.keyspaceStat = *CreateKeyspaceStat()
 }
 
 func TestEval(t *testing.T) {
@@ -622,7 +622,7 @@ func testEvalDel(t *testing.T, store *Store) {
 				}
 				store.store[unsafe.Pointer(obj)] = obj
 				store.keypool[key] = unsafe.Pointer(obj)
-				KeyspaceStat[0]["keys"]++
+				store.keyspaceStat.IncrStat("keys")
 			},
 			input:  []string{"EXISTING_KEY"},
 			output: []byte(":1\r\n"),

--- a/core/stats.go
+++ b/core/stats.go
@@ -1,7 +1,42 @@
 package core
 
-var KeyspaceStat [4]map[string]int
+import (
+	"sync"
+)
 
-func UpdateDBStat(num int, metric string, value int) {
-	KeyspaceStat[num][metric] = value
+type KeyspaceStat struct {
+	stats map[string]int
+	mutex sync.Mutex
+}
+
+func CreateKeyspaceStat() *KeyspaceStat {
+	keyspace := &KeyspaceStat{
+		stats: make(map[string]int),
+	}
+	return keyspace
+}
+
+func (ks *KeyspaceStat) UpdateDBStat(metric string, value int) {
+	ks.mutex.Lock()
+	defer ks.mutex.Unlock()
+	ks.stats[metric] = value
+}
+
+func (ks *KeyspaceStat) IncrStat(metric string) {
+	ks.mutex.Lock()
+	defer ks.mutex.Unlock()
+	ks.stats[metric]++
+}
+
+func (ks *KeyspaceStat) DecrKeys(metric string) {
+	ks.mutex.Lock()
+	defer ks.mutex.Unlock()
+	ks.stats[metric]--
+}
+
+func (ks *KeyspaceStat) GetStat(metric string) int {
+	ks.mutex.Lock()
+	defer ks.mutex.Unlock()
+	keyCount := ks.stats[metric]
+	return keyCount
 }

--- a/core/stats_test.go
+++ b/core/stats_test.go
@@ -1,0 +1,32 @@
+package core_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/dicedb/dice/core"
+	"gotest.tools/v3/assert"
+)
+
+func TestIncrDecrStat(t *testing.T) {
+	var wg sync.WaitGroup
+	keyspace := *core.CreateKeyspaceStat()
+	for i := 1; i <= 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			keyspace.IncrStat("keys")
+		}()
+	}
+	for i := 1; i <= 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			keyspace.DecrKeys("keys")
+		}()
+	}
+	wg.Wait()
+	value := keyspace.GetStat("keys")
+	assert.Equal(t, value, 7, fmt.Sprintf("Incorrect stat , Expected : %d, Actutal : %d\n", 7, value))
+}


### PR DESCRIPTION
### Summary

Support for keyspace stats at store level and protect operations using mutex. 

### Changes

- Introduce store level struct for keyspace stats.
- Protect keyspace operations with mutex.
- Unit tests.

Issue : #296 