### PR TITLE
Adds support for 'LIKE' and 'NOT LIKE' to the SQL Executor

### DIFF
--- a/internal/querywatcher/executor.go
+++ b/internal/querywatcher/executor.go
@@ -380,7 +380,7 @@ func sqlValToGoValue(sqlVal *sqlparser.SQLVal) (val interface{}, s string, e err
 }
 
 func compareStrings(left, right, operator string) (bool, error) {
-	switch operator {
+	switch strings.ToLower(operator) {
 	case sqlparser.EqualStr:
 		return left == right, nil
 	case sqlparser.NotEqualStr:
@@ -393,6 +393,10 @@ func compareStrings(left, right, operator string) (bool, error) {
 		return left > right, nil
 	case sqlparser.GreaterEqualStr:
 		return left >= right, nil
+	case sqlparser.LikeStr:
+		return regex.WildCardMatch(right, left), nil
+	case sqlparser.NotLikeStr:
+		return !regex.WildCardMatch(right, left), nil
 	default:
 		return false, fmt.Errorf("unsupported operator for strings: %s", operator)
 	}

--- a/internal/querywatcher/executor_test.go
+++ b/internal/querywatcher/executor_test.go
@@ -369,7 +369,7 @@ func TestExecuteQueryWithEdgeCases(t *testing.T) {
 			},
 			Where: &sqlparser.ComparisonExpr{
 				Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent("_value")},
-				Operator: "LIKE",
+				Operator: "regexp",
 				Right:    sqlparser.NewStrVal([]byte("%3")),
 			},
 		}


### PR DESCRIPTION
This PR introduces support for `LIKE` and `NOT LIKE` string comparisons for the DiceDB SQL Executor.

This is necessary pre-work for the upcoming changes to the DSQL syntax which would rely purely on the WHERE clause for key filtering and not on the FROM clause.