### PR TITLE
#385: fix(benchmark): Reset store for each iteration in BenchmarkEvalMSET

### DIFF
--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -888,10 +888,11 @@ func runEvalTests(t *testing.T, tests map[string]evalTestCase, evalFunc func([]s
 }
 
 func BenchmarkEvalMSET(b *testing.B) {
-	store := NewStore()
-	for i := 0; i < b.N; i++ {
-		evalMSET([]string{"KEY", "VAL", "KEY2", "VAL2"}, store)
-	}
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        store := NewStore()
+        evalMSET([]string{"KEY", "VAL", "KEY2", "VAL2"}, store)
+    }
 }
 
 func BenchmarkEvalHSET(b *testing.B) {


### PR DESCRIPTION
- Create a new store for each iteration of the benchmark
- Ensures accurate performance measurement by starting with a clean state
- Prevents potential infinite loops or deadlocks caused by accumulated state
- Resolves issue with benchmark suite hanging indefinitely

Closes #385 

Ran test locally 
```
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkEvalMSET$ github.com/dicedb/dice/core

goos: darwin
goarch: arm64
pkg: github.com/dicedb/dice/core
BenchmarkEvalMSET-10    	   50248	     22360 ns/op	  328741 B/op	      24 allocs/op
PASS
ok  	github.com/dicedb/dice/core	1.615s
```