### PR TITLE
#499: Add support for command JSON.OBJLEN

### DIFF
--- a/integration_tests/commands/json_test.go
+++ b/integration_tests/commands/json_test.go
@@ -677,8 +677,6 @@ func TestJsonObjLen(t *testing.T) {
 				cmd := tcase.commands[i]
 				out := tcase.expected[i]
 				result := FireCommand(conn, cmd)
-				fmt.Println("RESSSSS",result)
-				fmt.Println("OUTTT",out)
 				assert.DeepEqual(t,out,result)
 			}
 		})

--- a/integration_tests/commands/json_test.go
+++ b/integration_tests/commands/json_test.go
@@ -671,7 +671,7 @@ func TestJsonObjLen(t *testing.T) {
 		{
 			name:     "JSON.OBJLEN invalid json path",
 			commands: []string{"json.set obj $ " + b, "json.objlen obj $..language*something"},
-			expected: []interface{}{"OK", "ERR invalid JSONPath"},
+			expected: []interface{}{"OK", "ERR parse error at 13 in $..language*something"},
 		},
 		{
 			name:     "JSON.OBJLEN with non-existant key",
@@ -686,7 +686,7 @@ func TestJsonObjLen(t *testing.T) {
 		{
 			name:     "JSON.OBJLEN invalid json path",
 			commands: []string{"json.set obj $ " + c, "json.objlen obj $[1"},
-			expected: []interface{}{"OK", "ERR invalid JSONPath"},
+			expected: []interface{}{"OK", "ERR expected a number at 4 in $[1"},
 		},
 		{
 			name:     "JSON.OBJLEN invalid json path",

--- a/integration_tests/commands/json_test.go
+++ b/integration_tests/commands/json_test.go
@@ -850,6 +850,11 @@ func TestJsonObjLen(t *testing.T) {
 	c := `{"name":"jerry","partner":{"name":"tom","language":["rust"]},"partner2":{"name":12,"language":["rust"]}}`
 	d := `["this","is","an","array"]`
 
+	defer func() {
+		resp := FireCommand(conn, "DEL obj")
+		assert.Equal(t, int64(1), resp)
+	}()
+
 	testCases := []struct {
 		name     string
 		commands []string
@@ -905,7 +910,6 @@ func TestJsonObjLen(t *testing.T) {
 			commands: []string{"json.set obj $ " + c, "json.objlen"},
 			expected: []interface{}{"OK", "ERR wrong number of arguments for 'json.objlen' command"},
 		},
-		
 	}
 
 	for _, tcase := range testCases {
@@ -915,10 +919,10 @@ func TestJsonObjLen(t *testing.T) {
 				cmd := tcase.commands[i]
 				out := tcase.expected[i]
 				result := FireCommand(conn, cmd)
-				assert.DeepEqual(t,out,result)
-      }
-    })
-  }
+				assert.DeepEqual(t, out, result)
+			}
+		})
+	}
 }
 
 func convertToArray(input string) []string {

--- a/integration_tests/commands/json_test.go
+++ b/integration_tests/commands/json_test.go
@@ -659,7 +659,7 @@ func TestJsonObjLen(t *testing.T) {
 			expected: []interface{}{"OK", []interface{}{"(nil)"}},
 		},
 		{
-			name:     "JSON.OBJLEN with invalid path",
+			name:     "JSON.OBJLEN with nested non-object path",
 			commands: []string{"json.set obj $ " + c, "json.objlen obj $.partner2.name"},
 			expected: []interface{}{"OK", []interface{}{"(nil)"}},
 		},
@@ -668,6 +668,32 @@ func TestJsonObjLen(t *testing.T) {
 			commands: []string{"json.set obj $ " + b, "json.objlen obj $..language"},
 			expected: []interface{}{"OK", []interface{}{"(nil)", "(nil)"}},
 		},
+		{
+			name:     "JSON.OBJLEN invalid json path",
+			commands: []string{"json.set obj $ " + b, "json.objlen obj $..language*something"},
+			expected: []interface{}{"OK", "ERR invalid JSONPath"},
+		},
+		{
+			name:     "JSON.OBJLEN with non-existant key",
+			commands: []string{"json.set obj $ " + b, "json.objlen non_existing_key $"},
+			expected: []interface{}{"OK", "(nil)"},
+		},
+		{
+			name:     "JSON.OBJLEN with empty path",
+			commands: []string{"json.set obj $ " + a, "json.objlen obj"},
+			expected: []interface{}{"OK", int64(2)},
+		},
+		{
+			name:     "JSON.OBJLEN invalid json path",
+			commands: []string{"json.set obj $ " + c, "json.objlen obj $[1"},
+			expected: []interface{}{"OK", "ERR invalid JSONPath"},
+		},
+		{
+			name:     "JSON.OBJLEN invalid json path",
+			commands: []string{"json.set obj $ " + c, "json.objlen"},
+			expected: []interface{}{"OK", "ERR wrong number of arguments for 'json.objlen' command"},
+		},
+		
 	}
 
 	for _, tcase := range testCases {

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -150,7 +150,9 @@ var (
 	jsonobjlenCmdMeta = DiceCmdMeta{
 		Name: "JSON.OBJLEN",
 		Info: `JSON.OBJLEN key [path]
-		Report the number of keys in the JSON object at path in key`,
+		Report the number of keys in the JSON object at path in key
+		Returns error response if the key doesn't exist or key is expired or the matching value is not an array. 
+		Error reply: If the number of arguments is incorrect.`,
 		Eval: evalJSONOBJLEN,
 		Arity: -2,
 		KeySpecs: KeySpecs{BeginIndex: 1},

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -147,6 +147,14 @@ var (
 		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	jsonobjlenCmdMeta = DiceCmdMeta{
+		Name: "JSON.OBJLEN",
+		Info: `JSON.OBJLEN key [path]
+		Report the number of keys in the JSON object at path in key`,
+		Eval: evalJSONOBJLEN,
+		Arity: -2,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
 		Info: `TTL returns Time-to-Live in secs for the queried key in args
@@ -693,6 +701,7 @@ func init() {
 	DiceCmds["JSON.DEL"] = jsondelCmdMeta
 	DiceCmds["JSON.FORGET"] = jsonforgetCmdMeta
 	DiceCmds["JSON.ARRLEN"] = jsonarrlenCmdMeta
+	DiceCmds["JSON.OBJLEN"] = jsonobjlenCmdMeta
 	DiceCmds["TTL"] = ttlCmdMeta
 	DiceCmds["DEL"] = delCmdMeta
 	DiceCmds["EXPIRE"] = expireCmdMeta

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -626,9 +626,8 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 		if utils.GetJSONFieldType(jsonData) == utils.ObjectType {
 			if castedData, ok := jsonData.(map[string]interface{}); ok {
 				return clientio.Encode(len(castedData), false)
-			}else{
-				return clientio.RespNIL
-			}			
+			}	
+			return clientio.RespNIL		
 		}
 		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -603,7 +603,7 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 	// Retrieve the object from the database
 	obj := store.Get(key)
 	if obj == nil {
-		return diceerrors.NewErrWithMessage("Path '.' does not exist or not a json")
+		return clientio.RespNIL
 	}
 
 	// check if the object is json
@@ -651,8 +651,6 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 
 	return clientio.Encode(objectLen,false)
 }
-
-
 
 // evalJSONDEL delete a value that the given json path include in.
 // Returns response.RespZero if key is expired or it does not exist

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -436,7 +436,6 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 		if utils.GetJSONFieldType(jsonData) == utils.ObjectType {
 			return clientio.Encode(len(jsonData.(map[string]interface{})), false)
 		}
-		// return diceerrors.NewErrWithMessage("Path '.' does not exist or not a json")
 		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -436,7 +436,8 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 		if utils.GetJSONFieldType(jsonData) == utils.ObjectType {
 			return clientio.Encode(len(jsonData.(map[string]interface{})), false)
 		}
-		return diceerrors.NewErrWithMessage("Path '.' does not exist or not a json")
+		// return diceerrors.NewErrWithMessage("Path '.' does not exist or not a json")
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
 	path := args[1]

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -623,7 +623,11 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 	if len(args) == 1 {
 		// check if the value is of json type
 		if utils.GetJSONFieldType(jsonData) == utils.ObjectType {
-			return clientio.Encode(len(jsonData.(map[string]interface{})), false)
+			if castedData, ok := jsonData.(map[string]interface{}); ok {
+				return clientio.Encode(len(castedData), false)
+			}else{
+				return clientio.RespNIL
+			}			
 		}
 		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
@@ -632,7 +636,7 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 
 	expr, err := jp.ParseString(path)
 	if err != nil {
-		return diceerrors.NewErrWithMessage("invalid JSONPath")
+		return diceerrors.NewErrWithMessage(err.Error())
 	}
 
 	// get all values for matching paths
@@ -643,12 +647,15 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 	for _,result := range results{
 		switch utils.GetJSONFieldType(result) {
 		case utils.ObjectType:
-			objectLen = append(objectLen,len(result.(map[string]interface{})))
+			if castedResult, ok := result.(map[string]interface{}); ok {
+				objectLen = append(objectLen, len(castedResult)) 
+			} else {
+				objectLen = append(objectLen, nil)
+			}
 		default:
 			objectLen = append(objectLen, nil)
 		}
 	}
-
 	return clientio.Encode(objectLen,false)
 }
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -400,9 +400,9 @@ func evalJSONARRLEN(args []string, store *dstore.Store) []byte {
 }
 
 
-// evalJSONOBJLEN return the number of keys in the JSON object at path in key
+// evalJSONOBJLEN return the number of keys in the JSON object at path in key.
 // Returns an array of integer replies, an integer for each matching value,
-// each is the json objects length, or nil, if the matching value is not a json.
+// which is the json objects length, or nil, if the matching value is not a json.
 // Returns encoded error if the key doesn't exist or key is expired or the matching value is not an array.
 // Returns encoded error response if incorrect number of arguments
 func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
@@ -418,7 +418,7 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 		return diceerrors.NewErrWithMessage("Path '.' does not exist or not a json")
 	}
 
-	// check if the value is json
+	// check if the object is json
 	errWithMessage := object.AssertTypeAndEncoding(obj.TypeEncoding, object.ObjTypeJSON, object.ObjEncodingJSON)
 	if errWithMessage != nil {
 		return errWithMessage
@@ -433,6 +433,7 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 
 
 	if len(args) == 1 {
+		// check if the value is of json type
 		if utils.GetJSONFieldType(jsonData) == utils.ObjectType {
 			return clientio.Encode(len(jsonData.(map[string]interface{})), false)
 		}
@@ -446,6 +447,7 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) []byte {
 		return diceerrors.NewErrWithMessage("invalid JSONPath")
 	}
 
+	// get all values for matching paths
 	results := expr.Get(jsonData)
 
 	objectLen := make([]interface{},0,len(results))

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -458,7 +458,7 @@ func testEvalJSONOBJLEN(t *testing.T, store *dstore.Store) {
 				store.Put(key, obj)
 			},
 			input:  []string{"EXISTING_KEY"},
-			output: []byte("-ERR Path '.' does not exist or not a json\r\n"),
+			output: []byte("-WRONGTYPE Operation against a key holding the wrong kind of value\r\n"),
 		},
 		"root object objlen": {
 			setup: func() {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -515,7 +515,7 @@ func testEvalJSONOBJLEN(t *testing.T, store *dstore.Store) {
 
 
 func BenchmarkEvalJSONOBJLEN(b *testing.B) {
-	sizes := []int{0, 10, 100, 1000, 10000} // Various sizes of JSON objects
+	sizes := []int{0, 10, 100, 1000, 10000, 100000} // Various sizes of JSON objects
 	store := dstore.NewStore(nil)
 
 	for _, size := range sizes {
@@ -528,19 +528,21 @@ func BenchmarkEvalJSONOBJLEN(b *testing.B) {
 				jsonObj[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
 			}
 
-			newObj := store.NewObj(jsonObj, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
-			store.Put(key, newObj)
+			// Set the JSON object in the store
+			args := []string{key, "$", fmt.Sprintf("%v", jsonObj)}
+			evalJSONSET(args, store)
 
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			// Benchmark the evalJSONOBJLEN function
 			for i := 0; i < b.N; i++ {
-				evalJSONOBJLEN([]string{key, "$"}, store)
+				_ = evalJSONOBJLEN([]string{key, "$"}, store)
 			}
 		})
 	}
 }
+
 
 
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -538,7 +538,43 @@ func testEvalJSONOBJLEN(t *testing.T, store *dstore.Store) {
 				store.Put(key, obj)
 			},
 			input:  []string{"EXISTING_KEY", "$invalid_path"},
-			output: []byte("-ERR invalid JSONPath\r\n"),
+			output: []byte("-ERR parse error at 2 in $invalid_path\r\n"),
+		},
+		"incomapitable type(int) objlen": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"person\":{\"name\":\"John\",\"age\":30},\"languages\":[\"python\",\"golang\"]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.person.age"},
+			output: []byte("*1\r\n$-1\r\n"),
+		},
+		"incomapitable type(string) objlen": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"person\":{\"name\":\"John\",\"age\":30},\"languages\":[\"python\",\"golang\"]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.person.name"},
+			output: []byte("*1\r\n$-1\r\n"),
+		},
+		"incomapitable type(array) objlen": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"person\":{\"name\":\"John\",\"age\":30},\"languages\":[\"python\",\"golang\"]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.languages"},
+			output: []byte("*1\r\n$-1\r\n"),
 		},
 	}
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -514,6 +514,36 @@ func testEvalJSONOBJLEN(t *testing.T, store *dstore.Store) {
 }
 
 
