### PR TITLE
Fix flaky JSON tests

### DIFF
--- a/integration_tests/commands/json_test.go
+++ b/integration_tests/commands/json_test.go
@@ -890,7 +890,7 @@ func TestJSONNumIncrBy(t *testing.T) {
 			setupData:   fmt.Sprintf("JSON.SET %s $ %s", "foo", `{"a":"b","b":[{"a":2.2},{"a":5},{"a":"c"}]}`),
 			commands:    []string{"JSON.NUMINCRBY foo $..a 2", "JSON.NUMINCRBY foo $.a 2", "JSON.GET foo", "JSON.NUMINCRBY foo $..a -2", "JSON.GET foo"},
 			expected:    []interface{}{"[null,4.2,7,null]", "[null]", "{\"a\":\"b\",\"b\":[{\"a\":4.2},{\"a\":7},{\"a\":\"c\"}]}", "[null,2.2,5,null]", "{\"a\":\"b\",\"b\":[{\"a\":2.2},{\"a\":5},{\"a\":\"c\"}]}"},
-			assert_type: []string{"perm_equal", "perm_equal", "equal", "perm_equal", "equal"},
+			assert_type: []string{"perm_equal", "perm_equal", "json_equal", "perm_equal", "json_equal"},
 			cleanUp:     []string{"DEL foo"},
 		},
 		{
@@ -921,12 +921,15 @@ func TestJSONNumIncrBy(t *testing.T) {
 				cmd := tc.commands[i]
 				out := tc.expected[i]
 				result := FireCommand(conn, cmd)
-				if tc.assert_type[i] == "equal" {
+				switch tc.assert_type[i] {
+				case "equal":
 					assert.Equal(t, out, result)
-				} else if tc.assert_type[i] == "perm_equal" {
+				case "perm_equal":
 					assert.Assert(t, arraysArePermutations(convertToArray(out.(string)), convertToArray(result.(string))))
-				} else if tc.assert_type[i] == "range" {
+				case "range":
 					assert.Assert(t, result.(int64) <= tc.expected[i].(int64) && result.(int64) > 0, "Expected %v to be within 0 to %v", result, tc.expected[i])
+				case "json_equal":
+					testutils.AssertJSONEqual(t, out.(string), result.(string))
 				}
 			}
 			for i := 0; i < len(tc.cleanUp); i++ {

--- a/integration_tests/commands/toggle_test.go
+++ b/integration_tests/commands/toggle_test.go
@@ -46,8 +46,8 @@ func TestJSONToggle(t *testing.T) {
 		},
 		{
 			name:     "JSON.TOGGLE with invalid path",
-			commands: []string{`JSON.SET testkey $ ` + simpleJSON, "JSON.TOGGLE user $.invalidPath"},
-			expected: []interface{}{"OK", "ERR could not perform this operation on a key that doesn't exist"},
+			commands: []string{"JSON.TOGGLE user $.invalidPath"},
+			expected: []interface{}{"ERR could not perform this operation on a key that doesn't exist"},
 		},
 		{
 			name:     "JSON.TOGGLE with invalid command format",

--- a/integration_tests/commands/toggle_test.go
+++ b/integration_tests/commands/toggle_test.go
@@ -22,7 +22,7 @@ func compareJSON(t *testing.T, expected, actual string) {
 	assert.DeepEqual(t, expectedMap, actualMap)
 }
 
-func TestEvalJSONTOGGLE(t *testing.T) {
+func TestJSONToggle(t *testing.T) {
 	conn := getLocalConnection()
 	defer conn.Close()
 
@@ -47,7 +47,7 @@ func TestEvalJSONTOGGLE(t *testing.T) {
 		{
 			name:     "JSON.TOGGLE with invalid path",
 			commands: []string{`JSON.SET testkey $ ` + simpleJSON, "JSON.TOGGLE user $.invalidPath"},
-			expected: []interface{}{"WRONGTYPE Operation against a key holding the wrong kind of value", "ERR could not perform this operation on a key that doesn't exist"},
+			expected: []interface{}{"OK", "ERR could not perform this operation on a key that doesn't exist"},
 		},
 		{
 			name:     "JSON.TOGGLE with invalid command format",
@@ -72,29 +72,28 @@ func TestEvalJSONTOGGLE(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-        t.Run(tc.name, func(t *testing.T) {
-            FireCommand(conn, "DEL user")
-            for i, cmd := range tc.commands {
-                result := FireCommand(conn, cmd)
-                switch expected := tc.expected[i].(type) {
-                case string:
-                    if isJSONString(expected) {
-                        compareJSON(t, expected, result.(string))
-                    } else {
-                        assert.Equal(t, expected, result)
-                    }
-                case []interface{}:
-                    assert.Assert(t, testutils.UnorderedEqual(expected, result))
-                default:
-                    assert.DeepEqual(t, expected, result)
-                }
-            }
-        })
-    }
+		t.Run(tc.name, func(t *testing.T) {
+			FireCommand(conn, "DEL user")
+			for i, cmd := range tc.commands {
+				result := FireCommand(conn, cmd)
+				switch expected := tc.expected[i].(type) {
+				case string:
+					if isJSONString(expected) {
+						compareJSON(t, expected, result.(string))
+					} else {
+						assert.Equal(t, expected, result)
+					}
+				case []interface{}:
+					assert.Assert(t, testutils.UnorderedEqual(expected, result))
+				default:
+					assert.DeepEqual(t, expected, result)
+				}
+			}
+		})
+	}
 }
 
 func isJSONString(s string) bool {
-    var js json.RawMessage
-    return json.Unmarshal([]byte(s), &js) == nil
+	var js json.RawMessage
+	return json.Unmarshal([]byte(s), &js) == nil
 }
-


### PR DESCRIPTION
We should be comparing unmarshalled JSON strings instead of just the string representations.