### PR TITLE
Remove query-watcher dependency from store

### DIFF
--- a/core/bloom_test.go
+++ b/core/bloom_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestBloomFilter(t *testing.T) {
-	store := NewStore()
+	store := NewStore(nil)
 	// This test only contains some basic checks for all the bloom filter
 	// operations like BFINIT, BFADD, BFEXISTS. It assumes that the
 	// functions called in the main function are working correctly and
@@ -110,7 +110,7 @@ func TestBloomFilter(t *testing.T) {
 }
 
 func TestGetOrCreateBloomFilter(t *testing.T) {
-	store := NewStore()
+	store := NewStore(nil)
 	// Create a key and default opts
 	key := "bf"
 	opts, _ := newBloomOpts([]string{}, true)

--- a/core/eval_test.go
+++ b/core/eval_test.go
@@ -39,7 +39,7 @@ func setupTest(store *Store) {
 }
 
 func TestEval(t *testing.T) {
-	store := NewStore()
+	store := NewStore(nil)
 
 	testEvalMSET(t, store)
 	testEvalPING(t, store)
@@ -997,13 +997,13 @@ func runEvalTests(t *testing.T, tests map[string]evalTestCase, evalFunc func([]s
 func BenchmarkEvalMSET(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		store := NewStore()
+		store := NewStore(nil)
 		evalMSET([]string{"KEY", "VAL", "KEY2", "VAL2"}, store)
 	}
 }
 
 func BenchmarkEvalHSET(b *testing.B) {
-	store := NewStore()
+	store := NewStore(nil)
 	for i := 0; i < b.N; i++ {
 		evalHSET([]string{"KEY", fmt.Sprintf("FIELD_%d", i), fmt.Sprintf("VALUE_%d", i)}, store)
 	}

--- a/core/executerbechmark_test.go
+++ b/core/executerbechmark_test.go
@@ -34,7 +34,7 @@ func generateBenchmarkData(count int, store *core.Store) {
 }
 
 func BenchmarkExecuteQueryOrderBykey(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -64,7 +64,7 @@ func BenchmarkExecuteQueryOrderBykey(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryBasicOrderByValue(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -93,7 +93,7 @@ func BenchmarkExecuteQueryBasicOrderByValue(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryLimit(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -123,7 +123,7 @@ func BenchmarkExecuteQueryLimit(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryNoMatch(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -148,7 +148,7 @@ func BenchmarkExecuteQueryNoMatch(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithBasicWhere(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -178,7 +178,7 @@ func BenchmarkExecuteQueryWithBasicWhere(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithComplexWhere(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -219,7 +219,7 @@ func BenchmarkExecuteQueryWithComplexWhere(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithCompareWhereKeyandValue(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -249,7 +249,7 @@ func BenchmarkExecuteQueryWithCompareWhereKeyandValue(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithBasicWhereNoMatch(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -279,7 +279,7 @@ func BenchmarkExecuteQueryWithBasicWhereNoMatch(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithNullValues(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -309,7 +309,7 @@ func BenchmarkExecuteQueryWithNullValues(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithCaseSesnsitivity(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -339,7 +339,7 @@ func BenchmarkExecuteQueryWithCaseSesnsitivity(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithClauseOnKey(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -373,7 +373,7 @@ func BenchmarkExecuteQueryWithClauseOnKey(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithEmptyKeyRegex(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizes {
 		generateBenchmarkData(v, store)
 		defer store.ResetStore()
@@ -417,7 +417,7 @@ func generateBenchmarkJSONData(b *testing.B, count int, json string, store *core
 }
 
 func BenchmarkExecuteQueryWithJSON(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizesJSON {
 		for jsonSize, json := range jsonList {
 			generateBenchmarkJSONData(b, v, json, store)
@@ -449,7 +449,7 @@ func BenchmarkExecuteQueryWithJSON(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithNestedJSON(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizesJSON {
 		for jsonSize, json := range jsonList {
 			generateBenchmarkJSONData(b, v, json, store)
@@ -481,7 +481,7 @@ func BenchmarkExecuteQueryWithNestedJSON(b *testing.B) {
 }
 
 func BenchmarkExecuteQueryWithJsonInLeftAndRightExpressions(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizesJSON {
 		for jsonSize, json := range jsonList {
 			generateBenchmarkJSONData(b, v, json, store)
@@ -514,7 +514,7 @@ func BenchmarkExecuteQueryWithJsonInLeftAndRightExpressions(b *testing.B) {
 
 func BenchmarkExecuteQueryWithJsonNoMatch(b *testing.B) {
 	for _, v := range benchmarkDataSizesJSON {
-		store := core.NewStore()
+		store := core.NewStore(nil)
 		for jsonSize, json := range jsonList {
 			generateBenchmarkJSONData(b, v, json, store)
 			defer store.ResetStore()

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -38,7 +38,7 @@ func setup(store *core.Store) {
 }
 
 func TestExecuteQueryOrderBykey(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setup(store)
 
 	query := core.DSQLQuery{
@@ -73,7 +73,7 @@ func TestExecuteQueryOrderBykey(t *testing.T) {
 }
 
 func TestExecuteQueryBasicOrderByValue(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setup(store)
 
 	query := core.DSQLQuery{
@@ -108,7 +108,7 @@ func TestExecuteQueryBasicOrderByValue(t *testing.T) {
 }
 
 func TestExecuteQueryLimit(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setup(store)
 
 	query := core.DSQLQuery{
@@ -144,7 +144,7 @@ func TestExecuteQueryLimit(t *testing.T) {
 }
 
 func TestExecuteQueryNoMatch(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setup(store)
 
 	query := core.DSQLQuery{
@@ -162,7 +162,7 @@ func TestExecuteQueryNoMatch(t *testing.T) {
 }
 
 func TestExecuteQueryWithWhere(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setup(store)
 	t.Run("BasicWhereClause", func(t *testing.T) {
 		query := core.DSQLQuery{
@@ -262,7 +262,7 @@ func TestExecuteQueryWithWhere(t *testing.T) {
 }
 
 func TestExecuteQueryWithIncompatibleTypes(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setup(store)
 
 	t.Run("ComparingStrWithInt", func(t *testing.T) {
@@ -310,7 +310,7 @@ func TestExecuteQueryWithIncompatibleTypes(t *testing.T) {
 }
 
 func TestExecuteQueryWithEdgeCases(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setup(store)
 
 	t.Run("CaseSensitivity", func(t *testing.T) {
@@ -417,7 +417,7 @@ func setupJSON(t *testing.T, store *core.Store) {
 }
 
 func TestExecuteQueryWithJsonExpressionInWhere(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	setupJSON(t, store)
 
 	t.Run("BasicWhereClauseWithJSON", func(t *testing.T) {

--- a/core/expire_test.go
+++ b/core/expire_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDelExpiry(t *testing.T) {
-	store := NewStore()
+	store := NewStore(nil)
 	// Initialize the test environment
 	store.store = swiss.New[string, *Obj](10240)
 	store.keypool = swiss.New[string, *string](10240)

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	store.ResetStore()
 
 	exitCode := m.Run()

--- a/core/queueref_test.go
+++ b/core/queueref_test.go
@@ -18,7 +18,7 @@ func TestQueueRef(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	store := core.NewStore()
+	store := core.NewStore(nil)
 
 	if _, err := qr.Remove(store); err != core.ErrQueueEmpty {
 		t.Error("removing from an empty queueref should return an empty queue error")
@@ -73,7 +73,7 @@ func TestRemoveSingleNonExpiredKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	val := 10
 	store.Put("key1", store.NewObj(val, -1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key1", store)
@@ -87,7 +87,7 @@ func TestRemoveMultipleNonExpiredKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	val := [3]int{10, 20, 30}
 	store.Put("key1", store.NewObj(val[0], -1, core.ObjTypeString, core.ObjEncodingInt))
 	qr.Insert("key1", store)
@@ -103,7 +103,7 @@ func TestRemoveMultipleNonExpiredKeys(t *testing.T) {
 
 // Test for removing from queue with expired keys before non-expired
 func TestRemoveExpiredBeforeNonExpire(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	mockTime := &utils.MockClock{CurrTime: time.Now()}
 	utils.CurrentTime = mockTime
 	qr, err := core.NewQueueRef()
@@ -122,7 +122,7 @@ func TestRemoveExpiredBeforeNonExpire(t *testing.T) {
 
 // Test for removing from queue with multiple expired keys before non-expired
 func TestRemoveMultipleExpiredBeforeNonExpire(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	mockTime := &utils.MockClock{CurrTime: time.Now()}
 	utils.CurrentTime = mockTime
 	qr, err := core.NewQueueRef()
@@ -144,7 +144,7 @@ func TestRemoveMultipleExpiredBeforeNonExpire(t *testing.T) {
 
 // Test for removing from queue with all expired keys
 func TestRemoveAllExpired(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	mockTime := &utils.MockClock{CurrTime: time.Now()}
 	utils.CurrentTime = mockTime
 	qr, err := core.NewQueueRef()
@@ -166,13 +166,12 @@ func TestRemoveAllExpired(t *testing.T) {
 
 func TestQueueRefMaxConstraints(t *testing.T) {
 	config.KeysLimit = 20000000
-	core.WatchChan = make(chan core.WatchEvent, config.KeysLimit)
 	core.QueueCount = 0 // reset counter
 	qr, err := core.NewQueueRef()
 	if err != nil {
 		t.Errorf("error creating QueueRef: %v", err)
 	}
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for i := 0; i < core.MaxQueueSize; i++ {
 		key := fmt.Sprintf("key%d", i)
 		store.Put(key, store.NewObj(i, -1, core.ObjTypeString, core.ObjEncodingInt))
@@ -201,7 +200,7 @@ func TestQueueRefMaxConstraints(t *testing.T) {
 }
 
 func TestQueueRefLen(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	core.QueueCount = 0
 	qr, err := core.NewQueueRef()
 	if err != nil {
@@ -242,7 +241,7 @@ func BenchmarkQueueRef(b *testing.B) {
 }
 
 func benchmarkQueueRefInsertAndRemove(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	mockTime := &utils.MockClock{CurrTime: time.Now()}
 	utils.CurrentTime = mockTime
 	benchmarkCases := []struct {

--- a/core/shard_manager.go
+++ b/core/shard_manager.go
@@ -22,14 +22,14 @@ type ShardManager struct {
 }
 
 // NewShardManager creates a new ShardManager instance with the given number of Shards and a parent context.
-func NewShardManager(shardCount int8) *ShardManager {
+func NewShardManager(shardCount int8, watchChan chan WatchEvent) *ShardManager {
 	shards := make([]*ShardThread, shardCount)
 	shardReqMap := make(map[ShardID]chan *ops.StoreOp)
 	globalErrorChan := make(chan *ShardError)
 
 	for i := int8(0); i < shardCount; i++ {
 		// Shards are numbered from 0 to shardCount-1
-		shard := NewShardThread(ShardID(i), globalErrorChan)
+		shard := NewShardThread(ShardID(i), globalErrorChan, watchChan)
 		shards[i] = shard
 		shardReqMap[ShardID(i)] = shard.ReqChan
 	}

--- a/core/shard_thread.go
+++ b/core/shard_thread.go
@@ -34,10 +34,10 @@ type ShardThread struct {
 }
 
 // NewShardThread creates a new ShardThread instance with the given shard id and error channel.
-func NewShardThread(id ShardID, errorChan chan *ShardError) *ShardThread {
+func NewShardThread(id ShardID, errorChan chan *ShardError, watchChan chan WatchEvent) *ShardThread {
 	return &ShardThread{
 		id:               id,
-		store:            NewStore(),
+		store:            NewStore(watchChan),
 		ReqChan:          make(chan *ops.StoreOp, 1000),
 		workerMap:        make(map[string]chan *ops.StoreResponse),
 		errorChan:        errorChan,

--- a/core/stackref_test.go
+++ b/core/stackref_test.go
@@ -19,7 +19,7 @@ func CreateAndPushKeyToStack(sr *core.StackRef, key string, value int, expDurati
 }
 
 func TestStackRef(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	sr, _ := core.NewStackRef()
 
 	if _, err := sr.Pop(store); err != core.ErrStackEmpty {
@@ -134,7 +134,7 @@ func TestStackRef(t *testing.T) {
 }
 
 func TestStackRefLen(t *testing.T) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 
 	sr, err := core.NewStackRef()
 	if err != nil {
@@ -171,8 +171,7 @@ func TestStackRefLen(t *testing.T) {
 }
 func TestStackRefMaxConstraints(t *testing.T) {
 	config.KeysLimit = 20000000
-	core.WatchChan = make(chan core.WatchEvent, config.KeysLimit)
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	core.StackCount = 0
 	sr, err := core.NewStackRef()
 	if err != nil {
@@ -200,10 +199,9 @@ func TestStackRefMaxConstraints(t *testing.T) {
 }
 
 func BenchmarkRemoveLargeNumberOfExpiredKeys(b *testing.B) {
-	store := core.NewStore()
+	store := core.NewStore(nil)
 	for _, v := range benchmarkDataSizesStackQueue {
 		config.KeysLimit = 20000000 // Set a high limit for benchmarking
-		core.WatchChan = make(chan core.WatchEvent, config.KeysLimit)
 		var sr *core.StackRef
 		var err error
 		if sr, err = core.NewStackRef(); err != nil {


### PR DESCRIPTION
There a cyclic dependency is being created between store and QueryWatcher.
This mainly caused as we initialize the QueryWatcher related global parameters as part of store initialization.
Without this change, it becomes difficult to separating out the worker/shard/QueryWatcher required for refactoring the code.

It also makes it difficult to refactor methods like `Encode()` in `resp.go` as the method references types from both `store` as well as `QueryWatcher` and QueryWatcher invokes the Encode() method creating a cyclic package dependency.