### PR TITLE
Adds retry with exponential backoff for QWATCH writes

### DIFF
--- a/examples/leaderboard-go/main.go
+++ b/examples/leaderboard-go/main.go
@@ -71,7 +71,6 @@ func updateScores() {
 		}
 		lentry, _ := json.Marshal(entry)
 		dice.JSONSet(ctx, entry.PlayerID, "$", lentry).Err()
-		time.Sleep(20 * time.Millisecond)
 	}
 }
 

--- a/internal/eval/bitpos.go
+++ b/internal/eval/bitpos.go
@@ -130,7 +130,7 @@ func getBitPos(byteSlice []byte, bitToFind byte, start, end int, rangeType strin
 	return result
 }
 
-//nolint: gocritic
+// nolint: gocritic
 func adjustBitPosSearchRange(start, end, byteLen int) (int, int) {
 	if start < 0 {
 		start += byteLen


### PR DESCRIPTION
This change adds a retry mechanism with exponential backoff to the client write logic of the `QueryManager`. This fixes undefined behavior in case of high number of writes.

## Issue
Presently, if the QueryManager wrote too much data too fast to the client's socket it was possible to encounter a "resource temporarily unavailable) error.

The error "resource temporarily unavailable" (which typically corresponds to the `EAGAIN` or `EWOULDBLOCK` error codes) occurs when you're trying to write to a non-blocking file descriptor that currently can't accept more data. This usually happens when the client isn't reading data fast enough, causing the kernel's write buffer for that socket to fill up.

## Fix
With the new changes, we check whether the client is only temporarily unavailable and implement a retry mechanism for the same. This means that even if the network resource is currently unavailable, we have a chance to retry the send operation without prematurely removing the client from the `WatchList`.