### PR TITLE
Fixing flaky unit test for JSON comparisons

### DIFF
--- a/integration_tests/commands/copy_test.go
+++ b/integration_tests/commands/copy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/dicedb/dice/testutils"
+	testifyAssert "github.com/stretchr/testify/assert"
 	"gotest.tools/v3/assert"
 )
 
@@ -83,7 +84,7 @@ func TestCopy(t *testing.T) {
 				// else compare the values as is.
 				// This is to handle cases where the expected value is a json string with a different key order.
 				if resOk && expOk && testutils.IsJSONResponse(resStr) && testutils.IsJSONResponse(expStr) {
-					testutils.AssertJSONEqual(t, expStr, resStr)
+					testifyAssert.JSONEq(t, expStr, resStr)
 				} else {
 					assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s", cmd)
 				}

--- a/integration_tests/commands/json_arrpop_test.go
+++ b/integration_tests/commands/json_arrpop_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/dicedb/dice/testutils"
+	testifyAssert "github.com/stretchr/testify/assert"
 	"gotest.tools/v3/assert"
 )
 
@@ -48,7 +49,7 @@ func TestJSONARRPOP(t *testing.T) {
 				jsonResult, isString := result.(string)
 
 				if isString && testutils.IsJSONResponse(jsonResult) {
-					testutils.AssertJSONEqual(t, out.(string), jsonResult)
+					testifyAssert.JSONEq(t, out.(string), jsonResult)
 					continue
 				}
 

--- a/integration_tests/commands/json_test.go
+++ b/integration_tests/commands/json_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytedance/sonic"
 
 	"github.com/dicedb/dice/testutils"
+	testifyAssert "github.com/stretchr/testify/assert"
 	"gotest.tools/v3/assert"
 )
 
@@ -607,6 +608,7 @@ func TestJSONForgetOperations(t *testing.T) {
 		})
 	}
 }
