### PR TITLE
#571: Feature `TYPE` command added.

### DIFF
--- a/integration_tests/commands/type_test.go
+++ b/integration_tests/commands/type_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"testing"
+
+	dstore "github.com/dicedb/dice/internal/store"
+	"gotest.tools/v3/assert"
+)
+
+func TestType(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []struct {
+		name     string
+		commands []string
+		expected []interface{}
+		setup    func(store *dstore.Store)
+	}{
+		{
+			name:     "TYPE for non-existent key",
+			commands: []string{"TYPE k1"},
+			expected: []interface{}{"none"},
+		},
+		{
+			name:     "TYPE for key with String value",
+			commands: []string{"SET k1 v1", "TYPE k1"},
+			expected: []interface{}{"OK", "string"},
+		},
+		{
+			name:     "TYPE for key with List value",
+			commands: []string{"LPUSH k1 v1", "TYPE k1"},
+			expected: []interface{}{"OK", "list"},
+		},
+		{
+			name:     "TYPE for key with Set value",
+			commands: []string{"SADD k1 v1", "TYPE k1"},
+			expected: []interface{}{int64(1), "set"},
+		},
+		{
+			name:     "TYPE for key with Hash value",
+			commands: []string{"HSET k1 field1 v1", "TYPE k1"},
+			expected: []interface{}{int64(1), "hash"},
+		},
+		// TODO: Adding the support of command ZADD and XADD to run the integration test for ZSet and Stream.
+		/*
+			{
+				name:     "TYPE for key with ZSet value",
+				commands: []string{"ZADD k1 1 v1", "TYPE k1"},
+				expected: []interface{}{int64(1), "zset"},
+			},
+			{
+				name:     "TYPE for key with Stream value",
+				commands: []string{"XADD k1 * field1 v1", "TYPE k1"},
+				expected: []interface{}{"OK", "stream"},
+			},
+		*/
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			FireCommand(conn, "DEL k1")
+
+			for i, cmd := range tc.commands {
+				result := FireCommand(conn, cmd)
+				assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -728,6 +728,13 @@ var (
 		Arity:    3,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	typeCmdMeta = DiceCmdMeta{
+		Name:     "TYPE",
+		Info:     `Returns the string representation of the type of the value stored at key. The different types that can be returned are: string, list, set, zset, hash and stream.`,
+		Eval:     evalTYPE,
+		Arity:    1,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 )
 
 func init() {
@@ -814,6 +821,7 @@ func init() {
 	DiceCmds["HLEN"] = hlenCmdMeta
 	DiceCmds["SELECT"] = selectCmdMeta
 	DiceCmds["JSON.NUMINCRBY"] = jsonnumincrbyCmdMeta
+	DiceCmds["TYPE"] = typeCmdMeta
 }
 
 // Function to convert DiceCmdMeta to []interface{}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -37,6 +37,7 @@ type exDurationState int
 const (
 	Uninitialized exDurationState = iota
 	Initialized
+	ObjTypeMask = 0b11110000
 )
 
 var (
@@ -3302,4 +3303,35 @@ func evalJSONNUMINCRBY(args []string, store *dstore.Store) []byte {
 
 	obj.Value = jsonData
 	return clientio.Encode(resultString, false)
+}
+
+func evalTYPE(args []string, store *dstore.Store) []byte {
+	if len(args) != 1 {
+		return diceerrors.NewErrArity("TYPE")
+	}
+	key := args[0]
+	obj := store.Get(key)
+	if obj == nil {
+		return clientio.Encode("none", false)
+	}
+
+	var typeStr string
+	switch obj.TypeEncoding & ObjTypeMask {
+	case object.ObjTypeString:
+		typeStr = "string"
+	case object.ObjTypeByteList:
+		typeStr = "list"
+	case object.ObjTypeSet:
+		typeStr = "set"
+	case object.ObjTypeHashMap:
+		typeStr = "hash"
+	case object.ObjTypeZSet:
+		typeStr = "zset"
+	case object.ObjTypeStream:
+		typeStr = "stream"
+	default:
+		typeStr = "none"
+	}
+
+	return clientio.Encode(typeStr, false)
 }

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -38,6 +38,10 @@ var ObjEncodingSetStr uint8 = 12
 var ObjEncodingHashMap uint8 = 6
 var ObjTypeHashMap uint8 = 7 << 4
 
+var ObjTypeZSet uint8 = 8 << 4
+
+var ObjTypeStream uint8 = 9 << 4
+
 func ExtractTypeEncoding(obj *Obj) (e1, e2 uint8) {
 	return obj.TypeEncoding & 0b11110000, obj.TypeEncoding & 0b00001111
 }


### PR DESCRIPTION
Description

This PR include the new command called TYPE(https://redis.io/docs/latest/commands/type/)

Implementation for TYPE command. 
Added unit tests
Added Integration tests
Add Benchmark

Two new commands need to add in DiceDB for supporting all the types. 
1. XADD (https://redis.io/docs/latest/commands/xadd/)
2. ZADD (https://redis.io/docs/latest/commands/zadd/)
