### PR TITLE
Added realtime leaderboard demo using QWATCH

### DIFF
--- a/demo/leaderboard/Dockerfile
+++ b/demo/leaderboard/Dockerfile
@@ -1,0 +1,28 @@
+# Use the official Golang image to create a build artifact.
+FROM golang:1.21 as builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+
+# Use a Docker multi-stage build to create a lean production image.
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+# Copy the pre-built binary file from the previous stage
+COPY --from=builder /app/main .
+
+# Copy the HTML file
+COPY index.html .
+
+EXPOSE 8080
+
+CMD ["./main"]

--- a/demo/leaderboard/README.md
+++ b/demo/leaderboard/README.md
@@ -1,0 +1,37 @@
+# Real-time Leaderboard Demo with DiceDB
+
+This demo showcases a real-time leaderboard application using DiceDB. Writing realtime applications with DiceDB is as simple as writing a single SQL query.
+
+## Overview
+
+The application consists of two main components:
+
+1. A Go backend that interacts with DiceDB and serves WebSocket connections.
+2. A simple HTML frontend that displays the leaderboard in real-time.
+
+The backend randomly generates player scores and updates them in DiceDB using a background thread. It then uses QWATCH to monitor changes and broadcasts updates to connected WebSocket clients.
+
+## Setup
+
+1. Build and run the services using Docker Compose:
+
+   ```
+   docker-compose up --build
+   ```
+
+2. Open a web browser and navigate to `http://localhost:8080` to view the leaderboard.
+
+## Project Structure
+
+- `main.go`: The Go backend application
+- `index.html`: The frontend HTML file
+- `Dockerfile`: Defines the Docker image for the application.
+- `docker-compose.yaml`: Compose setup which launches a DiceDB instance and the Go backend.
+
+## How It Works
+
+1. The Go backend connects to DiceDB and starts updating random player scores every few seconds.
+2. A `QWATCH` query is set up to monitor changes in player scores above a threshold.
+3. When the query's key-set receives updates, the backend is notified of the updated results.
+4. The backend then broadcasts the updated leaderboard to all connected WebSocket clients.
+5. The frontend establishes a WebSocket connection and updates the leaderboard in real-time as it receives data.

--- a/demo/leaderboard/docker-compose.yaml
+++ b/demo/leaderboard/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  dicedb:
+    build:
+      context: ../..  # This points to the root of the DiceDB project
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    ports:
+      - "7379:7379"
+
+  leaderboard-demo:
+    build:
+      context: .  # This is now the current directory (leaderboard folder)
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+        - dicedb
+    environment:
+      - DICEDB_HOST=dicedb
+      - DICEDB_PORT=7379

--- a/demo/leaderboard/go.mod
+++ b/demo/leaderboard/go.mod
@@ -1,0 +1,13 @@
+module leaderboard-demo
+
+go 1.21.0
+
+require (
+	github.com/dicedb/go-dice v0.0.0-20240820180649-d97f15fca831
+	github.com/gorilla/websocket v1.5.3
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+)

