### PR TITLE
Move QWATCH logic to QueryWatcher

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -1529,10 +1529,14 @@ func evalQWATCH(args []string, c *Client, store *Store) []byte {
 		return Encode(e, false)
 	}
 
-	store.AddWatcher(query, c.Fd)
+	WatchSubscriptionChan <- WatchSubscription{
+		subscribe: true,
+		query:     query,
+		clientFd:  c.Fd,
+	}
 
 	// Return the result of the query.
-	queryResult, err := ExecuteQuery(query, store)
+	queryResult, err := ExecuteQuery(&query, store)
 	if err != nil {
 		return Encode(err, false)
 	}
@@ -1542,7 +1546,7 @@ func evalQWATCH(args []string, c *Client, store *Store) []byte {
 }
 
 // evalQUNWATCH removes the specified key from the watch list for the caller client.
-func evalQUNWATCH(args []string, c *Client, store *Store) []byte {
+func evalQUNWATCH(args []string, c *Client) []byte {
 	if len(args) != 1 {
 		return diceerrors.NewErrArity("QUNWATCH")
 	}
@@ -1550,7 +1554,13 @@ func evalQUNWATCH(args []string, c *Client, store *Store) []byte {
 	if e != nil {
 		return Encode(e, false)
 	}
-	store.RemoveWatcher(query, c.Fd)
+
+	WatchSubscriptionChan <- WatchSubscription{
+		subscribe: false,
+		query:     query,
+		clientFd:  c.Fd,
+	}
+
 	return RespOK
 }
 
@@ -2029,7 +2039,7 @@ func executeCommand(cmd *RedisCmd, c *Client, store *Store) []byte {
 		return evalQWATCH(cmd.Args, c, store)
 	}
 	if diceCmd.Name == "UNSUBSCRIBE" || diceCmd.Name == "QUNWATCH" {
-		return evalQUNWATCH(cmd.Args, c, store)
+		return evalQUNWATCH(cmd.Args, c)
 	}
 	if diceCmd.Name == "MULTI" {
 		c.TxnBegin()

--- a/core/executerbechmark_test.go
+++ b/core/executerbechmark_test.go
@@ -55,7 +55,7 @@ func BenchmarkExecuteQueryOrderBykey(b *testing.B) {
 
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -84,7 +84,7 @@ func BenchmarkExecuteQueryBasicOrderByValue(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -114,7 +114,7 @@ func BenchmarkExecuteQueryLimit(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -139,7 +139,7 @@ func BenchmarkExecuteQueryNoMatch(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -169,7 +169,7 @@ func BenchmarkExecuteQueryWithBasicWhere(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -210,7 +210,7 @@ func BenchmarkExecuteQueryWithComplexWhere(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -240,7 +240,7 @@ func BenchmarkExecuteQueryWithCompareWhereKeyandValue(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -270,7 +270,7 @@ func BenchmarkExecuteQueryWithBasicWhereNoMatch(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -300,7 +300,7 @@ func BenchmarkExecuteQueryWithNullValues(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -330,7 +330,7 @@ func BenchmarkExecuteQueryWithCaseSesnsitivity(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -364,7 +364,7 @@ func BenchmarkExecuteQueryWithClauseOnKey(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -389,7 +389,7 @@ func BenchmarkExecuteQueryWithEmptyKeyRegex(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -439,7 +439,7 @@ func BenchmarkExecuteQueryWithJSON(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := core.ExecuteQuery(query, store); err != nil {
+					if _, err := core.ExecuteQuery(&query, store); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -471,7 +471,7 @@ func BenchmarkExecuteQueryWithNestedJSON(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := core.ExecuteQuery(query, store); err != nil {
+					if _, err := core.ExecuteQuery(&query, store); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -503,7 +503,7 @@ func BenchmarkExecuteQueryWithJsonInLeftAndRightExpressions(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := core.ExecuteQuery(query, store); err != nil {
+					if _, err := core.ExecuteQuery(&query, store); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -535,7 +535,7 @@ func BenchmarkExecuteQueryWithJsonNoMatch(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := core.ExecuteQuery(query, store); err != nil {
+					if _, err := core.ExecuteQuery(&query, store); err != nil {
 						b.Fatal(err)
 					}
 				}

--- a/core/executor.go
+++ b/core/executor.go
@@ -22,7 +22,7 @@ type DSQLQueryResultRow struct {
 }
 
 //nolint:gocritic
-func ExecuteQuery(query DSQLQuery, store *Store) ([]DSQLQueryResultRow, error) {
+func ExecuteQuery(query *DSQLQuery, store *Store) ([]DSQLQueryResultRow, error) {
 	var result []DSQLQueryResultRow
 
 	var err error
@@ -97,7 +97,7 @@ func MarshalResultIfJSON(row DSQLQueryResultRow) error {
 }
 
 //nolint:gocritic
-func sortResults(query DSQLQuery, result []DSQLQueryResultRow) {
+func sortResults(query *DSQLQuery, result []DSQLQueryResultRow) {
 	if query.OrderBy.OrderBy == constants.EmptyStr {
 		return
 	}

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -53,7 +53,7 @@ func TestExecuteQueryOrderBykey(t *testing.T) {
 		},
 	}
 
-	result, err := core.ExecuteQuery(query, store)
+	result, err := core.ExecuteQuery(&query, store)
 
 	assert.NilError(t, err)
 	assert.Equal(t, len(result), len(dataset))
@@ -88,7 +88,7 @@ func TestExecuteQueryBasicOrderByValue(t *testing.T) {
 		},
 	}
 
-	result, err := core.ExecuteQuery(query, store)
+	result, err := core.ExecuteQuery(&query, store)
 
 	assert.NilError(t, err)
 	assert.Equal(t, len(result), len(dataset))
@@ -124,7 +124,7 @@ func TestExecuteQueryLimit(t *testing.T) {
 		Limit: 3,
 	}
 
-	result, err := core.ExecuteQuery(query, store)
+	result, err := core.ExecuteQuery(&query, store)
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Len(result, 3)) // Checks if limit is respected
@@ -155,7 +155,7 @@ func TestExecuteQueryNoMatch(t *testing.T) {
 		},
 	}
 
-	result, err := core.ExecuteQuery(query, store)
+	result, err := core.ExecuteQuery(&query, store)
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Len(result, 0)) // No keys match "x*"
@@ -178,7 +178,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause")
@@ -200,7 +200,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 0, "Expected empty result for non-matching WHERE clause")
@@ -231,7 +231,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 2, "Expected 2 results for complex WHERE clause")
@@ -252,7 +252,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for comparison between key and value")
@@ -279,7 +279,7 @@ func TestExecuteQueryWithIncompatibleTypes(t *testing.T) {
 			},
 		}
 
-		_, err := core.ExecuteQuery(query, store)
+		_, err := core.ExecuteQuery(&query, store)
 
 		assert.Error(t, err, "incompatible types in comparison: string and int")
 	})
@@ -303,7 +303,7 @@ func TestExecuteQueryWithIncompatibleTypes(t *testing.T) {
 			},
 		}
 
-		_, err := core.ExecuteQuery(query, store)
+		_, err := core.ExecuteQuery(&query, store)
 
 		assert.Error(t, err, "unsupported value type: <nil>")
 	})
@@ -327,7 +327,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 0, "Expected 0 results due to case sensitivity")
@@ -351,7 +351,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 2, "Expected 2 results for WHERE clause on key")
@@ -372,7 +372,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 			},
 		}
 
-		_, err := core.ExecuteQuery(query, store)
+		_, err := core.ExecuteQuery(&query, store)
 
 		assert.ErrorContains(t, err, "unsupported operator")
 	})
@@ -385,7 +385,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 				ValueSelection: true,
 			},
 		}
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 0, "Expected no keys to be returned for empty regex")
@@ -434,7 +434,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 results for WHERE clause")
@@ -460,7 +460,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 0, "Expected empty result for non-matching WHERE clause")
@@ -480,7 +480,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with floating point values")
@@ -506,7 +506,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with integer values")
@@ -532,7 +532,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with nested json")
@@ -558,7 +558,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(query, store)
+		result, err := core.ExecuteQuery(&query, store)
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for Complex WHERE clause expression")

--- a/core/query_watcher.go
+++ b/core/query_watcher.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"context"
+	"github.com/charmbracelet/log"
+	"sync"
+	"syscall"
+)
+
+// WatchEvent Event to notify clients about changes in query results due to key updates
+type WatchEvent struct {
+	Key       string
+	Operation string
+	Value     *Obj
+}
+
+// WatchSubscription Event to watch/unwatch a query
+type WatchSubscription struct {
+	subscribe bool      // true for subscribe, false for unsubscribe
+	query     DSQLQuery // query to watch
+	clientFd  int       // client file descriptor
+}
+
+// WatchChan Channel to receive updates about keys that are being watched
+var WatchChan chan WatchEvent
+
+// WatchSubscriptionChan Channel to receive updates about query subscriptions
+var WatchSubscriptionChan chan WatchSubscription
+
+// QueryWatcher watches for changes in keys and notifies clients
+type QueryWatcher struct {
+	WatchList sync.Map
+	store     *Store
+}
+
+// NewQueryWatcher initializes a new QueryWatcher
+func NewQueryWatcher(store *Store) *QueryWatcher {
+	return &QueryWatcher{
+		WatchList: sync.Map{},
+		store:     store,
+	}
+}
+
+func (w *QueryWatcher) Run(ctx context.Context) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		w.Watch(ctx)
+	}()
+
+	<-ctx.Done()
+	wg.Wait()
+}
+
+// Watch watches for changes in keys and notifies clients
+func (w *QueryWatcher) Watch(ctx context.Context) {
+	for {
+		select {
+		case event := <-WatchSubscriptionChan:
+			if event.subscribe {
+				w.AddWatcher(event.query, event.clientFd)
+			} else {
+				w.RemoveWatcher(event.query, event.clientFd)
+			}
+		case event := <-WatchChan:
+			w.WatchList.Range(func(key, value interface{}) bool {
+				query := key.(DSQLQuery)
+				clients := value.(*sync.Map)
+
+				if WildCardMatch(query.KeyRegex, event.Key) {
+					queryResult, err := ExecuteQuery(&query, w.store)
+					if err != nil {
+						log.Error(err)
+						return true
+					}
+
+					encodedResult := Encode(CreatePushResponse(&query, &queryResult), false)
+					clients.Range(func(clientKey, _ interface{}) bool {
+						clientFd := clientKey.(int)
+						_, err := syscall.Write(clientFd, encodedResult)
+						if err != nil {
+							w.RemoveWatcher(query, clientFd)
+						}
+						return true
+					})
+				}
+				return true
+			})
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// AddWatcher adds a client as a watcher to a query.
+func (w *QueryWatcher) AddWatcher(query DSQLQuery, clientFd int) { //nolint:gocritic
+	clients, _ := w.WatchList.LoadOrStore(query, &sync.Map{})
+	clients.(*sync.Map).Store(clientFd, struct{}{})
+}
+
+// RemoveWatcher removes a client from the watchlist for a query.
+func (w *QueryWatcher) RemoveWatcher(query DSQLQuery, clientFd int) { //nolint:gocritic
+	if clients, ok := w.WatchList.Load(query); ok {
+		clients.(*sync.Map).Delete(clientFd)
+		// If no more clients for this query, remove the query from WatchList
+		if w.clientCount(clients.(*sync.Map)) == 0 {
+			w.WatchList.Delete(query)
+		}
+	}
+}
+
+// Helper function to count clients
+func (w *QueryWatcher) clientCount(clients *sync.Map) int {
+	count := 0
+	clients.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
+}

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -166,7 +166,7 @@ func TestRemoveAllExpired(t *testing.T) {
 
 func TestQueueRefMaxConstraints(t *testing.T) {
 	config.KeysLimit = 20000000
-	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
+	core.WatchChan = make(chan core.WatchEvent, config.KeysLimit)
 	core.QueueCount = 0 // reset counter
 	qr, err := core.NewQueueRef()
 	if err != nil {

--- a/core/resp.go
+++ b/core/resp.go
@@ -217,8 +217,7 @@ func Encode(value interface{}, isSimple bool) []byte {
 		we := value.(WatchEvent)
 		buf.Write(Encode(fmt.Sprintf("key:%s", we.Key), false))
 		buf.Write(Encode(fmt.Sprintf("op:%s", we.Operation), false))
-		buf.Write(Encode(we.Value.Value, false))
-		return []byte(fmt.Sprintf("*3\r\n%s", buf.Bytes()))
+		return []byte(fmt.Sprintf("*2\r\n%s", buf.Bytes()))
 	case []DSQLQueryResultRow:
 		var b []byte
 		buf := bytes.NewBuffer(b)

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -171,7 +171,7 @@ func TestStackRefLen(t *testing.T) {
 }
 func TestStackRefMaxConstraints(t *testing.T) {
 	config.KeysLimit = 20000000
-	core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
+	core.WatchChan = make(chan core.WatchEvent, config.KeysLimit)
 	store := core.NewStore()
 	core.StackCount = 0
 	sr, err := core.NewStackRef()
@@ -203,7 +203,7 @@ func BenchmarkRemoveLargeNumberOfExpiredKeys(b *testing.B) {
 	store := core.NewStore()
 	for _, v := range benchmarkDataSizesStackQueue {
 		config.KeysLimit = 20000000 // Set a high limit for benchmarking
-		core.WatchChannel = make(chan core.WatchEvent, config.KeysLimit)
+		core.WatchChan = make(chan core.WatchEvent, config.KeysLimit)
 		var sr *core.StackRef
 		var err error
 		if sr, err = core.NewStackRef(); err != nil {

--- a/core/store.go
+++ b/core/store.go
@@ -108,7 +108,7 @@ func (store *Store) putHelper(k string, obj *Obj, opts ...PutOption) {
 	store.store[*ptr] = obj
 
 	store.incrementKeyCount()
-	notifyWatchers(k, "SET", obj)
+	notifyWatchers(k, "SET")
 }
 
 func (store *Store) getHelper(k string, touch bool) *Obj {
@@ -235,7 +235,7 @@ func (store *Store) Rename(sourceKey, destKey string) bool {
 		}
 
 		// Notify watchers about the deletion of the source key
-		notifyWatchers(sourceKey, "DEL", sourceObj)
+		notifyWatchers(sourceKey, "DEL")
 
 		return true
 	}, store, WithStoreLock(), WithKeypoolLock())
@@ -300,7 +300,7 @@ func (store *Store) deleteKey(k, ptr string, obj *Obj) bool {
 		delete(store.expires, obj)
 		delete(store.keypool, k)
 		KeyspaceStat[0]["keys"]--
-		notifyWatchers(k, "DEL", obj)
+		notifyWatchers(k, "DEL")
 		return true
 	}
 	return false
@@ -314,6 +314,6 @@ func (store *Store) delByPtr(ptr string) bool {
 	return false
 }
 
-func notifyWatchers(k, operation string, obj *Obj) {
-	WatchChan <- WatchEvent{k, operation, obj}
+func notifyWatchers(k, operation string) {
+	WatchChan <- WatchEvent{k, operation}
 }

--- a/core/store.go
+++ b/core/store.go
@@ -8,27 +8,18 @@ import (
 	"github.com/dicedb/dice/server/utils"
 )
 
-type WatchEvent struct {
-	Key       string
-	Operation string
-	Value     *Obj
-}
-
 type Store struct {
 	store        map[string]*Obj
 	expires      map[*Obj]uint64 // Does not need to be thread-safe as it is only accessed by a single thread.
 	keypool      map[string]*string
 	storeMutex   sync.RWMutex
 	keypoolMutex sync.RWMutex
-	WatchList    sync.Map // Maps queries to the file descriptors of clients that are watching them.
-
 }
 
-// WatchChannel Channel to receive updates about keys that are being watched.
-var WatchChannel chan WatchEvent
-
 func NewStore() *Store {
-	WatchChannel = make(chan WatchEvent, config.KeysLimit)
+	WatchChan = make(chan WatchEvent, config.KeysLimit)
+	WatchSubscriptionChan = make(chan WatchSubscription)
+
 	return &Store{
 		store:   make(map[string]*Obj),
 		expires: make(map[*Obj]uint64),
@@ -53,7 +44,8 @@ func (store *Store) ResetStore() {
 		store.store = make(map[string]*Obj)
 		store.expires = make(map[*Obj]uint64)
 		store.keypool = make(map[string]*string)
-		WatchChannel = make(chan WatchEvent, config.KeysLimit)
+		WatchChan = make(chan WatchEvent, config.KeysLimit)
+		WatchSubscriptionChan = make(chan WatchSubscription)
 	}, store, WithStoreLock(), WithKeypoolLock())
 }
 
@@ -210,23 +202,6 @@ func (store *Store) GetDBSize() uint64 {
 	return noOfKeys
 }
 
-// Function to add a new watcher to a query.
-func (store *Store) AddWatcher(query DSQLQuery, clientFd int) { //nolint:gocritic
-	clients, _ := store.WatchList.LoadOrStore(query, &sync.Map{})
-	clients.(*sync.Map).Store(clientFd, struct{}{})
-}
-
-// Function to remove a watcher from a query.
-func (store *Store) RemoveWatcher(query DSQLQuery, clientFd int) { //nolint:gocritic
-	if clients, ok := store.WatchList.Load(query); ok {
-		clients.(*sync.Map).Delete(clientFd)
-		// If no more clients for this query, remove the query from WatchList
-		if countClients(clients.(*sync.Map)) == 0 {
-			store.WatchList.Delete(query)
-		}
-	}
-}
-
 // Rename function to implement RENAME functionality using existing helpers
 
 func (store *Store) Rename(sourceKey, destKey string) bool {
@@ -310,16 +285,6 @@ func (store *Store) setUnixTimeExpiry(obj *Obj, exUnixTimeSec int64) {
 	store.expires[obj] = uint64(exUnixTimeSec * 1000)
 }
 
-// Helper function to count clients
-func countClients(clients *sync.Map) int {
-	count := 0
-	clients.Range(func(_, _ interface{}) bool {
-		count++
-		return true
-	})
-	return count
-}
-
 func (store *Store) ensureKeyInPool(k string) *string {
 	ptr, ok := store.keypool[k]
 	if !ok {
@@ -350,5 +315,5 @@ func (store *Store) delByPtr(ptr string) bool {
 }
 
 func notifyWatchers(k, operation string, obj *Obj) {
-	WatchChannel <- WatchEvent{k, operation, obj}
+	WatchChan <- WatchEvent{k, operation, obj}
 }

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -27,16 +27,20 @@ type AsyncServer struct {
 	multiplexerPollTimeout time.Duration
 	connectedClients       map[int]*core.Client
 	store                  *core.Store
+	queryWatcher           *core.QueryWatcher
 	lastCronExecTime       time.Time
 	cronFrequency          time.Duration
+	WatchList              sync.Map // Maps queries to the file descriptors of clients that are watching them.
 }
 
 // NewAsyncServer initializes a new AsyncServer
 func NewAsyncServer() *AsyncServer {
+	store := core.NewStore()
 	return &AsyncServer{
 		maxClients:             config.ServerMaxClients,
 		connectedClients:       make(map[int]*core.Client),
-		store:                  core.NewStore(),
+		store:                  store,
+		queryWatcher:           core.NewQueryWatcher(store),
 		multiplexerPollTimeout: config.ServerMultiplexerPollTimeout,
 		lastCronExecTime:       utils.GetCurrentTime(),
 		cronFrequency:          config.ServerCronFrequency,
@@ -54,40 +58,6 @@ func (s *AsyncServer) SetupUsers() error {
 	}
 	log.Info("default user set up", "password required", config.RequirePass != constants.EmptyStr)
 	return nil
-}
-
-// WatchKeys watches for changes in keys and notifies clients
-func (s *AsyncServer) WatchKeys(ctx context.Context) {
-	for {
-		select {
-		case event := <-core.WatchChannel:
-			s.store.WatchList.Range(func(key, value interface{}) bool {
-				query := key.(core.DSQLQuery)
-				clients := value.(*sync.Map)
-
-				if core.WildCardMatch(query.KeyRegex, event.Key) {
-					queryResult, err := core.ExecuteQuery(query, s.store)
-					if err != nil {
-						log.Error(err)
-						return true
-					}
-
-					encodedResult := core.Encode(core.CreatePushResponse(&query, &queryResult), false)
-					clients.Range(func(clientKey, _ interface{}) bool {
-						clientFd := clientKey.(int)
-						_, err := syscall.Write(clientFd, encodedResult)
-						if err != nil {
-							s.store.RemoveWatcher(query, clientFd)
-						}
-						return true
-					})
-				}
-				return true
-			})
-		case <-ctx.Done():
-			return
-		}
-	}
 }
 
 // FindPortAndBind binds the server to the given host and port
@@ -135,18 +105,18 @@ func (s *AsyncServer) Run(ctx context.Context) error {
 		}
 	}(s.serverFD)
 
-	watchCtx, cancelWatch := context.WithCancel(ctx)
-	defer cancelWatch()
-
 	if err := s.SetupUsers(); err != nil {
 		return err
 	}
 
+	watchCtx, cancelWatch := context.WithCancel(ctx)
+	defer cancelWatch()
 	var wg sync.WaitGroup
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		s.WatchKeys(watchCtx)
+		s.queryWatcher.Run(watchCtx)
 	}()
 
 	if err := syscall.Listen(s.serverFD, s.maxClients); err != nil {

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -30,7 +30,6 @@ type AsyncServer struct {
 	queryWatcher           *core.QueryWatcher
 	lastCronExecTime       time.Time
 	cronFrequency          time.Duration
-	WatchList              sync.Map // Maps queries to the file descriptors of clients that are watching them.
 }
 
 // NewAsyncServer initializes a new AsyncServer

--- a/tests/qunwatch_test.go
+++ b/tests/qunwatch_test.go
@@ -18,7 +18,7 @@ func TestQWatchUnwatch(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
-	// Cleanup Store to remove any existing keys from other qwatch tests
+	// Cleanup store to remove any existing keys from other qwatch tests
 	// The cleanup is done both on the start and finish just to keep the order of tests run agnostic
 	for _, tc := range qWatchTestCases {
 		fireCommand(publisher, fmt.Sprintf("DEL match:100:user:%d", tc.userID))
@@ -75,7 +75,7 @@ func TestQWatchUnwatch(t *testing.T) {
 	expectedUpdate = []interface{}{[]interface{}{"match:100:user:0", int64(80)}, []interface{}{"match:100:user:5", int64(75)}, []interface{}{"match:100:user:1", int64(62)}}
 	assert.DeepEqual(t, []interface{}{constants.Qwatch, qWatchQuery, expectedUpdate}, resp)
 
-	// Cleanup Store for next tests
+	// Cleanup store for next tests
 	for _, tc := range qWatchTestCases {
 		fireCommand(publisher, fmt.Sprintf("DEL match:100:user:%d", tc.userID))
 	}

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -214,7 +214,7 @@ var JSONTestCases = []struct {
 func TestQwatchWithJSON(t *testing.T) {
 	publisher := getLocalConnection()
 
-	// Cleanup Store for next tests
+	// Cleanup store for next tests
 	for _, tc := range JSONTestCases {
 		fireCommand(publisher, fmt.Sprintf("DEL %s", tc.key))
 	}


### PR DESCRIPTION
## QWATCH Refactoring

Key changes:

- Extracted QWATCH logic into a new `QueryWatcher` struct.
- Moved `WatchList` from `Store` to `QueryWatcher`.
- Created `WatchSubscriptionChan` to handle subscribe/unsubscribe events.
- Updated `QWATCH` and `QUNWATCH` commands to use new channels.
- Refactored `ExecuteQuery` to take a pointer to `DSQLQuery`.
- Updated tests and benchmarks accordinly.