### PR TITLE
Bug fix for deadlock issue with cache eviction

### DIFF
--- a/internal/store/eviction.go
+++ b/internal/store/eviction.go
@@ -54,18 +54,16 @@ func populateEvictionPool(store *Store) {
 
 	// TODO: if we already have obj, why do we need to
 	// look up in store.store again?
-	withLocks(func() {
-		store.store.All(func(k string, obj *object.Obj) bool {
-			v, ok := store.store.Get(k)
-			if ok {
-				ePool.Push(k, v.LastAccessedAt)
-				sampleSize--
-			}
-			// continue if sample size > 0
-			// stop as soon as it hits 0
-			return sampleSize > 0
-		})
-	}, store, WithStoreRLock())
+	store.store.All(func(k string, obj *object.Obj) bool {
+		v, ok := store.store.Get(k)
+		if ok {
+			ePool.Push(k, v.LastAccessedAt)
+			sampleSize--
+		}
+		// continue if sample size > 0
+		// stop as soon as it hits 0
+		return sampleSize > 0
+	})
 }
 
 // TODO: no need to populate everytime. should populate
@@ -78,7 +76,7 @@ func EvictAllkeysLRU(store *Store) {
 		if item == nil {
 			return
 		}
-		store.DelByPtr(item.keyPtr)
+		store.DelByPtrUnsafe(item.keyPtr)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -183,6 +183,10 @@ func (store *Store) DelByPtr(ptr string) bool {
 	}, store, WithStoreLock())
 }
 
+func (store *Store) DelByPtrUnsafe(ptr string) bool {
+	return store.delByPtr(ptr)
+}
+
 func (store *Store) Keys(p string) ([]string, error) {
 	var keys []string
 	var err error


### PR DESCRIPTION
Summary
There was a deadlock happening during cache eviction. Since the lock was being tried to be acquired by populateEvictionPool() while it was already being acquired during PutHelper 

Changes

- Removed the withLocks() function in populateEvictionPool() as lock is already acquired. There seems to be a singular code flow to calling populateEvictionPool() so this code change should not impact anything else
- Introduce a public unsafe DelByPtrUnsafe() method in store as the prev DelByPtr() method was again leading to deadlock in this scenario

Testing

- Evaluated cache eviction happening successfully without deadlock
- Rand integration tests to see none other tests are failing

Issue: #520 