### PR TITLE
#411: Add asserts checking non-set commands: addresses #411

### DIFF
--- a/core/diceerrors/diceerrors.go
+++ b/core/diceerrors/diceerrors.go
@@ -65,7 +65,3 @@ func NewErrArity(cmdName string) []byte {
 func NewErrExpireTime(cmdName string) []byte {
 	return NewErrWithFormattedMessage(ExpiryErr, strings.ToLower(cmdName))
 }
-
-func NewErrSetType() []byte {
-	return []byte(fmt.Sprintf("%s\r\n", WrongTypeErr))
-}

--- a/core/eval.go
+++ b/core/eval.go
@@ -261,11 +261,6 @@ func evalGET(args []string, store *Store) []byte {
 		return RespNIL
 	}
 
-	// If the object exists, check if it is a set object.
-	if err := assertType(obj.TypeEncoding, ObjTypeSet); err == nil {
-		return diceerrors.NewErrSetType()
-	}
-
 	// Decode and return the value based on its encoding
 	switch _, oEnc := ExtractTypeEncoding(obj); oEnc {
 	case ObjEncodingInt:
@@ -319,7 +314,7 @@ func evalGETDEL(args []string, store *Store) []byte {
 
 	// If the object exists, check if it is a set object.
 	if err := assertType(obj.TypeEncoding, ObjTypeSet); err == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	// return the RESP encoded value
@@ -933,7 +928,7 @@ func incrDecrCmd(args []string, incr int64, store *Store) []byte {
 
 	// If the object exists, check if it is a set object.
 	if err := assertType(obj.TypeEncoding, ObjTypeSet); err == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeInt); err != nil {
@@ -1032,11 +1027,11 @@ func evalQINTINS(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQint); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	store.Put(args[0], obj)
@@ -1067,11 +1062,11 @@ func evalSTACKINTPUSH(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackInt); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	store.Put(args[0], obj)
@@ -1098,11 +1093,11 @@ func evalQINTREM(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQint); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	q := obj.Value.(*QueueInt)
@@ -1131,11 +1126,11 @@ func evalSTACKINTPOP(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackInt); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	s := obj.Value.(*StackInt)
@@ -1162,11 +1157,11 @@ func evalQINTLEN(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQint); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	q := obj.Value.(*QueueInt)
@@ -1187,11 +1182,11 @@ func evalSTACKINTLEN(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackInt); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	s := obj.Value.(*StackInt)
@@ -1222,11 +1217,11 @@ func evalQINTPEEK(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQint); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	q := obj.Value.(*QueueInt)
@@ -1257,11 +1252,11 @@ func evalSTACKINTPEEK(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackInt); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	s := obj.Value.(*StackInt)
@@ -1289,11 +1284,11 @@ func evalQREFINS(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQref); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	store.Put(args[0], obj)
@@ -1326,11 +1321,11 @@ func evalSTACKREFPUSH(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackRef); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	store.Put(args[0], obj)
@@ -1358,11 +1353,11 @@ func evalQREFREM(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQref); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	q := obj.Value.(*QueueRef)
@@ -1391,11 +1386,11 @@ func evalSTACKREFPOP(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackRef); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	s := obj.Value.(*StackRef)
@@ -1422,11 +1417,11 @@ func evalQREFLEN(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQref); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	q := obj.Value.(*QueueRef)
@@ -1447,11 +1442,11 @@ func evalSTACKREFLEN(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackRef); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	s := obj.Value.(*StackRef)
@@ -1482,11 +1477,11 @@ func evalQREFPEEK(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingQref); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	q := obj.Value.(*QueueRef)
@@ -1517,11 +1512,11 @@ func evalSTACKREFPEEK(args []string, store *Store) []byte {
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertEncoding(obj.TypeEncoding, ObjEncodingStackRef); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	s := obj.Value.(*StackRef)
@@ -1602,7 +1597,7 @@ func evalSETBIT(args []string, store *Store) []byte {
 	}
 	// handle the case when it is set
 	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 	// handle the case when it is byte array
 	if assertType(obj.TypeEncoding, ObjTypeByteArray) == nil {
@@ -1652,7 +1647,7 @@ func evalGETBIT(args []string, store *Store) []byte {
 	}
 	// if object is a set type, return error
 	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	requiredByteArraySize := offset/8 + 1
@@ -1698,7 +1693,7 @@ func evalBITCOUNT(args []string, store *Store) []byte {
 
 	// Check for the type of the object
 	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	var valueInterface = obj.Value
@@ -2231,7 +2226,7 @@ func evalGETEX(args []string, store *Store) []byte {
 
 	// check if the object is set type if yes then return error
 	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	var exDurationMs int64 = -1
@@ -2398,7 +2393,7 @@ func evalLPUSH(args []string, store *Store) []byte {
 
 	// if object is a set type, return error
 	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -2429,7 +2424,7 @@ func evalRPUSH(args []string, store *Store) []byte {
 
 	// if object is a set type, return error
 	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -2460,7 +2455,7 @@ func evalRPOP(args []string, store *Store) []byte {
 
 	// if object is a set type, return error
 	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -2495,7 +2490,7 @@ func evalLPOP(args []string, store *Store) []byte {
 
 	// if object is a set type, return error
 	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -2586,16 +2581,16 @@ func evalSADD(args []string, store *Store) []byte {
 		// If the object does not exist, create a new set object.
 		value := make(map[string]bool)
 		// Create a new object.
-		obj = store.NewObj(value, exDurationMs, ObjTypeSet, ObjEncodingHT)
+		obj = store.NewObj(value, exDurationMs, ObjTypeSet, ObjEncodingSetStr)
 		store.Put(key, obj, WithKeepTTL(keepttl))
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeSet); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
-	if err := assertEncoding(obj.TypeEncoding, ObjEncodingHT); err != nil {
-		return diceerrors.NewErrSetType()
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingSetStr); err != nil {
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	// Get the set object.
@@ -2626,11 +2621,11 @@ func evalSMEMBERS(args []string, store *Store) []byte {
 
 	// If the object exists, check if it is a set object.
 	if err := assertType(obj.TypeEncoding, ObjTypeSet); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
-	if err := assertEncoding(obj.TypeEncoding, ObjEncodingHT); err != nil {
-		return diceerrors.NewErrSetType()
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingSetStr); err != nil {
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	// Get the set object.
@@ -2662,11 +2657,11 @@ func evalSREM(args []string, store *Store) []byte {
 
 	// If the object exists, check if it is a set object.
 	if err := assertType(obj.TypeEncoding, ObjTypeSet); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
-	if err := assertEncoding(obj.TypeEncoding, ObjEncodingHT); err != nil {
-		return diceerrors.NewErrSetType()
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingSetStr); err != nil {
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	// Get the set object.
@@ -2697,11 +2692,11 @@ func evalSCARD(args []string, store *Store) []byte {
 
 	// If the object exists, check if it is a set object.
 	if err := assertType(obj.TypeEncoding, ObjTypeSet); err != nil {
-		return diceerrors.NewErrSetType()
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
-	if err := assertEncoding(obj.TypeEncoding, ObjEncodingHT); err != nil {
-		return diceerrors.NewErrSetType()
+	if err := assertEncoding(obj.TypeEncoding, ObjEncodingSetStr); err != nil {
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	// Get the set object.
@@ -2736,11 +2731,11 @@ func evalSDIFF(args []string, store *Store) []byte {
 	var count int = 0
 	if obj != nil {
 		if err := assertType(obj.TypeEncoding, ObjTypeSet); err != nil {
-			return diceerrors.NewErrSetType()
+			return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 		}
 
-		if err := assertEncoding(obj.TypeEncoding, ObjEncodingHT); err != nil {
-			return diceerrors.NewErrSetType()
+		if err := assertEncoding(obj.TypeEncoding, ObjEncodingSetStr); err != nil {
+			return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 		}
 
 		// create a deep copy of the set object
@@ -2763,11 +2758,11 @@ func evalSDIFF(args []string, store *Store) []byte {
 
 		// If the object exists, check if it is a set object.
 		if err := assertType(obj.TypeEncoding, ObjTypeSet); err != nil {
-			return diceerrors.NewErrSetType()
+			return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 		}
 
-		if err := assertEncoding(obj.TypeEncoding, ObjEncodingHT); err != nil {
-			return diceerrors.NewErrSetType()
+		if err := assertEncoding(obj.TypeEncoding, ObjEncodingSetStr); err != nil {
+			return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 		}
 
 		// only if the count is greater than 0, we need to check the other sets
@@ -2818,11 +2813,11 @@ func evalSINTER(args []string, store *Store) []byte {
 
 		// If the object exists, check if it is a set object.
 		if err := assertType(obj.TypeEncoding, ObjTypeSet); err != nil {
-			return diceerrors.NewErrSetType()
+			return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 		}
 
-		if err := assertEncoding(obj.TypeEncoding, ObjEncodingHT); err != nil {
-			return diceerrors.NewErrSetType()
+		if err := assertEncoding(obj.TypeEncoding, ObjEncodingSetStr); err != nil {
+			return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 		}
 
 		// Get the set object.

--- a/core/eval.go
+++ b/core/eval.go
@@ -261,6 +261,11 @@ func evalGET(args []string, store *Store) []byte {
 		return RespNIL
 	}
 
+	// If the object exists, check if it is a set object.
+	if err := assertType(obj.TypeEncoding, ObjTypeSet); err == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	// Decode and return the value based on its encoding
 	switch _, oEnc := ExtractTypeEncoding(obj); oEnc {
 	case ObjEncodingInt:
@@ -310,6 +315,11 @@ func evalGETDEL(args []string, store *Store) []byte {
 	// if key does not exist, return RESP encoded nil
 	if obj == nil {
 		return RespNIL
+	}
+
+	// If the object exists, check if it is a set object.
+	if err := assertType(obj.TypeEncoding, ObjTypeSet); err == nil {
+		return diceerrors.NewErrSetType()
 	}
 
 	// return the RESP encoded value
@@ -921,6 +931,11 @@ func incrDecrCmd(args []string, incr int64, store *Store) []byte {
 		store.Put(key, obj)
 	}
 
+	// If the object exists, check if it is a set object.
+	if err := assertType(obj.TypeEncoding, ObjTypeSet); err == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	if err := assertType(obj.TypeEncoding, ObjTypeInt); err != nil {
 		return diceerrors.NewErrWithMessage(err.Error())
 	}
@@ -1051,6 +1066,11 @@ func evalSTACKINTPUSH(args []string, store *Store) []byte {
 		obj = store.NewObj(NewStackInt(), -1, ObjTypeByteList, ObjEncodingStackInt)
 	}
 
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1115,6 +1135,11 @@ func evalSTACKINTPOP(args []string, store *Store) []byte {
 		return RespNIL
 	}
 
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1169,6 +1194,11 @@ func evalSTACKINTLEN(args []string, store *Store) []byte {
 	obj := store.Get(args[0])
 	if obj == nil {
 		return RespZero
+	}
+
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -1241,6 +1271,11 @@ func evalSTACKINTPEEK(args []string, store *Store) []byte {
 		return RespEmptyArray
 	}
 
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1310,6 +1345,11 @@ func evalSTACKREFPUSH(args []string, store *Store) []byte {
 		obj = store.NewObj(sr, -1, ObjTypeByteList, ObjEncodingStackRef)
 	}
 
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1375,6 +1415,11 @@ func evalSTACKREFPOP(args []string, store *Store) []byte {
 		return RespNIL
 	}
 
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1429,6 +1474,11 @@ func evalSTACKREFLEN(args []string, store *Store) []byte {
 	obj := store.Get(args[0])
 	if obj == nil {
 		return RespZero
+	}
+
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -1499,6 +1549,11 @@ func evalSTACKREFPEEK(args []string, store *Store) []byte {
 	obj := store.Get(args[0])
 	if obj == nil {
 		return RespEmptyArray
+	}
+
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -1585,7 +1640,10 @@ func evalSETBIT(args []string, store *Store) []byte {
 	if assertType(obj.TypeEncoding, ObjTypeString) == nil {
 		return diceerrors.NewErrWithMessage("value is not a valid byte array")
 	}
-
+	// handle the case when it is set
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
 	// handle the case when it is byte array
 	if assertType(obj.TypeEncoding, ObjTypeByteArray) == nil {
 		byteArray := obj.Value.(*ByteArray)
@@ -1632,6 +1690,10 @@ func evalGETBIT(args []string, store *Store) []byte {
 	if obj == nil {
 		return Encode(0, true)
 	}
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
 
 	requiredByteArraySize := offset/8 + 1
 
@@ -1672,6 +1734,11 @@ func evalBITCOUNT(args []string, store *Store) []byte {
 	var obj = store.Get(key)
 	if obj == nil {
 		return Encode(0, false)
+	}
+
+	// Check for the type of the object
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
 	}
 
 	var valueInterface = obj.Value
@@ -2202,6 +2269,11 @@ func evalGETEX(args []string, store *Store) []byte {
 		return RespNIL
 	}
 
+	// check if the object is set type if yes then return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	var exDurationMs int64 = -1
 	var state exDurationState = Uninitialized
 	var persist bool = false
@@ -2364,6 +2436,11 @@ func evalLPUSH(args []string, store *Store) []byte {
 		obj = store.NewObj(NewDeque(), -1, ObjTypeByteList, ObjEncodingDeque)
 	}
 
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return Encode(err, false)
 	}
@@ -2390,6 +2467,11 @@ func evalRPUSH(args []string, store *Store) []byte {
 		obj = store.NewObj(NewDeque(), -1, ObjTypeByteList, ObjEncodingDeque)
 	}
 
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
+	}
+
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return Encode(err, false)
 	}
@@ -2414,6 +2496,11 @@ func evalRPOP(args []string, store *Store) []byte {
 	obj := store.Get(args[0])
 	if obj == nil {
 		return RespNIL
+	}
+
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -2444,6 +2531,11 @@ func evalLPOP(args []string, store *Store) []byte {
 	obj := store.Get(args[0])
 	if obj == nil {
 		return RespNIL
+	}
+
+	// if object is a set type, return error
+	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
+		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {

--- a/core/eval.go
+++ b/core/eval.go
@@ -1066,11 +1066,6 @@ func evalSTACKINTPUSH(args []string, store *Store) []byte {
 		obj = store.NewObj(NewStackInt(), -1, ObjTypeByteList, ObjEncodingStackInt)
 	}
 
-	// if object is a set type, return error
-	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
-	}
-
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1135,11 +1130,6 @@ func evalSTACKINTPOP(args []string, store *Store) []byte {
 		return RespNIL
 	}
 
-	// if object is a set type, return error
-	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
-	}
-
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1194,11 +1184,6 @@ func evalSTACKINTLEN(args []string, store *Store) []byte {
 	obj := store.Get(args[0])
 	if obj == nil {
 		return RespZero
-	}
-
-	// if object is a set type, return error
-	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -1271,11 +1256,6 @@ func evalSTACKINTPEEK(args []string, store *Store) []byte {
 		return RespEmptyArray
 	}
 
-	// if object is a set type, return error
-	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
-	}
-
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1345,11 +1325,6 @@ func evalSTACKREFPUSH(args []string, store *Store) []byte {
 		obj = store.NewObj(sr, -1, ObjTypeByteList, ObjEncodingStackRef)
 	}
 
-	// if object is a set type, return error
-	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
-	}
-
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1415,11 +1390,6 @@ func evalSTACKREFPOP(args []string, store *Store) []byte {
 		return RespNIL
 	}
 
-	// if object is a set type, return error
-	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
-	}
-
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
 		return diceerrors.NewErrSetType()
 	}
@@ -1474,11 +1444,6 @@ func evalSTACKREFLEN(args []string, store *Store) []byte {
 	obj := store.Get(args[0])
 	if obj == nil {
 		return RespZero
-	}
-
-	// if object is a set type, return error
-	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {
@@ -1549,11 +1514,6 @@ func evalSTACKREFPEEK(args []string, store *Store) []byte {
 	obj := store.Get(args[0])
 	if obj == nil {
 		return RespEmptyArray
-	}
-
-	// if object is a set type, return error
-	if assertType(obj.TypeEncoding, ObjTypeSet) == nil {
-		return diceerrors.NewErrSetType()
 	}
 
 	if err := assertType(obj.TypeEncoding, ObjTypeByteList); err != nil {

--- a/core/object.go
+++ b/core/object.go
@@ -37,7 +37,8 @@ var ObjEncodingByteArray uint8 = 4
 var ObjTypeInt uint8 = 5 << 4 // 01010000
 
 var ObjTypeSet uint8 = 6 << 4 // 01010000
-var ObjEncodingHT uint8 = 0   // 00000000
+var ObjEncodingSetInt uint8 = 11
+var ObjEncodingSetStr uint8 = 12
 
 func ExtractTypeEncoding(obj *Obj) (e1, e2 uint8) {
 	return obj.TypeEncoding & 0b11110000, obj.TypeEncoding & 0b00001111

--- a/core/resp.go
+++ b/core/resp.go
@@ -228,6 +228,8 @@ func Encode(value interface{}, isSimple bool) []byte {
 			buf.Write(Encode(row.Value.Value, false))
 		}
 		return []byte(fmt.Sprintf("*%d\r\n%s", len(v), buf.Bytes()))
+	case map[string]bool:
+		return RespNIL
 	default:
 		fmt.Printf("Unsupported type: %T\n", v)
 		return RespNIL

--- a/tests/check_type_test.go
+++ b/tests/check_type_test.go
@@ -1,0 +1,103 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+// this file may contain test cases for checking error messages accross all commands
+func TestErrorsForSetData(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	setErrorMsg := "WRONGTYPE Operation against a key holding the wrong kind of value"
+	testCases := []struct {
+		name        string
+		cmd         []string
+		expected    []interface{}
+		assert_type []string
+		delay       []time.Duration
+	}{
+		{
+			name:        "GET a key holding a set",
+			cmd:         []string{"SADD foo bar", "GET foo"},
+			expected:    []interface{}{int64(1), setErrorMsg},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name:        "GETDEL a key holding a set",
+			cmd:         []string{"SADD foo bar", "GETDEL foo"},
+			expected:    []interface{}{int64(1), setErrorMsg},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name:        "INCR a key holding a set",
+			cmd:         []string{"SADD foo bar", "INCR foo"},
+			expected:    []interface{}{int64(1), setErrorMsg},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name:        "DECR a key holding a set",
+			cmd:         []string{"SADD foo bar", "DECR foo"},
+			expected:    []interface{}{int64(1), setErrorMsg},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name:        "STACKINT{OP} a key holding a set",
+			cmd:         []string{"SADD foo bar", "STACKINTPUSH foo 1", "STACKINTPOP foo", "STACKINTLEN foo", "STACKINTPEEK foo", "STACKREFPUSH foo 1", "STACKREFPOP foo", "STACKREFLEN foo", "STACKREFPEEK foo"},
+			expected:    []interface{}{int64(1), setErrorMsg, setErrorMsg, setErrorMsg, setErrorMsg, setErrorMsg, setErrorMsg, setErrorMsg, setErrorMsg},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:        "BIT operations on a key holding a set",
+			cmd:         []string{"SADD foo bar", "GETBIT foo 1", "BITCOUNT foo"},
+			expected:    []interface{}{int64(1), setErrorMsg, setErrorMsg},
+			assert_type: []string{"equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0},
+		},
+		{
+			name:        "GETEX a key holding a set",
+			cmd:         []string{"SADD foo bar", "GETEX foo"},
+			expected:    []interface{}{int64(1), setErrorMsg},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name:        "GETSET a key holding a set",
+			cmd:         []string{"SADD foo bar", "GETSET foo bar"},
+			expected:    []interface{}{int64(1), setErrorMsg},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name:        "LPUSH, LPOP, RPUSH, RPOP a key holding a set",
+			cmd:         []string{"SADD foo bar", "LPUSH foo bar", "LPOP foo", "RPUSH foo bar", "RPOP foo"},
+			expected:    []interface{}{int64(1), setErrorMsg, setErrorMsg, setErrorMsg, setErrorMsg},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Delete the key before running the test
+			fireCommand(conn, "DEL foo")
+			for i, cmd := range tc.cmd {
+				if tc.delay[i] > 0 {
+					time.Sleep(tc.delay[i])
+				}
+				res := fireCommand(conn, cmd)
+				if tc.assert_type[i] == "equal" {
+					assert.Equal(t, res, tc.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
* The changes that are included in the PR.

Addresses #411 
Added assertType for commands that are not applicable for SET Data structures.

  * Design document, if any.
  
Commands related to STACKINT, Queue, BITs, GET were modified to return consistent messages.

  * Information on any implementation choices that were made.

  * Evidence of sufficient testing. You ``MUST`` indicate the tests done, either manually or automated.

existing test cases pass + added new test cases to check this behaviour.