+
 func arraysArePermutations[T comparable](a, b []T) bool {
 	if len(a) != len(b) {
 		return false
@@ -934,6 +936,7 @@ func convertToArray(input string) []string {
 	}
 	return elements
 }
+
 func TestJSONNumIncrBy(t *testing.T) {
 	conn := getLocalConnection()
 	defer conn.Close()
@@ -1010,6 +1013,7 @@ func TestJSONNumIncrBy(t *testing.T) {
 				case "equal":
 					assert.Equal(t, out, result)
 				case "perm_equal":
+					testifyAssert.JSONEq(t, out.(string), result.(string))
 					assert.Assert(t, arraysArePermutations(convertToArray(out.(string)), convertToArray(result.(string))))
 				case "range":
 					assert.Assert(t, result.(int64) <= tc.expected[i].(int64) && result.(int64) > 0, "Expected %v to be within 0 to %v", result, tc.expected[i])

--- a/integration_tests/commands/json_test.go
+++ b/integration_tests/commands/json_test.go
@@ -2,14 +2,13 @@ package commands
 
 import (
 	"fmt"
-	testifyAssert "github.com/stretchr/testify/assert"
 	"net"
 	"strings"
 	"testing"
 
 	"github.com/bytedance/sonic"
-
 	"github.com/dicedb/dice/testutils"
+	testifyAssert "github.com/stretchr/testify/assert"
 	"gotest.tools/v3/assert"
 )
 
@@ -184,7 +183,7 @@ func TestJSONOperations(t *testing.T) {
 				if tc.getCmd != "" {
 					result := FireCommand(conn, tc.getCmd)
 					if testutils.IsJSONResponse(result.(string)) {
-						testutils.AssertJSONEqual(t, tc.expected, result.(string))
+						testifyAssert.JSONEq(t, tc.expected, result.(string))
 					} else {
 						assert.Equal(t, tc.expected, result)
 					}
@@ -335,7 +334,7 @@ func TestJSONSetWithNXAndXX(t *testing.T) {
 				result := FireCommand(conn, cmd)
 				jsonResult, isString := result.(string)
 				if isString && testutils.IsJSONResponse(jsonResult) {
-					testutils.AssertJSONEqual(t, tc.expected[i].(string), jsonResult)
+					testifyAssert.JSONEq(t, tc.expected[i].(string), jsonResult)
 				} else {
 					assert.Equal(t, tc.expected[i], result)
 				}
@@ -512,7 +511,7 @@ func TestJSONDelOperations(t *testing.T) {
 				result := FireCommand(conn, cmd)
 				stringResult, ok := result.(string)
 				if ok && testutils.IsJSONResponse(stringResult) {
-					testutils.AssertJSONEqual(t, tc.expected[i].(string), stringResult)
+					testifyAssert.JSONEq(t, tc.expected[i].(string), stringResult)
 				} else {
 					assert.Equal(t, tc.expected[i], result)
 				}
@@ -600,7 +599,7 @@ func TestJSONForgetOperations(t *testing.T) {
 				result := FireCommand(conn, cmd)
 				stringResult, ok := result.(string)
 				if ok && testutils.IsJSONResponse(stringResult) {
-					testutils.AssertJSONEqual(t, tc.expected[i].(string), stringResult)
+					testifyAssert.JSONEq(t, tc.expected[i].(string), stringResult)
 				} else {
 					assert.Equal(t, tc.expected[i], result)
 				}
@@ -734,7 +733,7 @@ func TestJSONMGET(t *testing.T) {
 				assert.Equal(t, len(tc.expected), len(results))
 				for i := range results {
 					if testutils.IsJSONResponse(tc.expected[i].(string)) {
-						testutils.AssertJSONEqual(t, tc.expected[i].(string), results[i].(string))
+						testifyAssert.JSONEq(t, tc.expected[i].(string), results[i].(string))
 					} else {
 						assert.Equal(t, tc.expected[i], results[i])
 					}

--- a/integration_tests/commands/json_test.go
+++ b/integration_tests/commands/json_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	testifyAssert "github.com/stretchr/testify/assert"
 	"net"
 	"strings"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/bytedance/sonic"
 
 	"github.com/dicedb/dice/testutils"
-	testifyAssert "github.com/stretchr/testify/assert"
 	"gotest.tools/v3/assert"
 )
 
@@ -1013,12 +1013,11 @@ func TestJSONNumIncrBy(t *testing.T) {
 				case "equal":
 					assert.Equal(t, out, result)
 				case "perm_equal":
-					testifyAssert.JSONEq(t, out.(string), result.(string))
 					assert.Assert(t, arraysArePermutations(convertToArray(out.(string)), convertToArray(result.(string))))
 				case "range":
 					assert.Assert(t, result.(int64) <= tc.expected[i].(int64) && result.(int64) > 0, "Expected %v to be within 0 to %v", result, tc.expected[i])
 				case "json_equal":
-					testutils.AssertJSONEqual(t, out.(string), result.(string))
+					testifyAssert.JSONEq(t, out.(string), result.(string))
 				}
 			}
 			for i := 0; i < len(tc.cleanUp); i++ {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -68,7 +68,7 @@ func TestEval(t *testing.T) {
 	testEvalHGET(t, store)
 	testEvalPFMERGE(t, store)
 	testEvalJSONSTRLEN(t, store)
-	testEvalJSONOBJLEN(t,store)
+	testEvalJSONOBJLEN(t, store)
 	testEvalHLEN(t, store)
 	testEvalSELECT(t, store)
 	testEvalLLEN(t, store)
@@ -2008,72 +2008,72 @@ func testEvalHSET(t *testing.T, store *dstore.Store) {
 }
 
 func BenchmarkEvalPFCOUNT(b *testing.B) {
-    store := *dstore.NewStore(nil)
+	store := *dstore.NewStore(nil)
 
-    // Helper function to create and insert HLL objects
-    createAndInsertHLL := func(key string, items []string) {
-        hll := hyperloglog.New()
-        for _, item := range items {
-            hll.Insert([]byte(item))
-        }
-        obj := &object.Obj{
-            Value:          hll,
-            LastAccessedAt: uint32(time.Now().Unix()),
-        }
-        store.Put(key, obj)
-    }
+	// Helper function to create and insert HLL objects
+	createAndInsertHLL := func(key string, items []string) {
+		hll := hyperloglog.New()
+		for _, item := range items {
+			hll.Insert([]byte(item))
+		}
+		obj := &object.Obj{
+			Value:          hll,
+			LastAccessedAt: uint32(time.Now().Unix()),
+		}
+		store.Put(key, obj)
+	}
 
-    // Create small HLLs (10000 items each)
+	// Create small HLLs (10000 items each)
 	smallItems := make([]string, 10000)
-    for i := 0; i < 100; i++ {
-        smallItems[i] = fmt.Sprintf("SmallItem%d", i)
-    }
-    createAndInsertHLL("SMALL1", smallItems)
-    createAndInsertHLL("SMALL2", smallItems)
+	for i := 0; i < 100; i++ {
+		smallItems[i] = fmt.Sprintf("SmallItem%d", i)
+	}
+	createAndInsertHLL("SMALL1", smallItems)
+	createAndInsertHLL("SMALL2", smallItems)
 
-    // Create medium HLLs (1000000 items each)
-    mediumItems := make([]string, 1000000)
-    for i := 0; i < 100; i++ {
-        mediumItems[i] = fmt.Sprintf("MediumItem%d", i)
-    }
-    createAndInsertHLL("MEDIUM1", mediumItems)
-    createAndInsertHLL("MEDIUM2", mediumItems)
+	// Create medium HLLs (1000000 items each)
+	mediumItems := make([]string, 1000000)
+	for i := 0; i < 100; i++ {
+		mediumItems[i] = fmt.Sprintf("MediumItem%d", i)
+	}
+	createAndInsertHLL("MEDIUM1", mediumItems)
+	createAndInsertHLL("MEDIUM2", mediumItems)
 
-    // Create large HLLs (1000000000 items each)
-    largeItems := make([]string, 1000000000)
-    for i := 0; i < 10000; i++ {
-        largeItems[i] = fmt.Sprintf("LargeItem%d", i)
-    }
-    createAndInsertHLL("LARGE1", largeItems)
-    createAndInsertHLL("LARGE2", largeItems)
+	// Create large HLLs (1000000000 items each)
+	largeItems := make([]string, 1000000000)
+	for i := 0; i < 10000; i++ {
+		largeItems[i] = fmt.Sprintf("LargeItem%d", i)
+	}
+	createAndInsertHLL("LARGE1", largeItems)
+	createAndInsertHLL("LARGE2", largeItems)
 
-    tests := []struct {
-        name string
-        args []string
-    }{
-        {"SingleSmallKey", []string{"SMALL1"}},
-        {"TwoSmallKeys", []string{"SMALL1", "SMALL2"}},
-        {"SingleMediumKey", []string{"MEDIUM1"}},
-        {"TwoMediumKeys", []string{"MEDIUM1", "MEDIUM2"}},
-        {"SingleLargeKey", []string{"LARGE1"}},
-        {"TwoLargeKeys", []string{"LARGE1", "LARGE2"}},
-        {"MixedSizes", []string{"SMALL1", "MEDIUM1", "LARGE1"}},
-        {"ManySmallKeys", []string{"SMALL1", "SMALL2", "SMALL1", "SMALL2", "SMALL1"}},
-        {"ManyMediumKeys", []string{"MEDIUM1", "MEDIUM2", "MEDIUM1", "MEDIUM2", "MEDIUM1"}},
-        {"ManyLargeKeys", []string{"LARGE1", "LARGE2", "LARGE1", "LARGE2", "LARGE1"}},
-        {"NonExistentKey", []string{"SMALL1", "NONEXISTENT", "LARGE1"}},
-        {"AllKeys", []string{"SMALL1", "SMALL2", "MEDIUM1", "MEDIUM2", "LARGE1", "LARGE2"}},
-    }
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"SingleSmallKey", []string{"SMALL1"}},
+		{"TwoSmallKeys", []string{"SMALL1", "SMALL2"}},
+		{"SingleMediumKey", []string{"MEDIUM1"}},
+		{"TwoMediumKeys", []string{"MEDIUM1", "MEDIUM2"}},
+		{"SingleLargeKey", []string{"LARGE1"}},
+		{"TwoLargeKeys", []string{"LARGE1", "LARGE2"}},
+		{"MixedSizes", []string{"SMALL1", "MEDIUM1", "LARGE1"}},
+		{"ManySmallKeys", []string{"SMALL1", "SMALL2", "SMALL1", "SMALL2", "SMALL1"}},
+		{"ManyMediumKeys", []string{"MEDIUM1", "MEDIUM2", "MEDIUM1", "MEDIUM2", "MEDIUM1"}},
+		{"ManyLargeKeys", []string{"LARGE1", "LARGE2", "LARGE1", "LARGE2", "LARGE1"}},
+		{"NonExistentKey", []string{"SMALL1", "NONEXISTENT", "LARGE1"}},
+		{"AllKeys", []string{"SMALL1", "SMALL2", "MEDIUM1", "MEDIUM2", "LARGE1", "LARGE2"}},
+	}
 
-    b.ResetTimer()
+	b.ResetTimer()
 
-    for _, tt := range tests {
-        b.Run(tt.name, func(b *testing.B) {
-            for i := 0; i < b.N; i++ {
-                evalPFCOUNT(tt.args, &store)
-            }
-        })
-    }
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				evalPFCOUNT(tt.args, &store)
+			}
+		})
+	}
 }
 
 func testEvalDebug(t *testing.T, store *dstore.Store) {

--- a/testutils/json.go
+++ b/testutils/json.go
@@ -13,12 +13,6 @@ func IsJSONResponse(s string) bool {
 	return (s != utils.EmptyStr && (sonic.ValidString(s)))
 }
 
-func AssertJSONEqual(t *testing.T, expected, actual string) {
-	if !compareJSONs(t, expected, actual) {
-		t.Errorf("JSON not equal.\nExpected: %s\nActual: %s", expected, actual)
-	}
-}
-
 func AssertJSONEqualList(t *testing.T, expected []string, actual string) {
 	res := false
 	for _, exp := range expected {


### PR DESCRIPTION
- Using `JSONEq` from [testify](https://pkg.go.dev/github.com/stretchr/testify/require#JSONEq) package for json comparisons. This would handle the ordering issues we're facing. For e.g. current test cases fails for scenarios like below where ordering of elements is changed.

`{"a":"b","b":[{"a":2.2},{"a":5},{"a":"c"}]} (out string) != {"b":[{"a":2.2},{"a":5},{"a":"c"}],"a":"b"} (result string)`

- One of the flaky builds log [here](https://productionresultssa18.blob.core.windows.net/actions-results/89060d43-0fce-4c1c-b438-727f7c4c1b7f/workflow-job-run-ca395085-040a-526b-2ce8-bdc85f692774/logs/job/job-logs.txt?rsct=text/plain&se=2024-09-17T14:27:48Z&sig=GAlQsKMGUqV2/2Vb6SQbzLwjU/eCNhNruoRZZzQ/gJM%3D&ske=2024-09-18T01:37:18Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-09-17T13:37:18Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-05-04&sp=r&spr=https&sr=b&st=2024-09-17T14:17:43Z&sv=2024-05-04)