### PR TITLE
Fix integer type handling inconsistencies in sql executor

### DIFF
--- a/core/bitpos.go
+++ b/core/bitpos.go
@@ -130,7 +130,7 @@ func getBitPos(byteSlice []byte, bitToFind byte, start, end int, rangeType strin
 	return result
 }
 
-//nolint: gocritic
+// nolint: gocritic
 func adjustBitPosSearchRange(start, end, byteLen int) (int, int) {
 	if start < 0 {
 		start += byteLen

--- a/core/executor.go
+++ b/core/executor.go
@@ -179,13 +179,6 @@ func compareInt64Values(order string, valI, valJ int64) bool {
 	return valI > valJ
 }
 
-func compareIntValues(order string, valI, valJ int) bool {
-	if order == constants.Asc {
-		return valI < valJ
-	}
-	return valI > valJ
-}
-
 func compareFloatValues(order string, valI, valJ float64) bool {
 	if order == constants.Asc {
 		return valI < valJ
@@ -406,25 +399,6 @@ func compareStrings(left, right, operator string) (bool, error) {
 		return left >= right, nil
 	default:
 		return false, fmt.Errorf("unsupported operator for strings: %s", operator)
-	}
-}
-
-func compareInts(left, right int, operator string) (bool, error) {
-	switch operator {
-	case "=":
-		return left == right, nil
-	case constants.OperatorNotEquals, constants.OperatorNotEqualsTo:
-		return left != right, nil
-	case "<":
-		return left < right, nil
-	case constants.OperatorLessThanEqualsTo:
-		return left <= right, nil
-	case ">":
-		return left > right, nil
-	case constants.OperatorGreaterThanEqualsTo:
-		return left >= right, nil
-	default:
-		return false, fmt.Errorf("unsupported operator for integers: %s", operator)
 	}
 }
 

--- a/core/executor_test.go
+++ b/core/executor_test.go
@@ -283,7 +283,7 @@ func TestExecuteQueryWithIncompatibleTypes(t *testing.T) {
 
 		_, err := core.ExecuteQuery(&query, store.GetStore())
 
-		assert.Error(t, err, "incompatible types in comparison: string and int")
+		assert.Error(t, err, "incompatible types in comparison: string and int64")
 	})
 
 	t.Run("NullValue", func(t *testing.T) {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -26,7 +26,7 @@ const (
 	Asc string = "asc"
 
 	String string = "string"
-	Int    string = "int"
+	Int64  string = "int64"
 	Float  string = "float"
 	Bool   string = "bool"
 	Nil    string = "nil"


### PR DESCRIPTION
We were mixing up int and int64 types in the system, this PR fixes this inconsistency.