+func BenchmarkEvalJSONOBJLEN(b *testing.B) {
+	sizes := []int{0, 10, 100, 1000, 10000} // Various sizes of JSON objects
+	store := dstore.NewStore(nil)
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("JSONObjectSize_%d", size), func(b *testing.B) {
+			key := fmt.Sprintf("benchmark_json_obj_%d", size)
+
+			// Create a large JSON object with the given size
+			jsonObj := make(map[string]interface{})
+			for i := 0; i < size; i++ {
+				jsonObj[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+			}
+
+			newObj := store.NewObj(jsonObj, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+			store.Put(key, newObj)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			// Benchmark the evalJSONOBJLEN function
+			for i := 0; i < b.N; i++ {
+				evalJSONOBJLEN([]string{key, "$"}, store)
+			}
+		})
+	}
+}
+
+
+
 func testEvalJSONDEL(t *testing.T, store *dstore.Store) {
 	tests := map[string]evalTestCase{
 		"nil value": {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -463,7 +463,6 @@ func testEvalJSONARRLEN(t *testing.T, store *dstore.Store) {
 	runEvalTests(t, tests, evalJSONARRLEN, store)
 }
 
-
 func testEvalJSONOBJLEN(t *testing.T, store *dstore.Store) {
 	tests := map[string]evalTestCase{
 		"nil value": {
@@ -479,7 +478,7 @@ func testEvalJSONOBJLEN(t *testing.T, store *dstore.Store) {
 		"key does not exist": {
 			setup:  func() {},
 			input:  []string{"NONEXISTENT_KEY"},
-			output: []byte("-ERR Path '.' does not exist or not a json\r\n"),
+			output: clientio.RespNIL,
 		},
 		"root not object": {
 			setup: func() {
@@ -546,7 +545,6 @@ func testEvalJSONOBJLEN(t *testing.T, store *dstore.Store) {
 	runEvalTests(t, tests, evalJSONOBJLEN, store)
 }
 
-
 func BenchmarkEvalJSONOBJLEN(b *testing.B) {
 	sizes := []int{0, 10, 100, 1000, 10000, 100000} // Various sizes of JSON objects
 	store := dstore.NewStore(nil)
@@ -575,9 +573,6 @@ func BenchmarkEvalJSONOBJLEN(b *testing.B) {
 		})
 	}
 }
-
-
-
 
 func testEvalJSONDEL(t *testing.T, store *dstore.Store) {
 	tests := map[string]evalTestCase{


### PR DESCRIPTION
## Issue
Issue fixed : #499 

## Description
This PR introduces the new command `JSON.OBJLEN`
1. Implementation for JSON.OBJLEN ref: [RedisJSON](https://github.com/RedisJSON/RedisJSON/blob/master/redis_json/src/commands.rs) , [JSON.OBJLEN](https://redis.io/docs/latest/commands/json.objlen/)
2. Add unit tests
3. Add integration tests
4. Add benchmark

Dice DB(CLI demo)
<img width="1475" alt="Screenshot 2024-09-16 at 2 10 54 AM" src="https://github.com/user-attachments/assets/2a1043a8-dbd3-43b8-9d91-17f797f023f5">

Redis
<img width="1475" alt="Screenshot 2024-09-16 at 2 11 45 AM" src="https://github.com/user-attachments/assets/ecf21047-307d-4e75-afe6-0408354fbf78">


## Testing details
1. Units tests
<img width="978" alt="Screenshot 2024-09-16 at 1 13 59 AM" src="https://github.com/user-attachments/assets/2d512be4-3798-44b9-80bb-2f6d427800ee">

2. Integration tests
<img width="988" alt="Screenshot 2024-09-16 at 1 16 50 AM" src="https://github.com/user-attachments/assets/2c8e180b-337f-43a7-af34-a231d89bc2dd">

3. Benchmarks
<img width="937" alt="Screenshot 2024-09-16 at 1 26 08 AM" src="https://github.com/user-attachments/assets/4dadf656-98ad-4f15-85b9-0cb9ea9256aa">

