### PR TITLE
#484: feat: add support for command [JSON.ARRLEN]

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -126,6 +126,16 @@ var (
 		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	jsonarrlenCmdMeta = DiceCmdMeta{
+		Name: "JSON.ARRLEN",
+		Info: `JSON.ARRLEN key [path]
+		Returns an array of integer replies.
+		Returns error response if the key doesn't exist or key is expired or the matching value is not an array.
+		Error reply: If the number of arguments is incorrect.`,
+		Eval:     evalJSONARRLEN,
+		Arity:    -2,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
 		Info: `TTL returns Time-to-Live in secs for the queried key in args
@@ -632,6 +642,7 @@ func init() {
 	DiceCmds["JSON.TYPE"] = jsontypeCmdMeta
 	DiceCmds["JSON.CLEAR"] = jsonclearCmdMeta
 	DiceCmds["JSON.DEL"] = jsondelCmdMeta
+	DiceCmds["JSON.ARRLEN"] = jsonarrlenCmdMeta
 	DiceCmds["TTL"] = ttlCmdMeta
 	DiceCmds["DEL"] = delCmdMeta
 	DiceCmds["EXPIRE"] = expireCmdMeta


### PR DESCRIPTION
hello:
this pr is link  #484 

add json.arrlen command. refer to redis [json.arrlen](https://redis.io/docs/latest/commands/json.arrlen/)
add unit tests in eval_test.go

because JSON.ARRLEN never change the json value, so I think there is no need to add integration test in tests/json_test.go

the json.arrlen in redis behavior as below:
`


    127.0.0.1:6379> JSON.SET user $ '{"age":13,"high":1.60,"pet":null,"language":["python","golang"],"flag":false,"partner":{"name":"tom","language":["rust"]}}'
    OK
    127.0.0.1:6379> JSON.ARRLEN user
    (error) ERR Path '.' does not exist or not an array
    127.0.0.1:6379> JSON.ARRLEN user $
    1) (nil)
    127.0.0.1:6379> JSON.ARRLEN user $.*
    1) (nil)
    2) (nil)
    3) (nil)
    4) (integer) 2
    5) (nil)
    6) (nil)
    127.0.0.1:6379> JSON.ARRLEN user $..language
    1) (integer) 2
    2) (integer) 1
    127.0.0.1:6379> JSON.ARRLEN user
    (error) ERR Path '.' does not exist or not an array

`

in dice, keep consistent