### PR TITLE
Implements caching for QWATCH queries to improve performance

### DIFF
--- a/core/dsql_test.go
+++ b/core/dsql_test.go
@@ -453,7 +453,7 @@ func TestDSQLQueryString(t *testing.T) {
 			expected: "SELECT $key, $value LIMIT 5",
 		},
 		{
-			name: "Full Query",
+			name: "Full query",
 			query: DSQLQuery{
 				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
 				KeyRegex:  "user:*",

--- a/core/dsql_test.go
+++ b/core/dsql_test.go
@@ -453,7 +453,7 @@ func TestDSQLQueryString(t *testing.T) {
 			expected: "SELECT $key, $value LIMIT 5",
 		},
 		{
-			name: "Full query",
+			name: "Full Query",
 			query: DSQLQuery{
 				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
 				KeyRegex:  "user:*",

--- a/core/eval.go
+++ b/core/eval.go
@@ -1599,7 +1599,7 @@ func evalQWATCH(args []string, clientFd int, store *Store) []byte {
 	}
 
 	// Return the result of the query.
-	queryResult, err := ExecuteQuery(&query, store)
+	queryResult, err := ExecuteQuery(&query, store.store)
 	if err != nil {
 		return Encode(err, false)
 	}

--- a/core/eval.go
+++ b/core/eval.go
@@ -1599,13 +1599,11 @@ func evalQWATCH(args []string, clientFd int, store *Store) []byte {
 	}
 
 	// Return the result of the query.
-	queryResult, err := ExecuteQuery(&query, store.store)
-	if err != nil {
-		return Encode(err, false)
-	}
-
+	// TODO: we can't just run the query directly on the shard, since it would end up considering all the keys in the shard.
+	//  We need to ensure we consult the query watcher's query specific shard. The QueryWatcher exposes a RunQuery API
+	//  for this, however, at this stage we don't have a way to call this API so we return an empty response.
 	// TODO: We should return the list of all queries being watched by the client.
-	return Encode(CreatePushResponse(&query, &queryResult), false)
+	return Encode(CreatePushResponse(&query, &[]DSQLQueryResultRow{}), false)
 }
 
 // evalQUNWATCH removes the specified key from the watch list for the caller client.

--- a/core/eval.go
+++ b/core/eval.go
@@ -1599,11 +1599,14 @@ func evalQWATCH(args []string, clientFd int, store *Store) []byte {
 	}
 
 	// Return the result of the query.
-	// TODO: we can't just run the query directly on the shard, since it would end up considering all the keys in the shard.
-	//  We need to ensure we consult the query watcher's query specific shard. The QueryWatcher exposes a RunQuery API
-	//  for this, however, at this stage we don't have a way to call this API so we return an empty response.
+	// TODO: Use the RunQuery API from the QueryExecutor so that only the cache is used to execute queries.
+	queryResult, err := ExecuteQuery(&query, store.GetStore())
+	if err != nil {
+		return Encode(err, false)
+	}
+
 	// TODO: We should return the list of all queries being watched by the client.
-	return Encode(CreatePushResponse(&query, &[]DSQLQueryResultRow{}), false)
+	return Encode(CreatePushResponse(&query, &queryResult), false)
 }
 
 // evalQUNWATCH removes the specified key from the watch list for the caller client.

--- a/core/eval.go
+++ b/core/eval.go
@@ -1604,7 +1604,7 @@ func evalQWATCH(args []string, clientFd int, store *Store) []byte {
 	store.CacheKeysForQuery(&query, cacheChannel)
 
 	// Return the result of the query.
-	responseChan := make(chan AdhocQueryResult, 1)
+	responseChan := make(chan AdhocQueryResult)
 	AdhocQueryChan <- AdhocQuery{
 		query:        query,
 		responseChan: responseChan,

--- a/core/eval.go
+++ b/core/eval.go
@@ -1595,10 +1595,10 @@ func evalQWATCH(args []string, clientFd int, store *Store) []byte {
 	// use an unbuffered channel to ensure that we only proceed to query execution once the query watcher has built the cache
 	cacheChannel := make(chan *[]KeyValue)
 	WatchSubscriptionChan <- WatchSubscription{
-		subscribe: true,
-		query:     query,
-		clientFd:  clientFd,
-		cacheChan: cacheChannel,
+		Subscribe: true,
+		Query:     query,
+		ClientFD:  clientFd,
+		CacheChan: cacheChannel,
 	}
 
 	store.CacheKeysForQuery(&query, cacheChannel)
@@ -1606,17 +1606,17 @@ func evalQWATCH(args []string, clientFd int, store *Store) []byte {
 	// Return the result of the query.
 	responseChan := make(chan AdhocQueryResult)
 	AdhocQueryChan <- AdhocQuery{
-		query:        query,
-		responseChan: responseChan,
+		Query:        query,
+		ResponseChan: responseChan,
 	}
 
 	queryResult := <-responseChan
-	if queryResult.err != nil {
-		return Encode(queryResult.err, false)
+	if queryResult.Err != nil {
+		return Encode(queryResult.Err, false)
 	}
 
 	// TODO: We should return the list of all queries being watched by the client.
-	return Encode(CreatePushResponse(&query, queryResult.result), false)
+	return Encode(CreatePushResponse(&query, queryResult.Result), false)
 }
 
 // evalQUNWATCH removes the specified key from the watch list for the caller client.
@@ -1630,9 +1630,9 @@ func evalQUNWATCH(args []string, clientFd int) []byte {
 	}
 
 	WatchSubscriptionChan <- WatchSubscription{
-		subscribe: false,
-		query:     query,
-		clientFd:  clientFd,
+		Subscribe: false,
+		Query:     query,
+		ClientFD:  clientFd,
 	}
 
 	return RespOK

--- a/core/executerbechmark_test.go
+++ b/core/executerbechmark_test.go
@@ -55,7 +55,7 @@ func BenchmarkExecuteQueryOrderBykey(b *testing.B) {
 
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -84,7 +84,7 @@ func BenchmarkExecuteQueryBasicOrderByValue(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -114,7 +114,7 @@ func BenchmarkExecuteQueryLimit(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -139,7 +139,7 @@ func BenchmarkExecuteQueryNoMatch(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -169,7 +169,7 @@ func BenchmarkExecuteQueryWithBasicWhere(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -210,7 +210,7 @@ func BenchmarkExecuteQueryWithComplexWhere(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -240,7 +240,7 @@ func BenchmarkExecuteQueryWithCompareWhereKeyandValue(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -270,7 +270,7 @@ func BenchmarkExecuteQueryWithBasicWhereNoMatch(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -300,7 +300,7 @@ func BenchmarkExecuteQueryWithNullValues(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -330,7 +330,7 @@ func BenchmarkExecuteQueryWithCaseSesnsitivity(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -364,7 +364,7 @@ func BenchmarkExecuteQueryWithClauseOnKey(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -389,7 +389,7 @@ func BenchmarkExecuteQueryWithEmptyKeyRegex(b *testing.B) {
 		b.ResetTimer()
 		b.Run(fmt.Sprintf("keys_%d", v), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := core.ExecuteQuery(&query, store); err != nil {
+				if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -439,7 +439,7 @@ func BenchmarkExecuteQueryWithJSON(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := core.ExecuteQuery(&query, store); err != nil {
+					if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -471,7 +471,7 @@ func BenchmarkExecuteQueryWithNestedJSON(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := core.ExecuteQuery(&query, store); err != nil {
+					if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -503,7 +503,7 @@ func BenchmarkExecuteQueryWithJsonInLeftAndRightExpressions(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := core.ExecuteQuery(&query, store); err != nil {
+					if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -535,7 +535,7 @@ func BenchmarkExecuteQueryWithJsonNoMatch(b *testing.B) {
 			b.ResetTimer()
 			b.Run(fmt.Sprintf("%s_keys_%d", jsonSize, v), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := core.ExecuteQuery(&query, store); err != nil {
+					if _, err := core.ExecuteQuery(&query, store.GetStore()); err != nil {
 						b.Fatal(err)
 					}
 				}

--- a/core/executor.go
+++ b/core/executor.go
@@ -29,9 +29,7 @@ func ExecuteQuery(query *DSQLQuery, store *swiss.Map[string, *Obj]) ([]DSQLQuery
 	var err error
 	store.All(func(key string, value *Obj) bool {
 		// TODO: We can remove this check once we have scatter-gather algorithm for multi-threaded execution implemented.
-		//  This is only required for two cases:
-		//  1. When we are running unit tests and passing the complete store to the function.
-		//  2. When we are running an ad-hoc query from evalQWATCH and passing the complete store to the function.
+		//  This is only required when we are running unit tests and passing the complete store to the function.
 		if !WildCardMatch(query.KeyRegex, key) {
 			return true
 		}

--- a/core/executor.go
+++ b/core/executor.go
@@ -222,7 +222,7 @@ func evaluateComparison(expr *sqlparser.ComparisonExpr, row DSQLQueryResultRow) 
 
 	// Check if types are compatible
 	if leftType != rightType {
-		return false, fmt.Errorf("incompatible types in comparison: %s and %s", leftType, rightType)
+		return false, fmt.Errorf("incompatible types in comparison: %s (%s) and %s (%s)", left, leftType, right, rightType)
 	}
 
 	switch leftType {

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -53,7 +53,7 @@ func TestExecuteQueryOrderBykey(t *testing.T) {
 		},
 	}
 
-	result, err := core.ExecuteQuery(&query, store)
+	result, err := core.ExecuteQuery(&query, store.GetStore())
 
 	assert.NilError(t, err)
 	assert.Equal(t, len(result), len(dataset))
@@ -88,7 +88,7 @@ func TestExecuteQueryBasicOrderByValue(t *testing.T) {
 		},
 	}
 
-	result, err := core.ExecuteQuery(&query, store)
+	result, err := core.ExecuteQuery(&query, store.GetStore())
 
 	assert.NilError(t, err)
 	assert.Equal(t, len(result), len(dataset))
@@ -124,7 +124,7 @@ func TestExecuteQueryLimit(t *testing.T) {
 		Limit: 3,
 	}
 
-	result, err := core.ExecuteQuery(&query, store)
+	result, err := core.ExecuteQuery(&query, store.GetStore())
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Len(result, 3)) // Checks if limit is respected
@@ -155,7 +155,7 @@ func TestExecuteQueryNoMatch(t *testing.T) {
 		},
 	}
 
-	result, err := core.ExecuteQuery(&query, store)
+	result, err := core.ExecuteQuery(&query, store.GetStore())
 
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.Len(result, 0)) // No keys match "x*"
@@ -178,7 +178,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause")
@@ -200,7 +200,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 0, "Expected empty result for non-matching WHERE clause")
@@ -231,7 +231,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 2, "Expected 2 results for complex WHERE clause")
@@ -252,7 +252,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for comparison between key and value")
@@ -279,7 +279,7 @@ func TestExecuteQueryWithIncompatibleTypes(t *testing.T) {
 			},
 		}
 
-		_, err := core.ExecuteQuery(&query, store)
+		_, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.Error(t, err, "incompatible types in comparison: string and int")
 	})
@@ -303,7 +303,7 @@ func TestExecuteQueryWithIncompatibleTypes(t *testing.T) {
 			},
 		}
 
-		_, err := core.ExecuteQuery(&query, store)
+		_, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.Error(t, err, "unsupported value type: <nil>")
 	})
@@ -327,7 +327,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 0, "Expected 0 results due to case sensitivity")
@@ -351,7 +351,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 2, "Expected 2 results for WHERE clause on key")
@@ -372,7 +372,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 			},
 		}
 
-		_, err := core.ExecuteQuery(&query, store)
+		_, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.ErrorContains(t, err, "unsupported operator")
 	})
@@ -385,7 +385,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 				ValueSelection: true,
 			},
 		}
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 0, "Expected no keys to be returned for empty regex")
@@ -434,7 +434,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 results for WHERE clause")
@@ -460,7 +460,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 0, "Expected empty result for non-matching WHERE clause")
@@ -480,7 +480,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with floating point values")
@@ -506,7 +506,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with integer values")
@@ -532,7 +532,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for WHERE clause with nested json")
@@ -558,7 +558,7 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 			},
 		}
 
-		result, err := core.ExecuteQuery(&query, store)
+		result, err := core.ExecuteQuery(&query, store.GetStore())
 
 		assert.NilError(t, err)
 		assert.Equal(t, len(result), 1, "Expected 1 result for Complex WHERE clause expression")

--- a/core/query_watcher.go
+++ b/core/query_watcher.go
@@ -109,7 +109,7 @@ func (w *QueryWatcher) listenForSubscriptions(ctx context.Context) {
 		select {
 		case event := <-WatchSubscriptionChan:
 			if event.Subscribe {
-				w.addWatcher(event.Query, event.ClientFD, event.CacheChan)
+				w.addWatcher(&event.Query, event.ClientFD, event.CacheChan)
 			} else {
 				w.removeWatcher(&event.Query, event.ClientFD)
 			}
@@ -201,8 +201,8 @@ func (w *QueryWatcher) serveAdhocQueries(ctx context.Context) {
 }
 
 // addWatcher adds a client as a watcher to a query.
-func (w *QueryWatcher) addWatcher(query DSQLQuery, clientFD int, cacheChan chan *[]KeyValue) {
-	clients, _ := w.WatchList.LoadOrStore(query, &sync.Map{})
+func (w *QueryWatcher) addWatcher(query *DSQLQuery, clientFD int, cacheChan chan *[]KeyValue) {
+	clients, _ := w.WatchList.LoadOrStore(*query, &sync.Map{})
 	clients.(*sync.Map).Store(clientFD, struct{}{})
 
 	w.QueryCacheMu.Lock()

--- a/core/query_watcher.go
+++ b/core/query_watcher.go
@@ -41,7 +41,6 @@ var WatchSubscriptionChan chan WatchSubscription
 // QueryWatcher watches for changes in keys and notifies clients
 type QueryWatcher struct {
 	WatchList    sync.Map
-	shardManager *ShardManager
 	queryCaches  *swiss.Map[string, queryCache]
 	queryCacheMu sync.RWMutex
 }

--- a/core/query_watcher.go
+++ b/core/query_watcher.go
@@ -2,16 +2,27 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"syscall"
 
+	"github.com/cockroachdb/swiss"
+	"github.com/dicedb/dice/internal/constants"
+
 	"github.com/charmbracelet/log"
 )
+
+type queryCache *swiss.Map[string, *Obj]
+
+func newQueryCache() queryCache {
+	return swiss.New[string, *Obj](0)
+}
 
 // WatchEvent Event to notify clients about changes in query results due to key updates
 type WatchEvent struct {
 	Key       string
 	Operation string
+	Value     *Obj
 }
 
 // WatchSubscription Event to watch/unwatch a query
@@ -31,13 +42,15 @@ var WatchSubscriptionChan chan WatchSubscription
 type QueryWatcher struct {
 	WatchList    sync.Map
 	shardManager *ShardManager
+	queryCaches  *swiss.Map[string, queryCache]
+	queryCacheMu sync.RWMutex
 }
 
 // NewQueryWatcher initializes a new QueryWatcher
-func NewQueryWatcher(shardManager *ShardManager) *QueryWatcher {
+func NewQueryWatcher() *QueryWatcher {
 	return &QueryWatcher{
-		WatchList:    sync.Map{},
-		shardManager: shardManager,
+		WatchList:   sync.Map{},                       // WatchList is a map of queries to their respective clients, type: map[DSQLQuery]*sync.Map[int]struct{}
+		queryCaches: swiss.New[string, queryCache](0), // queryCaches is a map of queries to their respective data caches
 	}
 }
 
@@ -85,24 +98,48 @@ func (w *QueryWatcher) watchKeys(ctx context.Context) {
 				query := key.(DSQLQuery)
 				clients := value.(*sync.Map)
 
-				if WildCardMatch(query.KeyRegex, event.Key) {
-					// TODO: Implement proper query execution on the shard.
-					queryResult, err := ExecuteQuery(&query, w.shardManager.GetShard(0).store)
-					if err != nil {
-						log.Error(err)
-						return true
-					}
-
-					encodedResult := Encode(CreatePushResponse(&query, &queryResult), false)
-					clients.Range(func(clientKey, _ interface{}) bool {
-						clientFd := clientKey.(int)
-						_, err := syscall.Write(clientFd, encodedResult)
-						if err != nil {
-							w.RemoveWatcher(query, clientFd)
-						}
-						return true
-					})
+				if !WildCardMatch(query.KeyRegex, event.Key) {
+					return true
 				}
+
+				// Add this key to the query store
+				// TODO: We can implement more finegrained locking here which locks only the particular query's store.
+				w.queryCacheMu.Lock()
+				store, ok := w.queryCaches.Get(query.String())
+				if !ok {
+					log.Warnf("Query not found in queryCaches: %s", query)
+					w.queryCacheMu.Unlock()
+					return true
+				}
+				switch event.Operation {
+				case constants.Set:
+					((*swiss.Map[string, *Obj])(store)).Put(event.Key, event.Value)
+				case constants.Del:
+					((*swiss.Map[string, *Obj])(store)).Delete(event.Key)
+				default:
+					log.Warnf("Unknown operation: %s", event.Operation)
+				}
+				w.queryCacheMu.Unlock()
+
+				// Execute the query
+				w.queryCacheMu.RLock()
+				queryResult, err := ExecuteQuery(&query, store)
+				w.queryCacheMu.RUnlock()
+				if err != nil {
+					log.Error(err)
+					return true
+				}
+
+				encodedResult := Encode(CreatePushResponse(&query, &queryResult), false)
+				clients.Range(func(clientKey, _ interface{}) bool {
+					clientFd := clientKey.(int)
+					_, err := syscall.Write(clientFd, encodedResult)
+					if err != nil {
+						w.RemoveWatcher(query, clientFd)
+					}
+					return true
+				})
+
 				return true
 			})
 		case <-ctx.Done():
@@ -115,15 +152,26 @@ func (w *QueryWatcher) watchKeys(ctx context.Context) {
 func (w *QueryWatcher) AddWatcher(query DSQLQuery, clientFd int) { //nolint:gocritic
 	clients, _ := w.WatchList.LoadOrStore(query, &sync.Map{})
 	clients.(*sync.Map).Store(clientFd, struct{}{})
+	w.queryCacheMu.Lock()
+	w.queryCaches.Put(query.String(), newQueryCache())
+	w.queryCacheMu.Unlock()
 }
 
 // RemoveWatcher removes a client from the watchlist for a query.
 func (w *QueryWatcher) RemoveWatcher(query DSQLQuery, clientFd int) { //nolint:gocritic
 	if clients, ok := w.WatchList.Load(query); ok {
 		clients.(*sync.Map).Delete(clientFd)
+		log.Info(fmt.Printf("Removed client %d from query %s", clientFd, query))
 		// If no more clients for this query, remove the query from WatchList
 		if w.clientCount(clients.(*sync.Map)) == 0 {
 			w.WatchList.Delete(query)
+
+			//	Remove this Query's cached data.
+			w.queryCacheMu.Lock()
+			w.queryCaches.Delete(query.String())
+			w.queryCacheMu.Unlock()
+
+			log.Info(fmt.Printf("Removed query %s from WatchList", query))
 		}
 	}
 }

--- a/core/query_watcher.go
+++ b/core/query_watcher.go
@@ -172,6 +172,8 @@ func (w *QueryWatcher) watchKeys(ctx context.Context) {
 	}
 }
 
+// ServeAdhocQueries listens for adhoc queries, executes them, and sends the result back to the client on the provided
+// response channel.
 func (w *QueryWatcher) ServeAdhocQueries(ctx context.Context) {
 	for {
 		select {
@@ -207,17 +209,17 @@ func (w *QueryWatcher) AddWatcher(query DSQLQuery, clientFd int, cacheChan chan 
 func (w *QueryWatcher) RemoveWatcher(query DSQLQuery, clientFd int) { //nolint:gocritic
 	if clients, ok := w.WatchList.Load(query); ok {
 		clients.(*sync.Map).Delete(clientFd)
-		log.Info(fmt.Printf("Removed client %d from query %s", clientFd, query))
+		log.Info(fmt.Printf("client '%d' no longer watching query: %s", clientFd, query))
 		// If no more clients for this query, remove the query from WatchList
 		if w.clientCount(clients.(*sync.Map)) == 0 {
 			w.WatchList.Delete(query)
 
-			//	Remove this Query's cached data.
+			// Remove this Query's cached data.
 			w.queryCacheMu.Lock()
 			w.queryCaches.Delete(query.String())
 			w.queryCacheMu.Unlock()
 
-			log.Info(fmt.Printf("Removed query %s from WatchList", query))
+			log.Info(fmt.Printf("no longer watching query: %s", query))
 		}
 	}
 }

--- a/core/query_watcher.go
+++ b/core/query_watcher.go
@@ -188,7 +188,7 @@ func (w *QueryWatcher) clientCount(clients *sync.Map) int {
 }
 
 // RunQuery takes a DSQLQuery object, and executes the query on its respective cache.
-func (w *QueryWatcher) RunQuery(query DSQLQuery) (*[]DSQLQueryResultRow, error) {
+func (w *QueryWatcher) RunQuery(query *DSQLQuery) (*[]DSQLQueryResultRow, error) {
 	w.queryCacheMu.RLock()
 	defer w.queryCacheMu.RUnlock()
 
@@ -197,7 +197,7 @@ func (w *QueryWatcher) RunQuery(query DSQLQuery) (*[]DSQLQueryResultRow, error) 
 		return nil, fmt.Errorf("query was not found in the cache: %s", query)
 	}
 
-	queryResult, err := ExecuteQuery(&query, store)
+	queryResult, err := ExecuteQuery(query, store)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/core/store.go
+++ b/core/store.go
@@ -332,3 +332,7 @@ func (store *Store) delByPtr(ptr string) bool {
 func notifyWatchers(k, operation string, obj *Obj) {
 	WatchChan <- WatchEvent{k, operation, obj}
 }
+
+func (store *Store) GetStore() *swiss.Map[string, *Obj] {
+	return store.store
+}

--- a/core/store.go
+++ b/core/store.go
@@ -4,6 +4,8 @@ import (
 	"path"
 	"sync"
 
+	"github.com/dicedb/dice/internal/constants"
+
 	"github.com/cockroachdb/swiss"
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/server/utils"
@@ -113,7 +115,7 @@ func (store *Store) putHelper(k string, obj *Obj, opts ...PutOption) {
 	store.store.Put(*ptr, obj)
 
 	store.incrementKeyCount()
-	notifyWatchers(k, "SET")
+	notifyWatchers(k, constants.Set, obj)
 }
 
 func (store *Store) getHelper(k string, touch bool) *Obj {
@@ -248,7 +250,7 @@ func (store *Store) Rename(sourceKey, destKey string) bool {
 		}
 
 		// Notify watchers about the deletion of the source key
-		notifyWatchers(sourceKey, "DEL")
+		notifyWatchers(sourceKey, constants.Del, nil)
 
 		return true
 	}, store, WithStoreLock(), WithKeypoolLock())
@@ -313,7 +315,7 @@ func (store *Store) deleteKey(k, ptr string, obj *Obj) bool {
 		store.expires.Delete(obj)
 		store.keypool.Delete(k)
 		KeyspaceStat[0]["keys"]--
-		notifyWatchers(k, "DEL")
+		notifyWatchers(k, constants.Del, nil)
 		return true
 	}
 	return false
@@ -327,6 +329,6 @@ func (store *Store) delByPtr(ptr string) bool {
 	return false
 }
 
-func notifyWatchers(k, operation string) {
-	WatchChan <- WatchEvent{k, operation}
+func notifyWatchers(k, operation string, obj *Obj) {
+	WatchChan <- WatchEvent{k, operation, obj}
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -48,4 +48,7 @@ const (
 	NumberZeroValue int    = 0
 
 	Qwatch string = "qwatch"
+
+	Set string = "set"
+	Del string = "del"
 )

--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -40,12 +40,11 @@ type AsyncServer struct {
 
 // NewAsyncServer initializes a new AsyncServer
 func NewAsyncServer() *AsyncServer {
-	shardManager := core.NewShardManager(1)
 	return &AsyncServer{
 		maxClients:             config.ServerMaxClients,
 		connectedClients:       make(map[int]*comm.Client),
-		shardManager:           shardManager,
-		queryWatcher:           core.NewQueryWatcher(shardManager),
+		shardManager:           core.NewShardManager(1),
+		queryWatcher:           core.NewQueryWatcher(),
 		multiplexerPollTimeout: config.ServerMultiplexerPollTimeout,
 		ioChan:                 make(chan *ops.StoreResponse, 1000),
 	}

--- a/server/sync_tcp.go
+++ b/server/sync_tcp.go
@@ -2,9 +2,10 @@ package server
 
 import (
 	"fmt"
-	"github.com/dicedb/dice/core/cmd"
 	"io"
 	"strings"
+
+	"github.com/dicedb/dice/core/cmd"
 
 	"github.com/dicedb/dice/core"
 )

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -83,6 +83,7 @@ func TestQWATCH(t *testing.T) {
 
 		v, err := rp.DecodeOne()
 		assert.NilError(t, err)
+		fmt.Printf("v: %v\n", v)
 		assert.Equal(t, 3, len(v.([]interface{})))
 	}
 
@@ -243,7 +244,6 @@ func TestQwatchWithJSON(t *testing.T) {
 
 		v, err := rp.DecodeOne()
 		assert.NilError(t, err)
-		fmt.Printf("Received: %v\n", v)
 		assert.Equal(t, 3, len(v.([]interface{})), fmt.Sprintf("Expected 3 elements, got %v", v))
 	}
 

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -243,6 +243,7 @@ func TestQwatchWithJSON(t *testing.T) {
 
 		v, err := rp.DecodeOne()
 		assert.NilError(t, err)
+		fmt.Printf("Received: %v\n", v)
 		assert.Equal(t, 3, len(v.([]interface{})), fmt.Sprintf("Expected 3 elements, got %v", v))
 	}
 

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -56,26 +56,66 @@ var qWatchTestCases = []qWatchTestCase{
 
 // TestQWATCH tests the QWATCH functionality using raw network connections.
 func TestQWATCH(t *testing.T) {
-	publisher := getLocalConnection()
+	publisher, subscribers, cleanup := setupQWATCHTest(t)
+	defer cleanup()
 
+	respParsers := subscribeToQWATCH(t, subscribers)
+	runQWatchScenarios(t, publisher, respParsers)
+}
+
+func TestQWATCHWithSDK(t *testing.T) {
+	publisher, subscribers, cleanup := setupQWATCHTestWithSDK(t)
+	defer cleanup()
+
+	channels := subscribeToQWATCHWithSDK(t, subscribers)
+	runQWatchScenarios(t, publisher, channels)
+}
+
+func setupQWATCHTest(t *testing.T) (net.Conn, []net.Conn, func()) {
+	t.Helper()
+	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
-	defer func() {
-		for _, tc := range qWatchTestCases {
-			fireCommand(publisher, fmt.Sprintf("DEL match:100:user:%d", tc.userID))
+	cleanup := func() {
+		cleanupKeys(publisher)
+		if err := publisher.Close(); err != nil {
+			t.Errorf("Error closing publisher connection: %v", err)
 		}
-		time.Sleep(100 * time.Millisecond)
-		publisher.Close()
 		for _, sub := range subscribers {
 			fireCommand(sub, fmt.Sprintf("QUNWATCH \"%s\"", qWatchQuery))
 			time.Sleep(100 * time.Millisecond)
-			sub.Close()
+			if err := sub.Close(); err != nil {
+				t.Errorf("Error closing subscriber connection: %v", err)
+			}
 		}
-	}()
+	}
 
+	return publisher, subscribers, cleanup
+}
+
+func setupQWATCHTestWithSDK(t *testing.T) (*redis.Client, []*redis.Client, func()) {
+	t.Helper()
+	publisher := getLocalSdk()
+	subscribers := []*redis.Client{getLocalSdk(), getLocalSdk(), getLocalSdk()}
+
+	cleanup := func() {
+		cleanupKeysWithSDK(publisher)
+		if err := publisher.Close(); err != nil {
+			t.Errorf("Error closing publisher connection: %v", err)
+		}
+		for _, sub := range subscribers {
+			if err := sub.Close(); err != nil {
+				t.Errorf("Error closing subscriber connection: %v", err)
+			}
+		}
+	}
+
+	return publisher, subscribers, cleanup
+}
+
+func subscribeToQWATCH(t *testing.T, subscribers []net.Conn) []*core.RESPParser {
+	t.Helper()
 	respParsers := make([]*core.RESPParser, len(subscribers))
-
-	// Subscribe to the QWATCH query
 	for i, subscriber := range subscribers {
 		rp := fireCommandAndGetRESPParser(subscriber, fmt.Sprintf("QWATCH \"%s\"", qWatchQuery))
 		assert.Assert(t, rp != nil)
@@ -83,92 +123,92 @@ func TestQWATCH(t *testing.T) {
 
 		v, err := rp.DecodeOne()
 		assert.NilError(t, err)
-		fmt.Printf("v: %v\n", v)
-		assert.Equal(t, 3, len(v.([]interface{})))
+		castedValue, ok := v.([]interface{})
+		if !ok {
+			t.Errorf("Type assertion to []interface{} failed for value: %v", v)
+			return nil
+		}
+		assert.Equal(t, 3, len(castedValue))
 	}
-
-	runQWatchScenarios(t, publisher, respParsers)
+	return respParsers
 }
 
-// TestQWATCHWithSDK tests the QWATCH functionality using the Redis SDK.
-func TestQWATCHWithSDK(t *testing.T) {
+func subscribeToQWATCHWithSDK(t *testing.T, subscribers []*redis.Client) []<-chan *redis.QMessage {
+	t.Helper()
 	ctx := context.Background()
-	publisher := getLocalSdk()
-
-	subscribers := []*redis.Client{getLocalSdk(), getLocalSdk(), getLocalSdk()}
-
-	defer func() {
-		for _, tc := range qWatchTestCases {
-			publisher.Del(context.Background(), fmt.Sprintf("match:100:user:%d", tc.userID))
-		}
-		time.Sleep(100 * time.Millisecond)
-		publisher.Close()
-		for _, sub := range subscribers {
-			// TODO: Implement QUNWATCH in the SDK
-			sub.Close()
-		}
-	}()
-
 	channels := make([]<-chan *redis.QMessage, len(subscribers))
-
-	// subscribe to the QWATCH query
 	for i, subscriber := range subscribers {
 		qwatch := subscriber.QWatch(ctx)
 		assert.Assert(t, qwatch != nil)
 		err := qwatch.WatchQuery(ctx, qWatchQuery)
 		assert.NilError(t, err)
 		channels[i] = qwatch.Channel()
-		//	Get the first message
-		<-channels[i]
+		<-channels[i] // Get the first message
 	}
-
-	runQWatchScenarios(t, publisher, channels)
+	return channels
 }
 
-// runQWatchScenario executes the QWATCH test scenarios.
 func runQWatchScenarios(t *testing.T, publisher interface{}, receivers interface{}) {
+	t.Helper()
 	for _, tc := range qWatchTestCases {
-		// Publish updates based on the publisher type
-		switch p := publisher.(type) {
-		case net.Conn:
-			fireCommand(p, fmt.Sprintf("SET match:100:user:%d %d", tc.userID, tc.score))
-		case *redis.Client:
-			err := p.Set(context.Background(), fmt.Sprintf("match:100:user:%d", tc.userID), tc.score, 0).Err()
-			assert.NilError(t, err)
-		}
+		publishUpdate(t, publisher, tc)
+		verifyUpdates(t, receivers, tc.expectedUpdates)
+	}
+}
 
-		// For raw connections, parse RESP responses
-		for _, expectedUpdate := range tc.expectedUpdates {
+func publishUpdate(t *testing.T, publisher interface{}, tc qWatchTestCase) {
+	key := fmt.Sprintf("match:100:user:%d", tc.userID)
+	switch p := publisher.(type) {
+	case net.Conn:
+		fireCommand(p, fmt.Sprintf("SET %s %d", key, tc.score))
+	case *redis.Client:
+		err := p.Set(context.Background(), key, tc.score, 0).Err()
+		assert.NilError(t, err)
+	}
+}
 
-			switch r := receivers.(type) {
-			case []*core.RESPParser:
-				// For raw connections, parse RESP responses
-				for _, rp := range r {
-					v, err := rp.DecodeOne()
-					assert.NilError(t, err)
-					update := v.([]interface{})
-					assert.DeepEqual(t, []interface{}{constants.Qwatch, qWatchQuery, expectedUpdate}, update)
-				}
-			case []<-chan *redis.QMessage:
-				// For raw connections, parse RESP responses
-				for _, ch := range r {
-					v := <-ch
-					assert.Equal(t, len(v.Updates), len(expectedUpdate), v.Updates)
-					for i, update := range v.Updates {
-						assert.DeepEqual(t, expectedUpdate[i], []interface{}{update.Key, update.Value})
-					}
-				}
-			}
+func verifyUpdates(t *testing.T, receivers interface{}, expectedUpdates [][]interface{}) {
+	for _, expectedUpdate := range expectedUpdates {
+		switch r := receivers.(type) {
+		case []*core.RESPParser:
+			verifyRESPUpdates(t, r, expectedUpdate)
+		case []<-chan *redis.QMessage:
+			verifySDKUpdates(t, r, expectedUpdate)
 		}
 	}
 }
 
-var JSONTestCases = []struct {
+func verifyRESPUpdates(t *testing.T, respParsers []*core.RESPParser, expectedUpdate []interface{}) {
+	for _, rp := range respParsers {
+		v, err := rp.DecodeOne()
+		assert.NilError(t, err)
+		update, ok := v.([]interface{})
+		if !ok {
+			t.Errorf("Type assertion to []interface{} failed for value: %v", v)
+			return
+		}
+		assert.DeepEqual(t, []interface{}{constants.Qwatch, qWatchQuery, expectedUpdate}, update)
+	}
+}
+
+func verifySDKUpdates(t *testing.T, channels []<-chan *redis.QMessage, expectedUpdate []interface{}) {
+	for _, ch := range channels {
+		v := <-ch
+		assert.Equal(t, len(v.Updates), len(expectedUpdate), v.Updates)
+		for i, update := range v.Updates {
+			assert.DeepEqual(t, expectedUpdate[i], []interface{}{update.Key, update.Value})
+		}
+	}
+}
+
+type JSONTestCase struct {
 	key             string
 	value           string
 	qwatchQuery     string
 	expectedUpdates [][]interface{}
-}{
+}
+
+var JSONTestCases = []JSONTestCase{
 	{
 		key:         "match:200:user:0",
 		value:       `{"name":"Tom"}`,
@@ -212,31 +252,37 @@ var JSONTestCases = []struct {
 }
 
 func TestQwatchWithJSON(t *testing.T) {
+	publisher, subscribers, cleanup := setupJSONTest(t)
+	defer cleanup()
+
+	respParsers := subscribeToJSONQueries(t, subscribers)
+	runJSONScenarios(t, publisher, respParsers)
+}
+
+func setupJSONTest(t *testing.T) (net.Conn, []net.Conn, func()) {
 	publisher := getLocalConnection()
-
-	// Cleanup store for next tests
-	for _, tc := range JSONTestCases {
-		fireCommand(publisher, fmt.Sprintf("DEL %s", tc.key))
+	subscribers := make([]net.Conn, len(JSONTestCases))
+	for i := range subscribers {
+		subscribers[i] = getLocalConnection()
 	}
 
-	subscribers := make([]net.Conn, 0, len(JSONTestCases))
-
-	for i := 0; i < len(JSONTestCases); i++ {
-		subscribers = append(subscribers, getLocalConnection())
-	}
-
-	defer func() {
-		for _, tc := range JSONTestCases {
-			fireCommand(publisher, fmt.Sprintf("DEL %s", tc.key))
+	cleanup := func() {
+		cleanupJSONKeys(publisher)
+		if err := publisher.Close(); err != nil {
+			t.Errorf("Error closing publisher connection: %v", err)
 		}
-		publisher.Close()
 		for _, sub := range subscribers {
-			sub.Close()
+			if err := sub.Close(); err != nil {
+				t.Errorf("Error closing subscriber connection: %v", err)
+			}
 		}
-	}()
+	}
 
+	return publisher, subscribers, cleanup
+}
+
+func subscribeToJSONQueries(t *testing.T, subscribers []net.Conn) []*core.RESPParser {
 	respParsers := make([]*core.RESPParser, len(subscribers))
-
 	for i, testCase := range JSONTestCases {
 		rp := fireCommandAndGetRESPParser(subscribers[i], fmt.Sprintf("QWATCH \"%s\"", testCase.qwatchQuery))
 		assert.Assert(t, rp != nil)
@@ -246,33 +292,59 @@ func TestQwatchWithJSON(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, 3, len(v.([]interface{})), fmt.Sprintf("Expected 3 elements, got %v", v))
 	}
+	return respParsers
+}
 
+func runJSONScenarios(t *testing.T, publisher net.Conn, respParsers []*core.RESPParser) {
 	for i, tc := range JSONTestCases {
 		fireCommand(publisher, fmt.Sprintf("JSON.SET %s $ %s", tc.key, tc.value))
-
-		for _, expectedUpdate := range tc.expectedUpdates {
-			rp := respParsers[i]
-
-			v, err := rp.DecodeOne()
-			assert.NilError(t, err)
-			response := v.([]interface{})
-			assert.Equal(t, 3, len(response))
-			assert.Equal(t, constants.Qwatch, response[0])
-
-			update := response[2].([]interface{})
-
-			assert.Equal(t, len(expectedUpdate), len(update), fmt.Sprintf("Expected update: %v, got %v", expectedUpdate, update))
-			assert.Equal(t, expectedUpdate[0].([]interface{})[0], update[0].([]interface{})[0], "Key mismatch")
-
-			var expectedJSON, actualJSON interface{}
-			assert.NilError(t, sonic.UnmarshalString(tc.value, &expectedJSON))
-			assert.NilError(t, sonic.UnmarshalString(update[0].([]interface{})[1].(string), &actualJSON))
-			assert.DeepEqual(t, expectedJSON, actualJSON)
-		}
+		verifyJSONUpdates(t, respParsers[i], tc)
 	}
+}
 
-	//	 unsubscribe from all qwatch queries
-	for i, tc := range JSONTestCases {
-		fireCommand(subscribers[i], fmt.Sprintf("QUNWATCH \"%s\"", tc.qwatchQuery))
+func verifyJSONUpdates(t *testing.T, rp *core.RESPParser, tc JSONTestCase) {
+	for _, expectedUpdate := range tc.expectedUpdates {
+		v, err := rp.DecodeOne()
+		assert.NilError(t, err)
+		response, ok := v.([]interface{})
+		if !ok {
+			t.Errorf("Type assertion to []interface{} failed for value: %v", v)
+			return
+		}
+		assert.Equal(t, 3, len(response))
+		assert.Equal(t, constants.Qwatch, response[0])
+
+		update, ok := response[2].([]interface{})
+		if !ok {
+			t.Errorf("Type assertion to []interface{} failed for value: %v", response[2])
+			return
+		}
+		assert.Equal(t, len(expectedUpdate), len(update), fmt.Sprintf("Expected update: %v, got %v", expectedUpdate, update))
+		assert.Equal(t, expectedUpdate[0].([]interface{})[0], update[0].([]interface{})[0], "Key mismatch")
+
+		var expectedJSON, actualJSON interface{}
+		assert.NilError(t, sonic.UnmarshalString(tc.value, &expectedJSON))
+		assert.NilError(t, sonic.UnmarshalString(update[0].([]interface{})[1].(string), &actualJSON))
+		assert.DeepEqual(t, expectedJSON, actualJSON)
+	}
+}
+
+func cleanupKeys(publisher net.Conn) {
+	for _, tc := range qWatchTestCases {
+		fireCommand(publisher, fmt.Sprintf("DEL match:100:user:%d", tc.userID))
+	}
+	time.Sleep(100 * time.Millisecond)
+}
+
+func cleanupKeysWithSDK(publisher *redis.Client) {
+	for _, tc := range qWatchTestCases {
+		publisher.Del(context.Background(), fmt.Sprintf("match:100:user:%d", tc.userID))
+	}
+	time.Sleep(100 * time.Millisecond)
+}
+
+func cleanupJSONKeys(publisher net.Conn) {
+	for _, tc := range JSONTestCases {
+		fireCommand(publisher, fmt.Sprintf("DEL %s", tc.key))
 	}
 }

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -67,7 +67,7 @@ func TestQWATCH(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		publisher.Close()
 		for _, sub := range subscribers {
-			fireCommand(sub, fmt.Sprintf("UNQWATCH \"%s\"", qWatchQuery))
+			fireCommand(sub, fmt.Sprintf("QUNWATCH \"%s\"", qWatchQuery))
 			time.Sleep(100 * time.Millisecond)
 			sub.Close()
 		}
@@ -103,6 +103,7 @@ func TestQWATCHWithSDK(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		publisher.Close()
 		for _, sub := range subscribers {
+			// TODO: Implement QUNWATCH in the SDK
 			sub.Close()
 		}
 	}()
@@ -271,6 +272,6 @@ func TestQwatchWithJSON(t *testing.T) {
 
 	//	 unsubscribe from all qwatch queries
 	for i, tc := range JSONTestCases {
-		fireCommand(subscribers[i], fmt.Sprintf("UNQWATCH \"%s\"", tc.qwatchQuery))
+		fireCommand(subscribers[i], fmt.Sprintf("QUNWATCH \"%s\"", tc.qwatchQuery))
 	}
 }


### PR DESCRIPTION
This PR implements a caching mechanism for QWATCH queries to improve performance and reduce load on the main shard store.

### key changes

1. Added a queryCache to store data relevant to each watched query, reducing the need to scan the entire store on each update.

2. Modified the QueryWatcher to maintain these caches, updating them as keys are modified.

3. Updated the QWATCH command to build the initial cache when a query is subscribed to.

4. Implemented an AdhocQuery channel and handler to execute queries against the cached data.

5. Updated the ExecuteQuery function to work with the new caching system.

6. Modified tests to work with the new caching system and added cleanup steps.

7. Added new constants for SET and DEL operations.

These changes should significantly improve the performance of QWATCH queries, especially for large datasets, by reducing the amount of data that needs to be scanned on each update. The caching system ensures that only relevant data is stored and processed for each query. Additionally, we don't need to filter keys during query execution.

Note: This PR sets the groundwork for future multi-threaded query execution, though additional work will be needed to fully implement scatter-gather algorithms across multiple shards.