--- a/demo/leaderboard/go.sum
+++ b/demo/leaderboard/go.sum
@@ -1,0 +1,12 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dicedb/go-dice v0.0.0-20240820180649-d97f15fca831 h1:Cqyj9WCtoobN6++bFbDSe27q94SPwJD9Z0wmu+SDRuk=
+github.com/dicedb/go-dice v0.0.0-20240820180649-d97f15fca831/go.mod h1:8+VZrr14c2LW8fW4tWZ8Bv3P2lfvlg+PpsSn5cWWuiQ=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/demo/leaderboard/index.html
+++ b/demo/leaderboard/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Real-time Leaderboard (Top 5 Scores > 500)</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        h1 {
+            text-align: center;
+        }
+        #leaderboard {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        #leaderboard th, #leaderboard td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: left;
+        }
+        #leaderboard th {
+            background-color: #f2f2f2;
+        }
+        #leaderboard tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+        #status {
+            text-align: center;
+            margin-bottom: 20px;
+            font-weight: bold;
+        }
+    </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reconnecting-websocket/1.0.0/reconnecting-websocket.min.js"></script>
+</head>
+<body>
+<h1>Real-time Leaderboard (Top 5 Scores > 500)</h1>
+<div id="status">Connecting...</div>
+<table id="leaderboard">
+    <thead>
+    <tr>
+        <th>Rank</th>
+        <th>Player ID</th>
+        <th>Score</th>
+        <th>Last Updated</th>
+    </tr>
+    </thead>
+    <tbody id="leaderboardBody">
+    </tbody>
+</table>
+
+<script>
+    const leaderboardBody = document.getElementById('leaderboardBody');
+    const statusElement = document.getElementById('status');
+
+    function updateLeaderboard(entries) {
+        // Clear existing rows
+        leaderboardBody.innerHTML = '';
+
+        // Add new rows
+        entries.forEach((entry, index) => {
+            const row = leaderboardBody.insertRow();
+            row.insertCell(0).textContent = index + 1;  // Derive rank from position
+            row.insertCell(1).textContent = entry.player_id;
+            row.insertCell(2).textContent = entry.score;
+            row.insertCell(3).textContent = new Date(entry.timestamp).toLocaleString();
+        });
+    }
+
+    function updateStatus(message, isError = false) {
+        statusElement.textContent = message;
+        statusElement.style.color = isError ? 'red' : 'green';
+    }
+
+    // Create a ReconnectingWebSocket instance
+    const socket = new ReconnectingWebSocket('ws://localhost:8080/ws');
+
+    socket.onopen = function(e) {
+        console.log('Connected to WebSocket server');
+        updateStatus('Connected');
+    };
+
+    socket.onmessage = function(event) {
+        try {
+            const entries = JSON.parse(event.data);
+            updateLeaderboard(entries);
+        } catch (error) {
+            console.error('Error parsing data:', error);
+        }
+    };
+
+    socket.onclose = function(event) {
+        if (event.wasClean) {
+            console.log(`Connection closed cleanly, code=${event.code}, reason=${event.reason}`);
+        } else {
+            console.log('Connection died');
+        }
+        updateStatus('Disconnected', true);
+    };
+
+    socket.onerror = function(error) {
+        console.log(`WebSocket error: ${error.message}`);
+        updateStatus('Connection error', true);
+    };
+
+    // ReconnectingWebSocket specific events
+    socket.addEventListener('reconnect', function(event) {
+        console.log('Reconnecting...', event);
+        updateStatus('Reconnecting...', true);
+    });
+
+    socket.addEventListener('reconnectSuccess', function(event) {
+        console.log('Reconnected successfully', event);
+        updateStatus('Reconnected');
+    });
+</script>
+</body>
+</html>

