### PR TITLE
Added minimum and maximum Expiry time

### DIFF
--- a/integration_tests/commands/expire_test.go
+++ b/integration_tests/commands/expire_test.go
@@ -55,7 +55,7 @@ func TestExpire(t *testing.T) {
 				"EXPIRE test_key -1",
 				"GET test_key",
 			},
-			expected: []interface{}{int64(1), "ERR invalid expire time in 'expire' command"},
+			expected: []interface{}{"ERR invalid expire time in 'expire' command", "test_value"},
 			delay:    []time.Duration{0, 0},
 		},
 		{

--- a/integration_tests/commands/expire_test.go
+++ b/integration_tests/commands/expire_test.go
@@ -55,7 +55,7 @@ func TestExpire(t *testing.T) {
 				"EXPIRE test_key -1",
 				"GET test_key",
 			},
-			expected: []interface{}{int64(1), "(nil)"},
+			expected: []interface{}{int64(1), "ERR invalid expire time in 'expire' command"},
 			delay:    []time.Duration{0, 0},
 		},
 		{

--- a/integration_tests/commands/expireat_test.go
+++ b/integration_tests/commands/expireat_test.go
@@ -52,10 +52,10 @@ func TestExpireat(t *testing.T) {
 			name:  "EXPIREAT with past time",
 			setup: "SET test_key test_value",
 			commands: []string{
-				"EXPIREAT test_key " + strconv.FormatInt(time.Now().Unix()-1, 10),
+				"EXPIREAT test_key " + strconv.FormatInt(-1, 10),
 				"GET test_key",
 			},
-			expected: []interface{}{int64(1), "ERR invalid expire time in 'expire' command"},
+			expected: []interface{}{"ERR invalid expire time in 'expireat' command", "test_value"},
 			delay:    []time.Duration{0, 0},
 		},
 		{

--- a/integration_tests/commands/expireat_test.go
+++ b/integration_tests/commands/expireat_test.go
@@ -55,7 +55,7 @@ func TestExpireat(t *testing.T) {
 				"EXPIREAT test_key " + strconv.FormatInt(time.Now().Unix()-1, 10),
 				"GET test_key",
 			},
-			expected: []interface{}{int64(1), "(nil)"},
+			expected: []interface{}{int64(1), "ERR invalid expire time in 'expire' command"},
 			delay:    []time.Duration{0, 0},
 		},
 		{

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -22,6 +22,7 @@ const (
 	WorkerNotFoundErr    = "worker with ID %s not found"
 	JSONPathNotExistErr  = "-ERR Path '%s' does not exist"
 	JSONPathValueTypeErr = "-WRONGTYPE wrong type of path value - expected string but found integer"
+	InvalidExpireTime    = "-ERR invalid expire time"
 )
 
 type DiceError struct {

--- a/internal/eval/bitpos.go
+++ b/internal/eval/bitpos.go
@@ -130,7 +130,7 @@ func getBitPos(byteSlice []byte, bitToFind byte, start, end int, rangeType strin
 	return result
 }
 
-//nolint: gocritic
+// nolint: gocritic
 func adjustBitPosSearchRange(start, end, byteLen int) (int, int) {
 	if start < 0 {
 		start += byteLen

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1880,7 +1880,7 @@ func evalGETEX(args []string, store *dstore.Store) []byte {
 			if err != nil {
 				return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
 			}
-			if exDuration < 0 || exDuration > maxExDuration {
+			if exDuration <= 0 {
 				return diceerrors.NewErrExpireTime("GETEX")
 			}
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -41,7 +41,7 @@ var serverID string
 var diceCommandsCount int
 
 const defaultRootPath = "$"
-const maxExDuration = 10000000000000000
+const maxExDuration = 9223372036854775
 
 func init() {
 	diceCommandsCount = len(DiceCmds)
@@ -810,8 +810,12 @@ func evalEXPIRE(args []string, store *dstore.Store) []byte {
 
 	var key string = args[0]
 	exDurationSec, err := strconv.ParseInt(args[1], 10, 64)
+	if exDurationSec < 0 || exDurationSec > maxExDuration {
+		return diceerrors.NewErrWithMessage(diceerrors.InvalidExpireTime)
+	}
+
 	if err != nil {
-		return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
+		return diceerrors.NewErrWithMessage(diceerrors.InvalidExpireTime)
 	}
 
 	obj := store.Get(key)
@@ -870,6 +874,10 @@ func evalEXPIREAT(args []string, store *dstore.Store) []byte {
 
 	var key string = args[0]
 	exUnixTimeSec, err := strconv.ParseUint(args[1], 10, 64)
+	if exUnixTimeSec < 0 || exUnixTimeSec > maxExDuration {
+		return diceerrors.NewErrWithMessage(diceerrors.InvalidExpireTime)
+	}
+
 	if err != nil {
 		return clientio.Encode(errors.New("ERR value is not an integer or out of range"), false)
 	}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -811,11 +811,11 @@ func evalEXPIRE(args []string, store *dstore.Store) []byte {
 	var key string = args[0]
 	exDurationSec, err := strconv.ParseInt(args[1], 10, 64)
 	if exDurationSec < 0 || exDurationSec > maxExDuration {
-		diceerrors.NewErrExpireTime("EXPIRE")
+		return diceerrors.NewErrExpireTime("EXPIRE")
 	}
 
 	if err != nil {
-		diceerrors.NewErrExpireTime("EXPIRE")
+		return diceerrors.NewErrExpireTime("EXPIRE")
 	}
 
 	obj := store.Get(key)
@@ -875,7 +875,7 @@ func evalEXPIREAT(args []string, store *dstore.Store) []byte {
 	var key string = args[0]
 	exUnixTimeSec, err := strconv.ParseInt(args[1], 10, 64)
 	if exUnixTimeSec < 0 || exUnixTimeSec > maxExDuration {
-		diceerrors.NewErrExpireTime("EXPIREAT")
+		return diceerrors.NewErrExpireTime("EXPIREAT")
 	}
 
 	if err != nil {
@@ -1904,7 +1904,7 @@ func evalGETEX(args []string, store *dstore.Store) []byte {
 				return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
 			}
 
-			if exDuration < 0 {
+			if exDuration < 0 || exDuration > maxExDuration {
 				return diceerrors.NewErrExpireTime("GETEX")
 			}
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -811,11 +811,11 @@ func evalEXPIRE(args []string, store *dstore.Store) []byte {
 	var key string = args[0]
 	exDurationSec, err := strconv.ParseInt(args[1], 10, 64)
 	if exDurationSec < 0 || exDurationSec > maxExDuration {
-		return diceerrors.NewErrWithMessage(diceerrors.InvalidExpireTime)
+		diceerrors.NewErrExpireTime("EXPIRE")
 	}
 
 	if err != nil {
-		return diceerrors.NewErrWithMessage(diceerrors.InvalidExpireTime)
+		diceerrors.NewErrExpireTime("EXPIRE")
 	}
 
 	obj := store.Get(key)
@@ -873,9 +873,9 @@ func evalEXPIREAT(args []string, store *dstore.Store) []byte {
 	}
 
 	var key string = args[0]
-	exUnixTimeSec, err := strconv.ParseUint(args[1], 10, 64)
+	exUnixTimeSec, err := strconv.ParseInt(args[1], 10, 64)
 	if exUnixTimeSec < 0 || exUnixTimeSec > maxExDuration {
-		return diceerrors.NewErrWithMessage(diceerrors.InvalidExpireTime)
+		diceerrors.NewErrExpireTime("EXPIREAT")
 	}
 
 	if err != nil {
@@ -898,7 +898,7 @@ func evalEXPIREAT(args []string, store *dstore.Store) []byte {
 // Returns Boolean True and error nil if expiry was set on the key successfully.
 // Returns Boolean False and error nil if conditions didn't met.
 // Returns Boolean False and error not-nil if invalid combination of subCommands or if subCommand is invalid
-func evaluateAndSetExpiry(subCommands []string, newExpiry uint64, key string,
+func evaluateAndSetExpiry(subCommands []string, newExpiry int64, key string,
 	store *dstore.Store) (shouldSetExpiry bool, err []byte) {
 	var newExpInMilli = newExpiry * 1000
 	var prevExpiry *uint64 = nil
@@ -912,7 +912,7 @@ func evaluateAndSetExpiry(subCommands []string, newExpiry uint64, key string,
 	shouldSetExpiry = true
 	// if no condition exists
 	if len(subCommands) == 0 {
-		store.SetUnixTimeExpiry(obj, int64(newExpiry))
+		store.SetUnixTimeExpiry(obj, newExpiry)
 		return shouldSetExpiry, nil
 	}
 
@@ -937,12 +937,12 @@ func evaluateAndSetExpiry(subCommands []string, newExpiry uint64, key string,
 			}
 		case GT:
 			gtCmd = true
-			if prevExpiry == nil || *prevExpiry > newExpInMilli {
+			if prevExpiry == nil || *prevExpiry > uint64(newExpInMilli) {
 				shouldSetExpiry = false
 			}
 		case LT:
 			ltCmd = true
-			if prevExpiry != nil && *prevExpiry < newExpInMilli {
+			if prevExpiry != nil && *prevExpiry < uint64(newExpInMilli) {
 				shouldSetExpiry = false
 			}
 		default:
@@ -1880,7 +1880,7 @@ func evalGETEX(args []string, store *dstore.Store) []byte {
 			if err != nil {
 				return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
 			}
-			if exDuration <= 0 {
+			if exDuration < 0 || exDuration > maxExDuration {
 				return diceerrors.NewErrExpireTime("GETEX")
 			}
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -960,7 +960,7 @@ func evaluateAndSetExpiry(subCommands []string, newExpiry int64, key string,
 	}
 
 	if shouldSetExpiry {
-		store.SetUnixTimeExpiry(obj, int64(newExpiry))
+		store.SetUnixTimeExpiry(obj, newExpiry)
 	}
 	return shouldSetExpiry, nil
 }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/bytedance/sonic"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/bytedance/sonic"
 
 	"github.com/dicedb/dice/internal/object"
 
@@ -217,6 +218,35 @@ func testEvalEXPIRE(t *testing.T, store *dstore.Store) {
 			input:  []string{"EXISTING_KEY", strconv.FormatInt(1, 10)},
 			output: clientio.RespOne,
 		},
+		"invalid expiry time exists - very large integer": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &object.Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store.Put(key, obj)
+
+			},
+			input:  []string{"EXISTING_KEY", strconv.FormatInt(9223372036854776, 10)},
+			output: []byte("-ERR invalid expire time in 'expire' command\r\n"),
+		},
+
+		"invalid expiry time exists - negative integer": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &object.Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store.Put(key, obj)
+
+			},
+			input:  []string{"EXISTING_KEY", strconv.FormatInt(-1, 10)},
+			output: []byte("-ERR invalid expire time in 'expire' command\r\n"),
+		},
 	}
 
 	runEvalTests(t, tests, evalEXPIRE, store)
@@ -297,6 +327,34 @@ func testEvalEXPIREAT(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"EXISTING_KEY", strconv.FormatInt(time.Now().Add(2*time.Minute).Unix(), 10)},
 			output: clientio.RespOne,
+		},
+		"invalid expire time - very large integer": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &object.Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store.Put(key, obj)
+
+			},
+			input:  []string{"EXISTING_KEY", strconv.FormatInt(9223372036854776, 10)},
+			output: []byte("-ERR invalid expire time in 'expireat' command\r\n"),
+		},
+		"invalid expire time - negative integer": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &object.Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store.Put(key, obj)
+
+			},
+			input:  []string{"EXISTING_KEY", strconv.FormatInt(-1, 10)},
+			output: []byte("-ERR invalid expire time in 'expireat' command\r\n"),
 		},
 	}
 

--- a/internal/server/utils/time.go
+++ b/internal/server/utils/time.go
@@ -32,6 +32,6 @@ func GetCurrentTime() time.Time {
 	return CurrentTime.Now()
 }
 
-func AddSecondsToUnixEpoch(second int64) uint64 {
-	return uint64(GetCurrentTime().Unix()) + uint64(second)
+func AddSecondsToUnixEpoch(second int64) int64 {
+	return int64(GetCurrentTime().Unix()) + int64(second)
 }

--- a/internal/server/utils/time.go
+++ b/internal/server/utils/time.go
@@ -33,5 +33,5 @@ func GetCurrentTime() time.Time {
 }
 
 func AddSecondsToUnixEpoch(second int64) int64 {
-	return int64(GetCurrentTime().Unix()) + int64(second)
+	return GetCurrentTime().Unix() + second
 }

--- a/tmp/build-errors.log
+++ b/tmp/build-errors.log
@@ -1,0 +1,1 @@
+exit status 1exit status 1exit status 1exit status 1

--- a/tmp/build-errors.log
+++ b/tmp/build-errors.log
@@ -1,1 +1,0 @@
-exit status 1exit status 1exit status 1exit status 1


### PR DESCRIPTION
The maximum TTL (Time to Live) in Redis is set to 9223372036854775 milliseconds, which is equivalent to approximately 106,751 days (or about 292 years). This value is based on the maximum possible value for a signed 64-bit integer (2^63 - 1), which is 9223372036854775807 milliseconds. Redis uses this value to represent TTLs internally. Redis stores TTL values in milliseconds. Therefore, the maximum value Redis can store for a TTL is constrained by the largest 64-bit signed integer.

Issues covered:
https://github.com/DiceDB/dice/issues/511
https://github.com/DiceDB/dice/issues/504
https://github.com/DiceDB/dice/issues/505

Evidences:
<img width="1227" alt="Screenshot 2024-09-13 at 11 53 59 PM" src="https://github.com/user-attachments/assets/fa60ba3a-7418-4746-ab1c-95a6a492a3e2">


