### PR TITLE
Adds JSON support to ORDER BY clause for DSQL queries.

### DIFF
--- a/core/bitpos.go
+++ b/core/bitpos.go
@@ -130,7 +130,7 @@ func getBitPos(byteSlice []byte, bitToFind byte, start, end int, rangeType strin
 	return result
 }
 
-// nolint: gocritic
+//nolint: gocritic
 func adjustBitPosSearchRange(start, end, byteLen int) (int, int) {
 	if start < 0 {
 		start += byteLen

--- a/core/bitpos.go
+++ b/core/bitpos.go
@@ -130,7 +130,7 @@ func getBitPos(byteSlice []byte, bitToFind byte, start, end int, rangeType strin
 	return result
 }
 
-//nolint: gocritic
+// nolint: gocritic
 func adjustBitPosSearchRange(start, end, byteLen int) (int, int) {
 	if start < 0 {
 		start += byteLen

--- a/core/dsql.go
+++ b/core/dsql.go
@@ -109,12 +109,7 @@ func replaceCustomSyntax(sql string) string {
 	return replacer.Replace(sql)
 }
 
-func revertCustomSyntax(name string) string {
-	replacer := strings.NewReplacer(TempKey, CustomKey, TempValue, CustomValue)
-	return replacer.Replace(name)
-}
-
-// Main parsing function
+// ParseQuery takes a SQL query string and returns a DSQLQuery struct
 func ParseQuery(sql string) (DSQLQuery, error) {
 	// Replace custom syntax before parsing
 	sql = replaceCustomSyntax(sql)

--- a/core/dsql.go
+++ b/core/dsql.go
@@ -50,6 +50,15 @@ type DSQLQuery struct {
 	Limit     int
 }
 
+// replacePlaceholders replaces temporary placeholders with custom ones
+func replacePlaceholders(s string) string {
+	replacer := strings.NewReplacer(
+		TempKey, CustomKey,
+		TempValue, CustomValue,
+	)
+	return replacer.Replace(s)
+}
+
 func (q DSQLQuery) String() string {
 	var parts []string
 
@@ -74,12 +83,16 @@ func (q DSQLQuery) String() string {
 
 	// Where
 	if q.Where != nil {
-		parts = append(parts, fmt.Sprintf("WHERE '%s'", strings.Replace(strings.Trim(sqlparser.String(q.Where), "'"), TempValue, CustomValue, -1)))
+		whereClause := sqlparser.String(q.Where)
+		whereClause = strings.Trim(whereClause, "'")
+		whereClause = replacePlaceholders(whereClause)
+		parts = append(parts, fmt.Sprintf("WHERE '%s'", whereClause))
 	}
 
 	// OrderBy
 	if q.OrderBy.OrderBy != "" {
-		parts = append(parts, fmt.Sprintf("ORDER BY %s %s", q.OrderBy.OrderBy, q.OrderBy.Order))
+		orderByClause := replacePlaceholders(q.OrderBy.OrderBy)
+		parts = append(parts, fmt.Sprintf("ORDER BY %s %s", orderByClause, q.OrderBy.Order))
 	}
 
 	// Limit

--- a/core/dsql.go
+++ b/core/dsql.go
@@ -217,9 +217,9 @@ func parseTableName(selectStmt *sqlparser.Select) (string, error) {
 func parseOrderBy(selectStmt *sqlparser.Select) (QueryOrder, error) {
 	orderBy := QueryOrder{}
 	if len(selectStmt.OrderBy) > 0 {
-		orderBy.OrderBy = revertCustomSyntax(sqlparser.String(selectStmt.OrderBy[0].Expr))
+		orderBy.OrderBy = sqlparser.String(selectStmt.OrderBy[0].Expr)
 		// Order by expr should either be $key or $value
-		if orderBy.OrderBy != CustomKey && orderBy.OrderBy != CustomValue {
+		if orderBy.OrderBy != TempKey && orderBy.OrderBy != TempValue && !strings.HasPrefix(orderBy.OrderBy, TempValue) {
 			return QueryOrder{}, fmt.Errorf("only $key and $value are supported in ORDER BY clause")
 		}
 		orderBy.Order = selectStmt.OrderBy[0].Direction

--- a/core/dsql_test.go
+++ b/core/dsql_test.go
@@ -22,7 +22,7 @@ func TestParseQuery(t *testing.T) {
 			want: DSQLQuery{
 				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
 				KeyRegex:  "match:100:*",
-				OrderBy:   QueryOrder{OrderBy: "$value", Order: "desc"},
+				OrderBy:   QueryOrder{OrderBy: "_value", Order: "desc"},
 				Limit:     10,
 			},
 			wantErr: false,
@@ -38,7 +38,7 @@ func TestParseQuery(t *testing.T) {
 					Operator: "=",
 					Right:    sqlparser.NewStrVal([]byte("test")),
 				},
-				OrderBy: QueryOrder{OrderBy: "$key", Order: constants.Asc},
+				OrderBy: QueryOrder{OrderBy: "_key", Order: constants.Asc},
 				Limit:   5,
 			},
 			wantErr: false,
@@ -128,7 +128,7 @@ func TestParseQuery(t *testing.T) {
 			want: DSQLQuery{
 				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
 				KeyRegex:  "test:*",
-				OrderBy:   QueryOrder{OrderBy: "$key", Order: "asc"},
+				OrderBy:   QueryOrder{OrderBy: "_key", Order: "asc"},
 			},
 			wantErr: false,
 		},
@@ -312,12 +312,12 @@ func TestParseOrderBy(t *testing.T) {
 		{
 			name: "order by key asc",
 			sql:  "SELECT $key FROM `test` ORDER BY $key ASC",
-			want: QueryOrder{OrderBy: "$key", Order: constants.Asc},
+			want: QueryOrder{OrderBy: "_key", Order: constants.Asc},
 		},
 		{
 			name: "order by value desc",
 			sql:  "SELECT $value FROM `test` ORDER BY $value DESC",
-			want: QueryOrder{OrderBy: "$value", Order: "desc"},
+			want: QueryOrder{OrderBy: "_value", Order: "desc"},
 		},
 		{
 			name:    "invalid order by field",
@@ -440,7 +440,7 @@ func TestDSQLQueryString(t *testing.T) {
 			name: "With OrderBy",
 			query: DSQLQuery{
 				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
-				OrderBy:   QueryOrder{OrderBy: "$key", Order: "DESC"},
+				OrderBy:   QueryOrder{OrderBy: "_key", Order: "DESC"},
 			},
 			expected: "SELECT $key, $value ORDER BY $key DESC",
 		},
@@ -458,7 +458,7 @@ func TestDSQLQueryString(t *testing.T) {
 				Selection: QuerySelection{KeySelection: true, ValueSelection: true},
 				KeyRegex:  "user:*",
 				Where:     sqlparser.NewStrVal([]byte("$value > 10")),
-				OrderBy:   QueryOrder{OrderBy: "$key", Order: "DESC"},
+				OrderBy:   QueryOrder{OrderBy: "_key", Order: "DESC"},
 				Limit:     5,
 			},
 			expected: "SELECT $key, $value FROM `user:*` WHERE '$value > 10' ORDER BY $key DESC LIMIT 5",

--- a/core/dsql_test.go
+++ b/core/dsql_test.go
@@ -315,9 +315,44 @@ func TestParseOrderBy(t *testing.T) {
 			want: QueryOrder{OrderBy: "_key", Order: constants.Asc},
 		},
 		{
+			name: "order by key desc",
+			sql:  "SELECT $key FROM `test` ORDER BY $key DESC",
+			want: QueryOrder{OrderBy: "_key", Order: "desc"},
+		},
+		{
+			name: "order by value asc",
+			sql:  "SELECT $value FROM `test` ORDER BY $value ASC",
+			want: QueryOrder{OrderBy: "_value", Order: "asc"},
+		},
+		{
 			name: "order by value desc",
 			sql:  "SELECT $value FROM `test` ORDER BY $value DESC",
 			want: QueryOrder{OrderBy: "_value", Order: "desc"},
+		},
+		{
+			name: "order by json path asc",
+			sql:  "SELECT $value FROM `test` ORDER BY $value.name ASC",
+			want: QueryOrder{OrderBy: "_value.name", Order: "asc"},
+		},
+		{
+			name: "order by nested json path desc",
+			sql:  "SELECT $value FROM `test` ORDER BY $value.address.city DESC",
+			want: QueryOrder{OrderBy: "_value.address.city", Order: "desc"},
+		},
+		{
+			name: "order by json path with array index",
+			sql:  "SELECT $value FROM `test` ORDER BY `$value.items[0].price`",
+			want: QueryOrder{OrderBy: "_value.items[0].price", Order: "asc"},
+		},
+		{
+			name: "order by complex json path",
+			sql:  "SELECT $value FROM `test` ORDER BY `$value.users[*].contacts[0].email`",
+			want: QueryOrder{OrderBy: "_value.users[*].contacts[0].email", Order: "asc"},
+		},
+		{
+			name: "no order by clause",
+			sql:  "SELECT $key FROM `test`",
+			want: QueryOrder{},
 		},
 		{
 			name:    "invalid order by field",
@@ -328,6 +363,11 @@ func TestParseOrderBy(t *testing.T) {
 			name: "no order by clause",
 			sql:  "SELECT $key FROM `test`",
 			want: QueryOrder{},
+		},
+		{
+			name:    "multiple order by clauses",
+			sql:     "SELECT $key FROM `test` ORDER BY $key ASC, $value DESC",
+			wantErr: true,
 		},
 	}
 

--- a/core/executor.go
+++ b/core/executor.go
@@ -155,11 +155,11 @@ func compareOrderByValues(valI, valJ interface{}, valueType, order string) (bool
 	case constants.String:
 		return compareStringValues(order, valI.(string), valJ.(string)), nil
 	case constants.Int:
-		switch valI.(type) {
+		switch v := valI.(type) {
 		case int:
-			return compareIntValues(order, valI.(int), valJ.(int)), nil
+			return compareIntValues(order, v, valJ.(int)), nil
 		case int64:
-			return compareInt64Values(order, valI.(int64), valJ.(int64)), nil
+			return compareInt64Values(order, v, valJ.(int64)), nil
 		default:
 			return false, fmt.Errorf("unsupported type for order by comparison: %T", valI)
 		}

--- a/core/executor.go
+++ b/core/executor.go
@@ -135,7 +135,7 @@ func sortResults(query *DSQLQuery, result []DSQLQueryResultRow) {
 	})
 }
 
-func getOrderByValue(orderBy string, row DSQLQueryResultRow) (interface{}, string, error) {
+func getOrderByValue(orderBy string, row DSQLQueryResultRow) (value interface{}, valueType string, err error) {
 	switch orderBy {
 	case TempKey:
 		return row.Key, constants.String, nil

--- a/core/executor.go
+++ b/core/executor.go
@@ -137,9 +137,9 @@ func sortResults(query *DSQLQuery, result []DSQLQueryResultRow) {
 
 func getOrderByValue(orderBy string, row DSQLQueryResultRow) (interface{}, string, error) {
 	switch orderBy {
-	case CustomKey:
+	case TempKey:
 		return row.Key, constants.String, nil
-	case CustomValue:
+	case TempValue:
 		return getValueAndType(&row.Value)
 	default:
 		// Handle JSON field
@@ -155,7 +155,12 @@ func compareOrderByValues(valI, valJ interface{}, valueType, order string) (bool
 	case constants.String:
 		return compareStringValues(order, valI.(string), valJ.(string)), nil
 	case constants.Int:
-		return compareIntValues(order, valI.(int), valJ.(int)), nil
+		switch valI.(type) {
+		case int:
+			return compareIntValues(order, valI.(int), valJ.(int)), nil
+		default:
+			return compareInt64Values(order, valI.(int64), valJ.(int64)), nil
+		}
 	case constants.Float:
 		return compareFloatValues(order, valI.(float64), valJ.(float64)), nil
 	case constants.Bool:

--- a/core/executor.go
+++ b/core/executor.go
@@ -158,8 +158,10 @@ func compareOrderByValues(valI, valJ interface{}, valueType, order string) (bool
 		switch valI.(type) {
 		case int:
 			return compareIntValues(order, valI.(int), valJ.(int)), nil
-		default:
+		case int64:
 			return compareInt64Values(order, valI.(int64), valJ.(int64)), nil
+		default:
+			return false, fmt.Errorf("unsupported type for order by comparison: %T", valI)
 		}
 	case constants.Float:
 		return compareFloatValues(order, valI.(float64), valJ.(float64)), nil

--- a/core/executor.go
+++ b/core/executor.go
@@ -57,11 +57,6 @@ func ExecuteQuery(query *DSQLQuery, store *swiss.Map[string, *Obj]) ([]DSQLQuery
 			}
 		}
 
-		if err := MarshalResultIfJSON(&row); err != nil {
-			// if error, skip the result and continue the iteration
-			return true
-		}
-
 		result = append(result, row)
 
 		return true
@@ -72,6 +67,12 @@ func ExecuteQuery(query *DSQLQuery, store *swiss.Map[string, *Obj]) ([]DSQLQuery
 	}
 
 	sortResults(query, result)
+
+	for i := range result {
+		if err := MarshalResultIfJSON(&result[i]); err != nil {
+			return nil, err
+		}
+	}
 
 	if !query.Selection.KeySelection {
 		for i := range result {
@@ -111,66 +112,57 @@ func sortResults(query *DSQLQuery, result []DSQLQueryResultRow) {
 		return
 	}
 
-	switch query.OrderBy.OrderBy {
+	sort.Slice(result, func(i, j int) bool {
+		valI, typeI, err := getOrderByValue(query.OrderBy.OrderBy, result[i])
+		if err != nil {
+			return false
+		}
+		valJ, typeJ, err := getOrderByValue(query.OrderBy.OrderBy, result[j])
+		if err != nil {
+			return false
+		}
+
+		if typeI != typeJ {
+			return false
+		}
+
+		comparison, err := compareOrderByValues(valI, valJ, typeI, query.OrderBy.Order)
+		if err != nil {
+			return false
+		}
+
+		return comparison
+	})
+}
+
+func getOrderByValue(orderBy string, row DSQLQueryResultRow) (interface{}, string, error) {
+	switch orderBy {
 	case CustomKey:
-		sort.Slice(result, func(i, j int) bool {
-			if query.OrderBy.Order == "desc" {
-				return result[i].Key > result[j].Key
-			}
-			return result[i].Key < result[j].Key
-		})
+		return row.Key, constants.String, nil
 	case CustomValue:
-		sort.Slice(result, func(i, j int) bool {
-			return compareValues(query.OrderBy.Order, &result[i].Value, &result[j].Value)
-		})
-	}
-}
-
-func compareValues(order string, valI, valJ *Obj) bool {
-	if valI == nil || valJ == nil {
-		return handleNilForOrder(order, valI, valJ)
-	}
-
-	typeI, encodingI := ExtractTypeEncoding(valI)
-	typeJ, encodingJ := ExtractTypeEncoding(valJ)
-
-	if typeI != typeJ || encodingI != encodingJ {
-		return handleMismatch()
-	}
-
-	switch kindI := valI.Value.(type) {
-	case string:
-		kindJ, ok := valJ.Value.(string)
-		if !ok {
-			return handleMismatch()
-		}
-		return compareStringValues(order, kindI, kindJ)
-	case int64:
-		kindJ, ok := valJ.Value.(int64)
-		if !ok {
-			return handleMismatch()
-		}
-		return compareIntValues(order, kindI, kindJ)
+		return getValueAndType(&row.Value)
 	default:
-		return handleUnsupportedType()
+		// Handle JSON field
+		if isJSONField(&sqlparser.SQLVal{Val: []byte(orderBy)}, &row.Value) {
+			return retrieveValueFromJSON(orderBy, &row.Value)
+		}
 	}
+	return nil, "", fmt.Errorf("invalid ORDER BY clause: %s", orderBy)
 }
 
-func handleNilForOrder(order string, valI, valJ *Obj) bool {
-	if order == constants.Asc {
-		return valI == nil
+func compareOrderByValues(valI, valJ interface{}, valueType, order string) (bool, error) {
+	switch valueType {
+	case constants.String:
+		return compareStringValues(order, valI.(string), valJ.(string)), nil
+	case constants.Int:
+		return compareIntValues(order, valI.(int), valJ.(int)), nil
+	case constants.Float:
+		return compareFloatValues(order, valI.(float64), valJ.(float64)), nil
+	case constants.Bool:
+		return compareBoolValues(order, valI.(bool), valJ.(bool)), nil
+	default:
+		return false, fmt.Errorf("unsupported type for comparison: %s", valueType)
 	}
-	return valJ == nil
-}
-
-func handleMismatch() bool {
-	// undefined behavior
-	return true
-}
-
-func handleUnsupportedType() bool {
-	// undefined behavior
-	return true
 }
 
 func compareStringValues(order, valI, valJ string) bool {
@@ -180,11 +172,32 @@ func compareStringValues(order, valI, valJ string) bool {
 	return valI > valJ
 }
 
-func compareIntValues(order string, valI, valJ int64) bool {
+func compareInt64Values(order string, valI, valJ int64) bool {
 	if order == constants.Asc {
 		return valI < valJ
 	}
 	return valI > valJ
+}
+
+func compareIntValues(order string, valI, valJ int) bool {
+	if order == constants.Asc {
+		return valI < valJ
+	}
+	return valI > valJ
+}
+
+func compareFloatValues(order string, valI, valJ float64) bool {
+	if order == constants.Asc {
+		return valI < valJ
+	}
+	return valI > valJ
+}
+
+func compareBoolValues(order string, valI, valJ bool) bool {
+	if order == constants.Asc {
+		return !valI && valJ
+	}
+	return valI && !valJ
 }
 
 func evaluateWhereClause(expr sqlparser.Expr, row DSQLQueryResultRow) (bool, error) {
@@ -346,7 +359,7 @@ func getValueAndType(obj *Obj) (val interface{}, s string, e error) {
 	switch v := obj.Value.(type) {
 	case string:
 		return v, constants.String, nil
-	case int:
+	case int64:
 		return v, constants.Int, nil
 	case float64:
 		return v, constants.Float, nil

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -419,7 +419,7 @@ func setupJSON(t *testing.T, store *core.Store, dataset []keyValue) {
 }
 
 func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setupJSON(t, store, jsonWhereClauseDataset)
 
 	t.Run("BasicWhereClauseWithJSON", func(t *testing.T) {
@@ -582,7 +582,7 @@ var jsonOrderDataset = []keyValue{
 }
 
 func TestExecuteQueryWithJsonOrderBy(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setupJSON(t, store, jsonOrderDataset)
 
 	t.Run("OrderBySimpleJSONField", func(t *testing.T) {

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -48,7 +48,7 @@ func TestExecuteQueryOrderBykey(t *testing.T) {
 			ValueSelection: true,
 		},
 		OrderBy: core.QueryOrder{
-			OrderBy: "$key",
+			OrderBy: "_key",
 			Order:   constants.Asc,
 		},
 	}
@@ -83,7 +83,7 @@ func TestExecuteQueryBasicOrderByValue(t *testing.T) {
 			ValueSelection: true,
 		},
 		OrderBy: core.QueryOrder{
-			OrderBy: "$value",
+			OrderBy: "_value",
 			Order:   constants.Asc,
 		},
 	}
@@ -118,7 +118,7 @@ func TestExecuteQueryLimit(t *testing.T) {
 			ValueSelection: true,
 		},
 		OrderBy: core.QueryOrder{
-			OrderBy: "$key",
+			OrderBy: "_key",
 			Order:   constants.Asc,
 		},
 		Limit: 3,
@@ -214,7 +214,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 				ValueSelection: true,
 			},
 			OrderBy: core.QueryOrder{
-				OrderBy: "$value",
+				OrderBy: "_value",
 				Order:   "desc",
 			},
 			Where: &sqlparser.AndExpr{
@@ -341,7 +341,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 				ValueSelection: true,
 			},
 			OrderBy: core.QueryOrder{
-				OrderBy: "$key",
+				OrderBy: "_key",
 				Order:   constants.Asc,
 			},
 			Where: &sqlparser.ComparisonExpr{

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -17,14 +17,16 @@ type keyValue struct {
 	value string
 }
 
-var dataset = []keyValue{
-	{"k2", "v4"},
-	{"k4", "v2"},
-	{"k3", "v3"},
-	{"k5", "v1"},
-	{"k1", "v5"},
-	{"k", "k"},
-}
+var (
+	dataset = []keyValue{
+		{"k2", "v4"},
+		{"k4", "v2"},
+		{"k3", "v3"},
+		{"k5", "v1"},
+		{"k1", "v5"},
+		{"k", "k"},
+	}
+)
 
 func setup(store *core.Store) {
 	// delete all keys
@@ -392,7 +394,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 	})
 }
 
-var JsonDataset = []keyValue{
+var jsonWhereClauseDataset = []keyValue{
 	{"json1", `{"name":"Tom"}`},
 	{"json2", `{"name":"Bob","score":18.1}`},
 	{"json3", `{"scoreInt":20}`},
@@ -400,13 +402,13 @@ var JsonDataset = []keyValue{
 	{"json5", `{"field1":{"field2":{"field3":{"score":18}},"score2":5}}`},
 }
 
-func setupJSON(t *testing.T, store *core.Store) {
+func setupJSON(t *testing.T, store *core.Store, dataset []keyValue) {
 	t.Helper()
-	for _, data := range JsonDataset {
+	for _, data := range dataset {
 		store.Del(data.key)
 	}
 
-	for _, data := range JsonDataset {
+	for _, data := range dataset {
 		var jsonValue interface{}
 		if err := sonic.UnmarshalString(data.value, &jsonValue); err != nil {
 			t.Fatalf("Failed to unmarshal value: %v", err)
@@ -418,7 +420,7 @@ func setupJSON(t *testing.T, store *core.Store) {
 
 func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 	store := core.NewStore()
-	setupJSON(t, store)
+	setupJSON(t, store, jsonWhereClauseDataset)
 
 	t.Run("BasicWhereClauseWithJSON", func(t *testing.T) {
 		query := core.DSQLQuery{
@@ -568,5 +570,157 @@ func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
 		assert.NilError(t, sonic.UnmarshalString(`{"field1":{"field2":{"field3":{"score":18}},"score2":5}}`, &expected))
 		assert.NilError(t, sonic.UnmarshalString(result[0].Value.Value.(string), &actual))
 		assert.DeepEqual(t, actual, expected)
+	})
+}
+
+var jsonOrderDataset = []keyValue{
+	{"json3", `{"name":"Alice", "age":35, "scoreInt":20, "nested":{"field":{"value":15}}}`},
+	{"json2", `{"name":"Bob", "age":25, "score":18.1, "nested":{"field":{"value":40}}}`},
+	{"json1", `{"name":"Tom", "age":30, "nested":{"field":{"value":20}}}`},
+	{"json5", `{"name":"Charlie", "age":50, "nested":{"field":{"value":19}}}`},
+	{"json4", `{"name":"Eve", "age":32, "nested":{"field":{"value":60}}}`},
+}
+
+func TestExecuteQueryWithJsonOrderBy(t *testing.T) {
+	store := core.NewStore()
+	setupJSON(t, store, jsonOrderDataset)
+
+	t.Run("OrderBySimpleJSONField", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "json*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			OrderBy: core.QueryOrder{
+				OrderBy: "_value.name",
+				Order:   "asc",
+			},
+		}
+
+		result, err := core.ExecuteQuery(&query, store.GetStore())
+
+		assert.NilError(t, err)
+		assert.Equal(t, 5, len(result), "Expected 5 results")
+		assert.Equal(t, "json3", result[0].Key) // Alice
+		assert.Equal(t, "json2", result[1].Key) // Bob
+		assert.Equal(t, "json5", result[2].Key) // Charlie
+		assert.Equal(t, "json4", result[3].Key) // Eve
+		assert.Equal(t, "json1", result[4].Key) // Tom
+	})
+
+	t.Run("OrderByNumericJSONField", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "json*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			OrderBy: core.QueryOrder{
+				OrderBy: "_value.age",
+				Order:   "desc",
+			},
+		}
+
+		result, err := core.ExecuteQuery(&query, store.GetStore())
+
+		assert.NilError(t, err)
+		assert.Equal(t, 5, len(result))
+		assert.Equal(t, "json5", result[0].Key) // Charlie, age 50
+		assert.Equal(t, "json3", result[1].Key) // Alice, age 35
+		assert.Equal(t, "json4", result[2].Key) // Eve, age 32
+		assert.Equal(t, "json1", result[3].Key) // Tom, age 30
+		assert.Equal(t, "json2", result[4].Key) // Bob, age 25
+	})
+
+	t.Run("OrderByNestedJSONField", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "json*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			OrderBy: core.QueryOrder{
+				OrderBy: "_value.nested.field.value",
+				Order:   "asc",
+			},
+		}
+
+		result, err := core.ExecuteQuery(&query, store.GetStore())
+
+		assert.NilError(t, err)
+		assert.Equal(t, 5, len(result))
+		assert.Equal(t, "json3", result[0].Key) // Alice, nested.field.value: 15
+		assert.Equal(t, "json5", result[1].Key) // Charlie, nested.field.value: 19
+		assert.Equal(t, "json1", result[2].Key) // Tom, nested.field.value: 20
+		assert.Equal(t, "json2", result[3].Key) // Bob, nested.field.value: 40
+		assert.Equal(t, "json4", result[4].Key) // Eve, nested.field.value: 60
+	})
+
+	t.Run("OrderByMixedTypes", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "json*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			OrderBy: core.QueryOrder{
+				OrderBy: "_value.score",
+				Order:   "desc",
+			},
+		}
+
+		result, err := core.ExecuteQuery(&query, store.GetStore())
+
+		assert.NilError(t, err)
+		// No ordering guarantees for mixed types.
+		assert.Equal(t, 5, len(result))
+	})
+
+	t.Run("OrderByWithWhereClause", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "json*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			Where: &sqlparser.ComparisonExpr{
+				Left:     sqlparser.NewStrVal([]byte("_value.age")),
+				Operator: ">",
+				Right:    sqlparser.NewIntVal([]byte("30")),
+			},
+			OrderBy: core.QueryOrder{
+				OrderBy: "_value.name",
+				Order:   "desc",
+			},
+		}
+
+		result, err := core.ExecuteQuery(&query, store.GetStore())
+
+		assert.NilError(t, err)
+		assert.Equal(t, 3, len(result), "Expected 3 results (age > 30, ordered by name)")
+		assert.Equal(t, "json4", result[0].Key) // Eve, age 32
+		assert.Equal(t, "json5", result[1].Key) // Charlie, age 50
+		assert.Equal(t, "json3", result[2].Key) // Alice, age 35
+	})
+
+	t.Run("OrderByNonExistentField", func(t *testing.T) {
+		query := core.DSQLQuery{
+			KeyRegex: "json*",
+			Selection: core.QuerySelection{
+				KeySelection:   true,
+				ValueSelection: true,
+			},
+			OrderBy: core.QueryOrder{
+				OrderBy: "_value.nonexistent",
+				Order:   "asc",
+			},
+		}
+
+		result, err := core.ExecuteQuery(&query, store.GetStore())
+
+		assert.NilError(t, err)
+		// No ordering guarantees for non-existent field references.
+		assert.Equal(t, 5, len(result), "Expected 5 results")
 	})
 }

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -602,11 +602,21 @@ func TestExecuteQueryWithJsonOrderBy(t *testing.T) {
 
 		assert.NilError(t, err)
 		assert.Equal(t, 5, len(result), "Expected 5 results")
+
 		assert.Equal(t, "json3", result[0].Key) // Alice
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[0].value, result[0].Value.Value.(string))
+
 		assert.Equal(t, "json2", result[1].Key) // Bob
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[1].value, result[1].Value.Value.(string))
+
 		assert.Equal(t, "json5", result[2].Key) // Charlie
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[3].value, result[2].Value.Value.(string))
+
 		assert.Equal(t, "json4", result[3].Key) // Eve
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[4].value, result[3].Value.Value.(string))
+
 		assert.Equal(t, "json1", result[4].Key) // Tom
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[2].value, result[4].Value.Value.(string))
 	})
 
 	t.Run("OrderByNumericJSONField", func(t *testing.T) {
@@ -626,11 +636,21 @@ func TestExecuteQueryWithJsonOrderBy(t *testing.T) {
 
 		assert.NilError(t, err)
 		assert.Equal(t, 5, len(result))
+
 		assert.Equal(t, "json5", result[0].Key) // Charlie, age 50
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[3].value, result[0].Value.Value.(string))
+
 		assert.Equal(t, "json3", result[1].Key) // Alice, age 35
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[0].value, result[1].Value.Value.(string))
+
 		assert.Equal(t, "json4", result[2].Key) // Eve, age 32
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[4].value, result[2].Value.Value.(string))
+
 		assert.Equal(t, "json1", result[3].Key) // Tom, age 30
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[2].value, result[3].Value.Value.(string))
+
 		assert.Equal(t, "json2", result[4].Key) // Bob, age 25
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[1].value, result[4].Value.Value.(string))
 	})
 
 	t.Run("OrderByNestedJSONField", func(t *testing.T) {
@@ -651,10 +671,19 @@ func TestExecuteQueryWithJsonOrderBy(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, 5, len(result))
 		assert.Equal(t, "json3", result[0].Key) // Alice, nested.field.value: 15
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[0].value, result[0].Value.Value.(string))
+
 		assert.Equal(t, "json5", result[1].Key) // Charlie, nested.field.value: 19
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[3].value, result[1].Value.Value.(string))
+
 		assert.Equal(t, "json1", result[2].Key) // Tom, nested.field.value: 20
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[2].value, result[2].Value.Value.(string))
+
 		assert.Equal(t, "json2", result[3].Key) // Bob, nested.field.value: 40
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[1].value, result[3].Value.Value.(string))
+
 		assert.Equal(t, "json4", result[4].Key) // Eve, nested.field.value: 60
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[4].value, result[4].Value.Value.(string))
 	})
 
 	t.Run("OrderByMixedTypes", func(t *testing.T) {
@@ -700,8 +729,13 @@ func TestExecuteQueryWithJsonOrderBy(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, 3, len(result), "Expected 3 results (age > 30, ordered by name)")
 		assert.Equal(t, "json4", result[0].Key) // Eve, age 32
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[4].value, result[0].Value.Value.(string))
+
 		assert.Equal(t, "json5", result[1].Key) // Charlie, age 50
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[3].value, result[1].Value.Value.(string))
+
 		assert.Equal(t, "json3", result[2].Key) // Alice, age 35
+		validateJSONStringRepresentationsAreEqual(t, jsonOrderDataset[0].value, result[2].Value.Value.(string))
 	})
 
 	t.Run("OrderByNonExistentField", func(t *testing.T) {
@@ -723,4 +757,13 @@ func TestExecuteQueryWithJsonOrderBy(t *testing.T) {
 		// No ordering guarantees for non-existent field references.
 		assert.Equal(t, 5, len(result), "Expected 5 results")
 	})
+}
+
+// validateJSONStringRepresentationsAreEqual unmarshals the expected and actual JSON strings and performs a deep comparison.
+func validateJSONStringRepresentationsAreEqual(t *testing.T, expectedJSONString, actualJSONString string) {
+	t.Helper()
+	var expectedValue, actualValue interface{}
+	assert.NilError(t, sonic.UnmarshalString(expectedJSONString, &expectedValue))
+	assert.NilError(t, sonic.UnmarshalString(actualJSONString, &actualValue))
+	assert.DeepEqual(t, actualValue, expectedValue)
 }

--- a/tests/qwatch_test.go
+++ b/tests/qwatch_test.go
@@ -383,7 +383,7 @@ func setupJSONOrderByTest(t *testing.T) (net.Conn, net.Conn, func()) {
 }
 
 func subscribeToJSONOrderByQuery(t *testing.T, subscriber net.Conn) *core.RESPParser {
-	query := "SELECT $key, $value FROM `user:*` ORDER BY $value.score DESC LIMIT 3"
+	query := "SELECT $key, $value FROM `player:*` ORDER BY $value.score DESC LIMIT 3"
 	rp := fireCommandAndGetRESPParser(subscriber, fmt.Sprintf("QWATCH \"%s\"", query))
 	assert.Assert(t, rp != nil)
 
@@ -401,36 +401,36 @@ func runJSONOrderByScenarios(t *testing.T, publisher net.Conn, respParser *core.
 		expectedUpdates [][]interface{}
 	}{
 		{
-			key:   "user:1",
+			key:   "player:1",
 			value: `{"name":"Alice","score":100}`,
 			expectedUpdates: [][]interface{}{
-				{[]interface{}{"user:1", map[string]interface{}{"name": "Alice", "score": float64(100)}}},
+				{[]interface{}{"player:1", map[string]interface{}{"name": "Alice", "score": float64(100)}}},
 			},
 		},
 		{
-			key:   "user:2",
+			key:   "player:2",
 			value: `{"name":"Bob","score":80}`,
 			expectedUpdates: [][]interface{}{
-				{[]interface{}{"user:1", map[string]interface{}{"name": "Alice", "score": float64(100)}},
-					[]interface{}{"user:2", map[string]interface{}{"name": "Bob", "score": float64(80)}}},
+				{[]interface{}{"player:1", map[string]interface{}{"name": "Alice", "score": float64(100)}},
+					[]interface{}{"player:2", map[string]interface{}{"name": "Bob", "score": float64(80)}}},
 			},
 		},
 		{
-			key:   "user:3",
+			key:   "player:3",
 			value: `{"name":"Charlie","score":90}`,
 			expectedUpdates: [][]interface{}{
-				{[]interface{}{"user:1", map[string]interface{}{"name": "Alice", "score": float64(100)}},
-					[]interface{}{"user:3", map[string]interface{}{"name": "Charlie", "score": float64(90)}},
-					[]interface{}{"user:2", map[string]interface{}{"name": "Bob", "score": float64(80)}}},
+				{[]interface{}{"player:1", map[string]interface{}{"name": "Alice", "score": float64(100)}},
+					[]interface{}{"player:3", map[string]interface{}{"name": "Charlie", "score": float64(90)}},
+					[]interface{}{"player:2", map[string]interface{}{"name": "Bob", "score": float64(80)}}},
 			},
 		},
 		{
-			key:   "user:4",
+			key:   "player:4",
 			value: `{"name":"David","score":95}`,
 			expectedUpdates: [][]interface{}{
-				{[]interface{}{"user:1", map[string]interface{}{"name": "Alice", "score": float64(100)}},
-					[]interface{}{"user:4", map[string]interface{}{"name": "David", "score": float64(95)}},
-					[]interface{}{"user:3", map[string]interface{}{"name": "Charlie", "score": float64(90)}}},
+				{[]interface{}{"player:1", map[string]interface{}{"name": "Alice", "score": float64(100)}},
+					[]interface{}{"player:4", map[string]interface{}{"name": "David", "score": float64(95)}},
+					[]interface{}{"player:3", map[string]interface{}{"name": "Charlie", "score": float64(90)}}},
 			},
 		},
 	}
@@ -488,6 +488,6 @@ func verifyJSONOrderByUpdates(t *testing.T, rp *core.RESPParser, tc struct {
 
 func cleanupJSONOrderByKeys(publisher net.Conn) {
 	for i := 1; i <= 4; i++ {
-		fireCommand(publisher, fmt.Sprintf("DEL user:%d", i))
+		fireCommand(publisher, fmt.Sprintf("DEL player:%d", i))
 	}
 }


### PR DESCRIPTION
# Implement JSON ORDER BY functionality

## Summary
This PR adds support for ordering query results based on JSON field values. This enhances the QWATCH feature to allow sorting of JSON objects.

## Key Changes
1. Modified `DSQLQuery.String()` method to properly handle JSON fields in ORDER BY clauses.
2. Updated `ParseQuery()` and `parseOrderBy()` functions to support JSON path expressions in ORDER BY clauses.
3. Refactored `sortResults()` function in `executor.go` to implement JSON field-based sorting.
4. Added new comparison functions for various data types (int, int64, float64, bool).
5. Updated and expanded test cases to cover JSON ORDER BY scenarios.

## Implementation Details
- Modified the `getOrderByValue()` function to extract values from JSON fields using the specified path.
- Updated `compareOrderByValues()` to handle different data types that can be present in JSON fields.
- Adjusted the sorting logic to work with both simple and nested JSON structures.
- We had to move the JSON value marshalling logic for the result set into a separate loop to allow JSON based ordering.

## Testing
- Added comprehensive test cases in `executor_test.go` to verify JSON ORDER BY functionality.
- Included new integration tests in `qwatch_test.go` to ensure QWATCH works correctly with JSON ORDER BY.

## TODO
- We had to move JSON marshalling into a new loop, this can be pretty inefficient for large result sets, a better way to handle this would be to somehow integrate this into the main query loop.
- We are making a copy of each value we iterate over, this is needed because we marshal json values into strings (and it would end up modifying the actual cache values), there's probably ways to work around this.