### PR TITLE
QWATCH tests failing on multiple runs 

### DIFF
--- a/integration_tests/commands/qunwatch_test.go
+++ b/integration_tests/commands/qunwatch_test.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"fmt"
-	"github.com/dicedb/dice/internal/sql"
 	"net"
 	"testing"
 
 	"github.com/dicedb/dice/internal/clientio"
+	"github.com/dicedb/dice/internal/sql"
+
 	"gotest.tools/v3/assert"
 )
 
@@ -79,4 +80,6 @@ func TestQWatchUnwatch(t *testing.T) {
 	for _, tc := range qWatchTestCases {
 		FireCommand(publisher, fmt.Sprintf("DEL %s:%d", tc.key, tc.userID))
 	}
+	// Unwatch the query on the third subscriber
+	fireCommandAndGetRESPParser(subscribers[2], "QUNWATCH \""+qWatchQuery+"\"")
 }


### PR DESCRIPTION
Apologies for the long delay but the PR closes #408 

What was the issue?
* The where clause in queries was being built as an object which meant the `==` for DSLQuery object was failing. Hence we could not unsubscribe from a given query and concurrent writes were being sent to open client file descriptors.
* We were not cleaning up after SDK tests
* Qunwatch test did not stop watching on the final subscriber

What was the fix?
* Change the watchlist key to be the string representation of the query and parse back whenever required.
* PR #447 Introduced the SDK cleanup
* Qunwatch test not stops watching from all subscribers.

Scenario: (-> subscribe request, -x> unsubscribe request, c-i client with fd "i", <= resp from watcher)
Test - 1
c-1 -> q1
c-2 -> q2
c-1 -x>  q1 (here we expect cleanup to be done, however that was not the case)
c-2 -x> q2 (here we expect cleanup to be done, however that was not the case)

Test - 2
c-1 -> q3 (here the file descriptor is the same however it's a different client)
c-1 <= q1 (This should not happen)

- [x] Passes integration tests
- [x] Passes multiple runs of qwatch tests
- [x] Behaves as expected  on actual non-test clients

Attaching a 50 run count output for the qwatch tests. 

[50runs.txt](https://github.com/user-attachments/files/16883369/50runs.txt)