--- a/demo/leaderboard/main.go
+++ b/demo/leaderboard/main.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/dicedb/go-dice"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var (
+	dice    *redis.Client
+	upgrade = websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return true // Allow all connections for simplicity
+		},
+	}
+)
+
+type LeaderboardEntry struct {
+	PlayerID  string    `json:"player_id"`
+	Score     int       `json:"score"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func main() {
+	time.Sleep(2 * time.Second)
+	// Initialize Redis client
+	dice = redis.NewClient(&redis.Options{
+		Addr:        fmt.Sprintf("%s:%s", os.Getenv("DICEDB_HOST"), os.Getenv("DICEDB_PORT")),
+		DialTimeout: 10 * time.Second,
+		MaxRetries:  10,
+	})
+
+	// Start the leaderboard update goroutine
+	go updateLeaderboard()
+
+	// Start the QWATCH listener goroutine
+	go watchLeaderboard()
+
+	// Serve static files
+	fs := http.FileServer(http.Dir("."))
+	http.Handle("/", fs)
+
+	// Set up WebSocket endpoint
+	http.HandleFunc("/ws", handleWebSocket)
+
+	// Start the HTTP server
+	log.Println("Server starting on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func updateLeaderboard() {
+	ctx := context.Background()
+	for {
+		entry := LeaderboardEntry{
+			PlayerID:  fmt.Sprintf("player_%d", rand.Intn(100)),
+			Score:     rand.Intn(10000),
+			Timestamp: time.Now(),
+		}
+
+		jsonData, err := json.Marshal(entry)
+		if err != nil {
+			log.Printf("Error marshaling JSON: %v", err)
+			continue
+		}
+
+		err = dice.JSONSet(ctx, entry.PlayerID, "$", jsonData).Err()
+		if err != nil {
+			log.Printf("Error setting data in Redis: %v", err)
+		}
+
+		// Expire keys after 10 seconds to prevent leaderboard from becoming static after a while.
+		err = dice.ExpireAt(ctx, entry.PlayerID, time.Now().Add(10*time.Second)).Err()
+		if err != nil {
+			log.Printf("Error setting expiration in Redis: %v", err)
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func watchLeaderboard() {
+	ctx := context.Background()
+	qwatch := dice.QWatch(ctx)
+	err := qwatch.WatchQuery(ctx, "SELECT $key, $value FROM `player_*` WHERE '$value.score' > 1000 ORDER BY $value.score DESC LIMIT 5")
+	if err != nil {
+		log.Fatalf("Error watching query: %v", err)
+	}
+	defer qwatch.Close()
+
+	ch := qwatch.Channel()
+	for {
+		select {
+		case msg := <-ch:
+			updates, err := formatToJSON(msg.Updates)
+			if err != nil {
+				log.Printf("Error formatting updates: %v", err)
+				continue
+			}
+			// Broadcast the formatted result to all connected WebSocket clients
+			broadcastToClients(updates)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func formatToJSON(updates []redis.KV) (string, error) {
+	var entries []LeaderboardEntry
+	for _, update := range updates {
+		var entry LeaderboardEntry
+		err := json.Unmarshal([]byte(update.Value.(string)), &entry)
+		if err != nil {
+			return "", fmt.Errorf("error unmarshaling entry: %v", err)
+		}
+		entries = append(entries, entry)
+	}
+	jsonData, err := json.Marshal(entries)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling entries: %v", err)
+	}
+	return string(jsonData), nil
+}
+
+var (
+	clients    = make(map[*websocket.Conn]bool)
+	clientsMux = &sync.Mutex{}
+)
+
+func handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrade.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("Error upgrading to WebSocket: %v", err)
+		return
+	}
+	defer func(conn *websocket.Conn) {
+		err := conn.Close()
+		if err != nil {
+			log.Printf("Error closing WebSocket connection: %v", err)
+		}
+	}(conn)
+
+	clientsMux.Lock()
+	clients[conn] = true
+	clientsMux.Unlock()
+
+	// Keep the connection open
+	for {
+		_, _, err := conn.ReadMessage()
+		if err != nil {
+			log.Printf("Error reading WebSocket message: %v", err)
+			break
+		}
+	}
+
+	clientsMux.Lock()
+	delete(clients, conn)
+	clientsMux.Unlock()
+}
+
+func broadcastToClients(message string) {
+	clientsMux.Lock()
+	defer clientsMux.Unlock()
+
+	for client := range clients {
+		err := client.WriteMessage(websocket.TextMessage, []byte(message))
+		if err != nil {
+			log.Printf("Error sending message to client: %v", err)
+			err := client.Close()
+			if err != nil {
+				log.Printf("Error closing WebSocket connection: %v", err)
+			}
+			delete(clients, client)
+		}
+	}
+}

--- a/demo/leaderboard/main.go
+++ b/demo/leaderboard/main.go
@@ -45,7 +45,7 @@ func main() {
 	// Start the QWATCH listener goroutine
 	go watchLeaderboard()
 
-	// Serve static files
+	// Serve static files for the frontend.
 	fs := http.FileServer(http.Dir("."))
 	http.Handle("/", fs)
 
@@ -57,6 +57,7 @@ func main() {
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
+// updateLeaderboard generates random leaderboard entries and updates them in Redis.
 func updateLeaderboard() {
 	ctx := context.Background()
 	for {
@@ -87,6 +88,7 @@ func updateLeaderboard() {
 	}
 }
 
+// watchLeaderboard watches the leaderboard for updates and sends them to all connected WebSocket clients.
 func watchLeaderboard() {
 	ctx := context.Background()
 	qwatch := dice.QWatch(ctx)
@@ -112,6 +114,10 @@ func watchLeaderboard() {
 		}
 	}
 }
+
+////////////////////////
+// Helper functions
+////////////////////////
 
 func formatToJSON(updates []redis.KV) (string, error) {
 	var entries []LeaderboardEntry


### PR DESCRIPTION
# Real-time Leaderboard Demo with DiceDB

This demo showcases a real-time leaderboard application using DiceDB. Writing realtime applications with DiceDB is as simple as writing a single SQL query.

## Overview

The application consists of two main components:

1. A Go backend that interacts with DiceDB and serves WebSocket connections.
2. A simple HTML frontend that displays the leaderboard in real-time.

The backend randomly generates player scores and updates them in DiceDB using a background thread. It then uses QWATCH to monitor changes and broadcasts updates to connected WebSocket clients.

## Setup

1. Build and run the services using Docker Compose:

   ```
   docker-compose up --build
   ```

2. Open a web browser and navigate to `http://localhost:8080` to view the leaderboard.

## Project Structure

- `main.go`: The Go backend application
- `index.html`: The frontend HTML file
- `Dockerfile`: Defines the Docker image for the application.
- `docker-compose.yaml`: Compose setup which launches a DiceDB instance and the Go backend.

## How It Works

1. The Go backend connects to DiceDB and starts updating random player scores every few seconds.
2. A `QWATCH` query is set up to monitor changes in player scores above a threshold.
3. When the query's key-set receives updates, the backend is notified of the updated results.
4. The backend then broadcasts the updated leaderboard to all connected WebSocket clients.
5. The frontend establishes a WebSocket connection and updates the leaderboard in real-time as it receives data.
