### PR TITLE
#371: feat: add support for command [JSON.CLEAR] 

### DIFF
--- a/core/commands.go
+++ b/core/commands.go
@@ -104,6 +104,16 @@ var (
 		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	jsonclearCmdMeta = DiceCmdMeta{
+		Name: "JSON.CLEAR",
+		Info: `JSON.CLEAR key [path]
+		Returns an integer reply specifying the number ofmatching JSON arrays and 
+		objects cleared +number of matching JSON numerical values zeroed.
+		Error reply: If the number of arguments is incorrect the key doesn't exist.`,
+		Eval:     evalJSONCLEAR,
+		Arity:    -2,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
 		Info: `TTL returns Time-to-Live in secs for the queried key in args
@@ -622,6 +632,7 @@ func init() {
 	diceCmds["JSON.SET"] = jsonsetCmdMeta
 	diceCmds["JSON.GET"] = jsongetCmdMeta
 	diceCmds["JSON.TYPE"] = jsontypeCmdMeta
+	diceCmds["JSON.CLEAR"] = jsonclearCmdMeta
 	diceCmds["TTL"] = ttlCmdMeta
 	diceCmds["DEL"] = delCmdMeta
 	diceCmds["EXPIRE"] = expireCmdMeta

--- a/core/eval.go
+++ b/core/eval.go
@@ -342,7 +342,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 
 	err := assertType(obj.TypeEncoding, ObjTypeJSON)
 	if err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrWithMessage("Existing key has wrong Dice type")
 	}
 	err = assertEncoding(obj.TypeEncoding, ObjEncodingJSON)
 	if err != nil {

--- a/core/eval.go
+++ b/core/eval.go
@@ -337,7 +337,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 	// Retrieve the object from the database
 	obj := store.Get(key)
 	if obj == nil {
-		return Encode(errors.New("ERR could not perform this operation on a key that doesn't exist"), false)
+		return diceerrors.NewErrWithMessage("ERR could not perform this operation on a key that doesn't exist")
 	}
 
 	err := assertType(obj.TypeEncoding, ObjTypeJSON)
@@ -353,7 +353,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 
 	_, err = sonic.Marshal(jsonData)
 	if err != nil {
-		return Encode(errors.New("ERR could not serialize result"), false)
+		return diceerrors.NewErrWithMessage("ERR could not serialize result")
 	}
 
 	var countClear uint64 = 0
@@ -369,7 +369,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 
 	expr, err := jp.ParseString(path)
 	if err != nil {
-		return Encode(errors.New("ERR invalid JSONPath"), false)
+		return diceerrors.NewErrWithMessage("ERR invalid JSONPath")
 	}
 
 	_, err = expr.Modify(jsonData, func(element any) (altered any, changed bool) {
@@ -395,7 +395,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 		return
 	})
 	if err != nil {
-		return Encode(errors.New(err.Error()), false)
+		return diceerrors.NewErrWithMessage(err.Error())
 	}
 	// Create a new object with the updated JSON data
 	newObj := store.NewObj(jsonData, -1, ObjTypeJSON, ObjEncodingJSON)
@@ -439,7 +439,7 @@ func evalJSONTYPE(args []string, store *Store) []byte {
 	if path == defaultRootPath {
 		_, err := sonic.Marshal(jsonData)
 		if err != nil {
-			return Encode(errors.New("ERR could not serialize result"), false)
+			return diceerrors.NewErrWithMessage("ERR could not serialize result")
 		}
 		// If path is root and len(args) == 1, return "object" instantly
 		if len(args) == 1 {
@@ -450,7 +450,7 @@ func evalJSONTYPE(args []string, store *Store) []byte {
 	// Parse the JSONPath expression
 	expr, err := jp.ParseString(path)
 	if err != nil {
-		return Encode(errors.New("ERR invalid JSONPath"), false)
+		return diceerrors.NewErrWithMessage("ERR invalid JSONPath")
 	}
 
 	results := expr.Get(jsonData)

--- a/core/eval.go
+++ b/core/eval.go
@@ -337,7 +337,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 	// Retrieve the object from the database
 	obj := store.Get(key)
 	if obj == nil {
-		return diceerrors.NewErrWithMessage("ERR could not perform this operation on a key that doesn't exist")
+		return diceerrors.NewErrWithMessage("could not perform this operation on a key that doesn't exist")
 	}
 
 	err := assertType(obj.TypeEncoding, ObjTypeJSON)
@@ -2432,7 +2432,7 @@ func evalFLUSHDB(args []string, store *Store) []byte {
 		flushType = strings.ToUpper(args[0])
 	}
 
-        // TODO: Update this method to work with shared-nothing multithreaded implementation
+	// TODO: Update this method to work with shared-nothing multithreaded implementation
 	switch flushType {
 	case constants.Sync, constants.Async:
 		store.ResetStore()

--- a/core/eval.go
+++ b/core/eval.go
@@ -353,7 +353,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 
 	_, err = sonic.Marshal(jsonData)
 	if err != nil {
-		return diceerrors.NewErrWithMessage("could not serialize result")
+		return diceerrors.NewErrWithMessage("Existing key has wrong Dice type")
 	}
 
 	var countClear uint64 = 0

--- a/core/eval.go
+++ b/core/eval.go
@@ -410,7 +410,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 // The RESP value of the key's value type is encoded and then returned
 func evalJSONTYPE(args []string, store *Store) []byte {
 	if len(args) < 1 {
-		return Encode(errors.New("ERR wrong number of arguments for 'JSON.TYPE' command"), false)
+		return diceerrors.NewErrArity("JSON.TYPE")
 	}
 	key := args[0]
 

--- a/core/eval.go
+++ b/core/eval.go
@@ -353,7 +353,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 
 	_, err = sonic.Marshal(jsonData)
 	if err != nil {
-		return diceerrors.NewErrWithMessage("ERR could not serialize result")
+		return diceerrors.NewErrWithMessage("could not serialize result")
 	}
 
 	var countClear uint64 = 0
@@ -369,7 +369,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 
 	expr, err := jp.ParseString(path)
 	if err != nil {
-		return diceerrors.NewErrWithMessage("ERR invalid JSONPath")
+		return diceerrors.NewErrWithMessage("invalid JSONPath")
 	}
 
 	_, err = expr.Modify(jsonData, func(element any) (altered any, changed bool) {
@@ -439,7 +439,7 @@ func evalJSONTYPE(args []string, store *Store) []byte {
 	if path == defaultRootPath {
 		_, err := sonic.Marshal(jsonData)
 		if err != nil {
-			return diceerrors.NewErrWithMessage("ERR could not serialize result")
+			return diceerrors.NewErrWithMessage("could not serialize result")
 		}
 		// If path is root and len(args) == 1, return "object" instantly
 		if len(args) == 1 {
@@ -450,7 +450,7 @@ func evalJSONTYPE(args []string, store *Store) []byte {
 	// Parse the JSONPath expression
 	expr, err := jp.ParseString(path)
 	if err != nil {
-		return diceerrors.NewErrWithMessage("ERR invalid JSONPath")
+		return diceerrors.NewErrWithMessage("invalid JSONPath")
 	}
 
 	results := expr.Get(jsonData)

--- a/core/eval.go
+++ b/core/eval.go
@@ -346,7 +346,7 @@ func evalJSONCLEAR(args []string, store *Store) []byte {
 	}
 	err = assertEncoding(obj.TypeEncoding, ObjEncodingJSON)
 	if err != nil {
-		return Encode(err, false)
+		return diceerrors.NewErrWithMessage("Existing key has wrong Dice type")
 	}
 
 	jsonData := obj.Value

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -323,8 +323,8 @@ func testEvalJSONCLEAR(t *testing.T, store *Store) {
 				var rootData interface{}
 				_ = sonic.Unmarshal([]byte(value), &rootData)
 				obj := store.NewObj(rootData, -1, ObjTypeJSON, ObjEncodingJSON)
-				store.store[unsafe.Pointer(obj)] = obj
-				store.keypool[key] = unsafe.Pointer(obj)
+				store.store[key] = obj
+				store.keypool[key] = &key
 			},
 			input:  []string{"EXISTING_KEY"},
 			output: []byte(":1\r\n"),
@@ -336,8 +336,8 @@ func testEvalJSONCLEAR(t *testing.T, store *Store) {
 				var rootData interface{}
 				_ = sonic.Unmarshal([]byte(value), &rootData)
 				obj := store.NewObj(rootData, -1, ObjTypeJSON, ObjEncodingJSON)
-				store.store[unsafe.Pointer(obj)] = obj
-				store.keypool[key] = unsafe.Pointer(obj)
+				store.store[key] = obj
+				store.keypool[key] = &key
 			},
 
 			input:  []string{"EXISTING_KEY"},
@@ -350,8 +350,8 @@ func testEvalJSONCLEAR(t *testing.T, store *Store) {
 				var rootData interface{}
 				_ = sonic.Unmarshal([]byte(value), &rootData)
 				obj := store.NewObj(rootData, -1, ObjTypeJSON, ObjEncodingJSON)
-				store.store[unsafe.Pointer(obj)] = obj
-				store.keypool[key] = unsafe.Pointer(obj)
+				store.store[key] = obj
+				store.keypool[key] = &key
 			},
 
 			input:  []string{"EXISTING_KEY", "$.a"},
@@ -364,8 +364,8 @@ func testEvalJSONCLEAR(t *testing.T, store *Store) {
 				var rootData interface{}
 				_ = sonic.Unmarshal([]byte(value), &rootData)
 				obj := store.NewObj(rootData, -1, ObjTypeJSON, ObjEncodingJSON)
-				store.store[unsafe.Pointer(obj)] = obj
-				store.keypool[key] = unsafe.Pointer(obj)
+				store.store[key] = obj
+				store.keypool[key] = &key
 			},
 
 			input:  []string{"EXISTING_KEY", "$.age"},
@@ -378,8 +378,8 @@ func testEvalJSONCLEAR(t *testing.T, store *Store) {
 				var rootData interface{}
 				_ = sonic.Unmarshal([]byte(value), &rootData)
 				obj := store.NewObj(rootData, -1, ObjTypeJSON, ObjEncodingJSON)
-				store.store[unsafe.Pointer(obj)] = obj
-				store.keypool[key] = unsafe.Pointer(obj)
+				store.store[key] = obj
+				store.keypool[key] = &key
 			},
 
 			input:  []string{"EXISTING_KEY", "$.price"},
@@ -392,8 +392,8 @@ func testEvalJSONCLEAR(t *testing.T, store *Store) {
 				var rootData interface{}
 				_ = sonic.Unmarshal([]byte(value), &rootData)
 				obj := store.NewObj(rootData, -1, ObjTypeJSON, ObjEncodingJSON)
-				store.store[unsafe.Pointer(obj)] = obj
-				store.keypool[key] = unsafe.Pointer(obj)
+				store.store[key] = obj
+				store.keypool[key] = &key
 			},
 			input:  []string{"EXISTING_KEY", "$.flag"},
 			output: []byte(":0\r\n"),
@@ -406,8 +406,8 @@ func testEvalJSONCLEAR(t *testing.T, store *Store) {
 				var rootData interface{}
 				_ = sonic.Unmarshal([]byte(value), &rootData)
 				obj := store.NewObj(rootData, -1, ObjTypeJSON, ObjEncodingJSON)
-				store.store[unsafe.Pointer(obj)] = obj
-				store.keypool[key] = unsafe.Pointer(obj)
+				store.store[key] = obj
+				store.keypool[key] = &key
 			},
 			input:  []string{"EXISTING_KEY", "$.*"},
 			output: []byte(":4\r\n"),

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -422,12 +422,12 @@ func testEvalJSONTYPE(t *testing.T, store *Store) {
 		"nil value": {
 			setup:  func() {},
 			input:  nil,
-			output: []byte("-ERR wrong number of arguments for 'JSON.TYPE' command\r\n"),
+			output: []byte("-ERR wrong number of arguments for 'json.type' command\r\n"),
 		},
 		"empty array": {
 			setup:  func() {},
 			input:  []string{},
-			output: []byte("-ERR wrong number of arguments for 'JSON.TYPE' command\r\n"),
+			output: []byte("-ERR wrong number of arguments for 'json.type' command\r\n"),
 		},
 		"key does not exist": {
 			setup:  func() {},

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -33,14 +33,15 @@ const (
 	OperatorLessThanEqualsTo    string = "<="
 	OperatorGreaterThanEqualsTo string = ">="
 
-	ObjectType  string = "object"
-	ArrayType   string = "array"
-	StringType  string = "string"
-	IntegerType string = "integer"
-	NumberType  string = "number"
-	BooleanType string = "boolean"
-	NullType    string = "null"
-	UnknownType string = "unknown"
+	ObjectType      string = "object"
+	ArrayType       string = "array"
+	StringType      string = "string"
+	IntegerType     string = "integer"
+	NumberType      string = "number"
+	BooleanType     string = "boolean"
+	NullType        string = "null"
+	UnknownType     string = "unknown"
+	NumberZeroValue int    = 0
 
 	Qwatch string = "qwatch"
 )


### PR DESCRIPTION
hello:
this pr is link issue: #371 
including two commits:

1. feature: add support for command [JSON.CLEAR]  including integration test. refer to redis command:[json.clear](https://redis.io/docs/latest/commands/json.clear/)
2. refactor: modify the json.type. use lowcase for match dice code style.