### PR TITLE
Adding TestEnvEnabled config and avoiding AOF dump for test env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,4 +38,4 @@ var (
 	RequirePass string = utils.EmptyStr
 )
 
-var TestEnvEnabled = false
+var WriteAOFOnCleanup = false

--- a/config/config.go
+++ b/config/config.go
@@ -37,3 +37,5 @@ var (
 	// if RequirePass is set to an empty string, no authentication is required
 	RequirePass string = utils.EmptyStr
 )
+
+var TestEnvEnabled = false

--- a/internal/shard/shard_thread.go
+++ b/internal/shard/shard_thread.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/charmbracelet/log"
+
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/internal/auth"
 	"github.com/dicedb/dice/internal/clientio"
@@ -127,5 +129,13 @@ func (shard *ShardThread) executeCommand(op *ops.StoreOp) []byte {
 // cleanup handles cleanup logic when the shard stops.
 func (shard *ShardThread) cleanup() {
 	close(shard.ReqChan)
+	if config.TestEnvEnabled {
+		// Avoiding AOF dump for test enabled environments as
+		// the tests were taking longer due to background tasks which exceeded the WaitDelay,
+		// thus causing the test process to be forcibly terminated.
+		log.Info("Skipping AOF dump as test env enabled.")
+		return
+	}
+
 	eval.EvalBGREWRITEAOF([]string{}, shard.store)
 }

--- a/internal/shard/shard_thread.go
+++ b/internal/shard/shard_thread.go
@@ -129,7 +129,7 @@ func (shard *ShardThread) executeCommand(op *ops.StoreOp) []byte {
 // cleanup handles cleanup logic when the shard stops.
 func (shard *ShardThread) cleanup() {
 	close(shard.ReqChan)
-	if config.TestEnvEnabled {
+	if config.WriteAOFOnCleanup {
 		// Avoiding AOF dump for test enabled environments as
 		// the tests were taking longer due to background tasks which exceeded the WaitDelay,
 		// thus causing the test process to be forcibly terminated.

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -91,7 +91,7 @@ func fireCommandAndGetRESPParser(conn net.Conn, cmd string) *clientio.RESPParser
 func runTestServer(ctx context.Context, wg *sync.WaitGroup) {
 	config.IOBufferLength = 16
 	config.Port = 8739
-	config.TestEnvEnabled = true
+	config.WriteAOFOnCleanup = true
 
 	const totalRetries = 100
 	var err error

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -91,6 +91,7 @@ func fireCommandAndGetRESPParser(conn net.Conn, cmd string) *clientio.RESPParser
 func runTestServer(ctx context.Context, wg *sync.WaitGroup) {
 	config.IOBufferLength = 16
 	config.Port = 8739
+	config.TestEnvEnabled = true
 
 	const totalRetries = 100
 	var err error


### PR DESCRIPTION
### Issue:
Due to intermittent build failures on pipeline, we analysed the cause might be due to AOF dump taking long time and thus in turn tests were getting timed out leading to failure of build.

### Fix:
As part of this PR we've introduced a config `WriteAOFOnCleanup` to be used for testing env, which current case is being used to avoid AOF dump.