### PR TITLE
Add darwin arm64 compatibility

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -103,7 +103,7 @@ var defaultConfig = Config{
 		KeysLimit:              10000,
 		AOFFile:                "./dice-master.aof",
 		PersistenceEnabled:     true,
-		WriteAOFOnCleanup:      false,
+		WriteAOFOnCleanup:      true,
 		LFULogFactor:           10,
 	},
 	Auth: struct {

--- a/examples/leaderboard-go/docker-compose.yaml
+++ b/examples/leaderboard-go/docker-compose.yaml
@@ -1,7 +1,6 @@
 services:
   dicedb:
     image: dicedb/dicedb:0.0.2
-    platform: linux/amd64
     ports:
       - "7379:7379"
 

--- a/integration_tests/commands/setup.go
+++ b/integration_tests/commands/setup.go
@@ -94,7 +94,7 @@ func fireCommandAndGetRESPParser(conn net.Conn, cmd string) *clientio.RESPParser
 
 func RunTestServer(ctx context.Context, wg *sync.WaitGroup, opt TestServerOptions) {
 	config.DiceConfig.Network.IOBufferLength = 16
-	config.DiceConfig.Server.WriteAOFOnCleanup = true
+	config.DiceConfig.Server.WriteAOFOnCleanup = false
 	if opt.Port != 0 {
 		config.DiceConfig.Server.Port = opt.Port
 	} else {

--- a/internal/eval/eval_darwin_arm64.go
+++ b/internal/eval/eval_darwin_arm64.go
@@ -1,14 +1,12 @@
-//go:build arm64
+//go:build darwin && arm64
 
 package eval
 
 import (
-	"syscall"
-
 	"github.com/dicedb/dice/internal/clientio"
 	diceerrors "github.com/dicedb/dice/internal/errors"
-	"github.com/dicedb/dice/internal/server/utils"
 	dstore "github.com/dicedb/dice/internal/store"
+	"syscall"
 )
 
 /* Description - Spawn a background thread to persist the data via AOF technique. Current implementation is
@@ -21,15 +19,19 @@ func EvalBGREWRITEAOF(args []string, store *dstore.Store) []byte {
 	// This technique utilizes the CoW or copy-on-write, so while the main process is free to modify them
 	// the child would save all the pages to disk.
 	// Check details here -https://www.sobyte.net/post/2022-10/fork-cow/
-	childThreadID, _, _ := syscall.Syscall(syscall.SYS_GETTID, 0, 0, 0)
-	newChild, _, _ := syscall.Syscall(syscall.SYS_CLONE, syscall.CLONE_PARENT_SETTID|syscall.CLONE_CHILD_CLEARTID|uintptr(syscall.SIGCHLD), 0, childThreadID)
-	if newChild == 0 {
+	pid, _, _ := syscall.RawSyscall(syscall.SYS_FORK, 0, 0, 0)
+
+	if pid == 0 {
 		// We are inside child process now, so we'll start flushing to disk.
 		if err := dstore.DumpAllAOF(store); err != nil {
 			return diceerrors.NewErrWithMessage("AOF failed")
 		}
-		return []byte(utils.EmptyStr)
+		syscall.Exit(0)
+	} else if pid < 0 {
+		// Fork failed
+		return diceerrors.NewErrWithMessage("Fork failed")
 	}
-	// Back to main threadg
+
+	// Back to main thread
 	return clientio.RespOK
 }

--- a/internal/eval/eval_linux_arm64.go
+++ b/internal/eval/eval_linux_arm64.go
@@ -1,0 +1,35 @@
+//go:build linux && arm64
+
+package eval
+
+import (
+	"syscall"
+
+	"github.com/dicedb/dice/internal/clientio"
+	diceerrors "github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/server/utils"
+	dstore "github.com/dicedb/dice/internal/store"
+)
+
+/* Description - Spawn a background thread to persist the data via AOF technique. Current implementation is
+based on CoW optimization and Fork */
+// TODO: Implement Acknowledgement so that main process could know whether child has finished writing to its AOF file or not.
+// TODO: Make it safe from failure, an stable policy would be to write the new flushes to a temporary files and then rename them to the main process's AOF file
+// TODO: Add fsync() and fdatasync() to persist to AOF for above cases.
+func EvalBGREWRITEAOF(args []string, store *dstore.Store) []byte {
+	// Fork a child process, this child process would inherit all the uncommitted pages from main process.
+	// This technique utilizes the CoW or copy-on-write, so while the main process is free to modify them
+	// the child would save all the pages to disk.
+	// Check details here -https://www.sobyte.net/post/2022-10/fork-cow/
+	childThreadID, _, _ := syscall.Syscall(syscall.SYS_GETTID, 0, 0, 0)
+	newChild, _, _ := syscall.Syscall(syscall.SYS_CLONE, syscall.CLONE_PARENT_SETTID|syscall.CLONE_CHILD_CLEARTID|uintptr(syscall.SIGCHLD), 0, childThreadID)
+	if newChild == 0 {
+		// We are inside child process now, so we'll start flushing to disk.
+		if err := dstore.DumpAllAOF(store); err != nil {
+			return diceerrors.NewErrWithMessage("AOF failed")
+		}
+		return []byte(utils.EmptyStr)
+	}
+	// Back to main threadg
+	return clientio.RespOK
+}

--- a/internal/shard/shard_thread.go
+++ b/internal/shard/shard_thread.go
@@ -134,11 +134,8 @@ func (shard *ShardThread) executeCommand(op *ops.StoreOp) []byte {
 // cleanup handles cleanup logic when the shard stops.
 func (shard *ShardThread) cleanup() {
 	close(shard.ReqChan)
-	if config.DiceConfig.Server.WriteAOFOnCleanup {
-		// Avoiding AOF dump for test enabled environments as
-		// the tests were taking longer due to background tasks which exceeded the WaitDelay,
-		// thus causing the test process to be forcibly terminated.
-		log.Info("Skipping AOF dump as test env enabled.")
+	if !config.DiceConfig.Server.WriteAOFOnCleanup {
+		log.Debug("Skipping AOF dump.")
 		return
 	}
 


### PR DESCRIPTION
## Key Changes

1. **AOF Persistence Configuration**
   - Changed default `WriteAOFOnCleanup` to `true` in `config/config.go`
   - Updated `integration_tests/commands/setup.go` to set `WriteAOFOnCleanup` to `false` for tests
   - Modified cleanup logic in `shard_thread.go` to respect the `WriteAOFOnCleanup` configuration

2. **Architecture Support**
   - Added support for Darwin ARM64 architecture with `eval_darwin_arm64.go`
   - Renamed `eval_arm64.go` to `eval_linux_arm64.go` for clarity

3. **Docker Compose Update**
   - Removed platform specification for AMD64 in `examples/leaderboard-go/docker-compose.yaml`