### PR TITLE
Avoid logging WARN for disconnections initiated from clients

### DIFF
--- a/server/async_tcp.go
+++ b/server/async_tcp.go
@@ -228,8 +228,12 @@ func (s *AsyncServer) eventLoop(ctx context.Context) error {
 						if errors.Is(err, ErrAborted) {
 							log.Info("Received abort command, initiating graceful shutdown")
 							return err
+						} else if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, net.ErrClosed) {
+							// Both are normal scenarios when client disconnections happen, hence just info log
+							log.Info("Connection closed by client or reset", "fd", event.Fd)
+						} else {
+							log.Warn(err)
 						}
-						log.Warn(err)
 					}
 				}
 			}


### PR DESCRIPTION
### Issue
- When a client gets abruptly disconnected the server is logging warn messages currently. Since we don't have any connection/keep-alive checks in place for clients, server tends to ACK the connection and tries to read from buffer which leads to `net.ErrClosed`.

### Fix
- We were already having check for `net.ErrClosed` which means connection has been closed from the client side and w can stop reading further. 
- Catch the error up the stack and just log `INFO` in such cases instead of `WARN` as it's an expected disconnection from client side.