### PR TITLE
Enhance GETDEL to handle Set, JSON, and ByteArray, String, Integer and Expand Test Coverage

### DIFF
--- a/integration_tests/commands/getdel_test.go
+++ b/integration_tests/commands/getdel_test.go
@@ -1,9 +1,10 @@
 package commands
 
 import (
-	"gotest.tools/v3/assert"
 	"testing"
 	"time"
+
+	"gotest.tools/v3/assert"
 )
 
 func TestGetDel(t *testing.T) {
@@ -42,9 +43,28 @@ func TestGetDel(t *testing.T) {
 				"ERR wrong number of arguments for 'getdel' command"},
 			delays: []time.Duration{0, 0},
 		},
+		{
+			name:   "Getdel with value created from Setbit",
+			cmds:   []string{"SETBIT k 1 1", "GET k", "GETDEL k", "GET k"},
+			expect: []interface{}{int64(0), "@", "@", "(nil)"},
+			delays: []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name:   "GetDel with Set object should return wrong type error",
+			cmds:   []string{"SADD myset member1", "GETDEL myset"},
+			expect: []interface{}{int64(1), "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name:   "GetDel with JSON object should return wrong type error",
+			cmds:   []string{"JSON.SET k $ 1", "GETDEL k", "JSON.GET k"},
+			expect: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value", "1"},
+			delays: []time.Duration{0, 0, 0},
+		},
 	}
 
 	for _, tc := range testCases {
+		FireCommand(conn, "del k")
 		t.Run(tc.name, func(t *testing.T) {
 			for i, cmd := range tc.cmds {
 				if tc.delays[i] > 0 {

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -311,7 +311,7 @@ func evalGETDEL(args []string, store *dstore.Store) []byte {
 
 	key := args[0]
 
-	//Getting the key based on previous touch value
+	// getting the key based on previous touch value
 	obj := store.GetNoTouch(key)
 
 	//Check if obj is nil

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -311,21 +311,53 @@ func evalGETDEL(args []string, store *dstore.Store) []byte {
 
 	key := args[0]
 
-	// Get the key from the hash table
-	obj := store.GetDel(key)
+	//Getting the key based on previous touch value
+	obj := store.GetNoTouch(key)
 
-	// if key does not exist, return RESP encoded nil
+	//Check if obj is nil
 	if obj == nil {
 		return clientio.RespNIL
 	}
 
-	// If the object exists, check if it is a set object.
+	// If the object exists, check if it is a Set object.
 	if err := object.AssertType(obj.TypeEncoding, object.ObjTypeSet); err == nil {
 		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
-	// return the RESP encoded value
-	return clientio.Encode(obj.Value, false)
+	// If the object exists, check if it is a JSON object.
+	if err := object.AssertType(obj.TypeEncoding, object.ObjTypeJSON); err == nil {
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
+	}
+
+	// Get the key from the hash table
+	objVal := store.GetDel(key)
+
+	// Decode and return the value based on its encoding
+	switch _, oEnc := object.ExtractTypeEncoding(objVal); oEnc {
+	case object.ObjEncodingInt:
+		// Value is stored as an int64, so use type assertion
+		if val, ok := objVal.Value.(int64); ok {
+			return clientio.Encode(val, false)
+		}
+		return diceerrors.NewErrWithFormattedMessage("expected int64 but got another type: %s", objVal.Value)
+
+	case object.ObjEncodingEmbStr, object.ObjEncodingRaw:
+		// Value is stored as a string, use type assertion
+		if val, ok := objVal.Value.(string); ok {
+			return clientio.Encode(val, false)
+		}
+		return diceerrors.NewErrWithMessage("expected string but got another type")
+
+	case object.ObjEncodingByteArray:
+		// Value is stored as a bytearray, use type assertion
+		if val, ok := objVal.Value.(*ByteArray); ok {
+			return clientio.Encode(string(val.data), false)
+		}
+		return diceerrors.NewErrWithMessage(diceerrors.WrongTypeErr)
+
+	default:
+		return diceerrors.NewErrWithMessage(diceerrors.WrongTypeErr)
+	}
 }
 
 // evaLJSONFORGET removes the field specified by the given JSONPath from the JSON document stored under the provided key.

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -314,7 +314,7 @@ func evalGETDEL(args []string, store *dstore.Store) []byte {
 	// getting the key based on previous touch value
 	obj := store.GetNoTouch(key)
 
-	//Check if obj is nil
+	// if key does not exist, return RESP encoded nil
 	if obj == nil {
 		return clientio.RespNIL
 	}


### PR DESCRIPTION
#474 

I handled the set and JSON data type for GETDEL and am throwing an error if it is! 

Using getnotouch to retrieve the key based on the previous touch value! Decoding the value and returning based on its encoding type - int64, string, byte array.

Wrote manually the test cases with SetBit, Getdel, and get. Also, wrote a test case for getdel with set and the JSON object

Please review and let me know in case of questions or suggestions. @arpitbbhayani @JyotinderSingh @apoorvyadav1111 