### PR TITLE
Fixed hyperloglog type assertion check.

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -19,6 +19,7 @@ const (
 	WrongTypeErr       = "-WRONGTYPE Operation against a key holding the wrong kind of value"
 	InvalidHllErr      = "-INVALIDOBJ Corrupted HLL object detected"
 	WorkerNotFoundErr  = "worker with ID %s not found"
+	WrongTypeHllErr    = "-WRONGTYPE Key is not a valid HyperLogLog string value."
 )
 
 type DiceError struct {

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2570,7 +2570,10 @@ func evalPFADD(args []string, store *dstore.Store) []byte {
 		return clientio.Encode(1, false)
 	}
 
-	existingHll := obj.Value.(*hyperloglog.Sketch)
+	existingHll, ok := obj.Value.(*hyperloglog.Sketch)
+	if !ok {
+		return diceerrors.NewErrWithMessage("*WRONGTYPE*")
+	}
 	initialCardinality := existingHll.Estimate()
 	for _, arg := range args[1:] {
 		existingHll.Insert([]byte(arg))
@@ -2593,7 +2596,10 @@ func evalPFCOUNT(args []string, store *dstore.Store) []byte {
 	for _, arg := range args {
 		obj := store.Get(arg)
 		if obj != nil {
-			currKeyHll := obj.Value.(*hyperloglog.Sketch)
+			currKeyHll, ok := obj.Value.(*hyperloglog.Sketch)
+			if !ok {
+				return diceerrors.NewErrWithMessage("*WRONGTYPE*")
+			}
 			err := unionHll.Merge(currKeyHll)
 			if err != nil {
 				return diceerrors.NewErrWithMessage(diceerrors.InvalidHllErr)

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2572,7 +2572,7 @@ func evalPFADD(args []string, store *dstore.Store) []byte {
 
 	existingHll, ok := obj.Value.(*hyperloglog.Sketch)
 	if !ok {
-		return diceerrors.NewErrWithMessage("*WRONGTYPE*")
+		return diceerrors.NewErrWithMessage(diceerrors.WrongTypeHllErr)
 	}
 	initialCardinality := existingHll.Estimate()
 	for _, arg := range args[1:] {
@@ -2598,7 +2598,7 @@ func evalPFCOUNT(args []string, store *dstore.Store) []byte {
 		if obj != nil {
 			currKeyHll, ok := obj.Value.(*hyperloglog.Sketch)
 			if !ok {
-				return diceerrors.NewErrWithMessage("*WRONGTYPE*")
+				return diceerrors.NewErrWithMessage(diceerrors.WrongTypeHllErr)
 			}
 			err := unionHll.Merge(currKeyHll)
 			if err != nil {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/dicedb/dice/internal/object"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dicedb/dice/internal/object"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/bytedance/sonic"
@@ -1006,6 +1007,17 @@ func testEvalPFADD(t *testing.T, store *dstore.Store) {
 		"one value":           {input: []string{"KEY"}, output: []byte(":1\r\n")},
 		"key val pair":        {input: []string{"KEY", "VAL"}, output: []byte(":1\r\n")},
 		"key multiple values": {input: []string{"KEY", "VAL", "VAL1", "VAL2"}, output: []byte(":1\r\n")},
+		"Incorrect type provided": {
+			setup: func() {
+				key, value := "EXISTING_KEY", "VALUE"
+				oType, oEnc := deduceTypeEncoding(value)
+				var exDurationMs int64 = -1
+				var keepttl bool = false
+
+				store.Put(key, store.NewObj(value, exDurationMs, oType, oEnc), dstore.WithKeepTTL(keepttl))
+			},
+			input:  []string{"EXISTING_KEY", "1"},
+			output: []byte("-WRONGTYPE Key is not a valid HyperLogLog string value.\r\n")},
 	}
 
 	runEvalTests(t, tests, evalPFADD, store)
@@ -1109,6 +1121,9 @@ func runEvalTests(t *testing.T, tests map[string]evalTestCase, evalFunc func([]s
 			}
 
 			output := evalFunc(tc.input, store)
+
+			fmt.Println(string(output))
+
 			if tc.validator != nil {
 				tc.validator(output)
 			} else {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1122,8 +1122,6 @@ func runEvalTests(t *testing.T, tests map[string]evalTestCase, evalFunc func([]s
 
 			output := evalFunc(tc.input, store)
 
-			fmt.Println(string(output))
-
 			if tc.validator != nil {
 				tc.validator(output)
 			} else {


### PR DESCRIPTION
The Dice server was breaking with the wrong `pfadd` command. 
This has been caught using TCL Redis tests.


Issue:
<img width="1465" alt="Screenshot 2024-09-12 at 1 16 55 AM" src="https://github.com/user-attachments/assets/ec5aafa2-6d31-4527-84af-6af80d29cf79">


Fix:
<img width="1485" alt="Screenshot 2024-09-12 at 1 34 42 AM" src="https://github.com/user-attachments/assets/14e8c773-5194-47bb-af5c-50b30d7f8251">

