### PR TITLE
SET with EX with big integer reports an error

### DIFF
--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -140,6 +140,7 @@ func evalSET(args []string, store *dstore.Store) []byte {
 			if err != nil {
 				return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
 			}
+			
 			if exDuration <= 0 || exDuration >= maxExDuration {
 				return diceerrors.NewErrExpireTime("SET")
 			}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -41,6 +41,7 @@ var serverID string
 var diceCommandsCount int
 
 const defaultRootPath = "$"
+const maxExDuration = 10000000000000000
 
 func init() {
 	diceCommandsCount = len(DiceCmds)
@@ -139,8 +140,7 @@ func evalSET(args []string, store *dstore.Store) []byte {
 			if err != nil {
 				return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
 			}
-
-			if exDuration <= 0 {
+			if exDuration <= 0 || exDuration >= maxExDuration {
 				return diceerrors.NewErrExpireTime("SET")
 			}
 


### PR DESCRIPTION
Closes #511 

Passes TCL Test
<img width="677" alt="Screenshot 2024-09-12 at 11 06 51 PM" src="https://github.com/user-attachments/assets/1c25e014-fc4d-459f-b6ab-acaddb4eeb99">

Passes existing dice tests
<img width="647" alt="Screenshot 2024-09-12 at 11 09 09 PM" src="https://github.com/user-attachments/assets/ebc264ea-0916-48cc-bc52-1fb553d8ca84">

Working Example. (Changed port number to 6379 locally for running server)
<img width="434" alt="Screenshot 2024-09-12 at 11 20 25 PM" src="https://github.com/user-attachments/assets/f1204f75-efb0-4b9e-bd40-bc4d2af52125">
