### PR TITLE
feat: add support for command [JSON.ARRINSERT]

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -223,6 +223,17 @@ var (
 		Arity:    -3,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	jsonarrinsertCmdMeta = DiceCmdMeta{
+		Name: "JSON.ARRINSERT",
+		Info: `JSON.ARRINSERT key path index value [value ...]
+		Returns an array of integer replies for each path.
+		Returns nil if the matching JSON value is not an array.
+		Returns error response if the key doesn't exist or key is expired or the matching value is not an array.
+		Error reply: If the number of arguments is incorrect.`,
+		Eval:     evalJSONARRINSERT,
+		Arity:    -5,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
 		Info: `TTL returns Time-to-Live in secs for the queried key in args
@@ -782,6 +793,7 @@ func init() {
 	DiceCmds["JSON.DEBUG"] = jsondebugCmdMeta
 	DiceCmds["JSON.ARRPOP"] = jsonarrpopCmdMeta
 	DiceCmds["JSON.INGEST"] = jsoningestCmdMeta
+	DiceCmds["JSON.ARRINSERT"] = jsonarrinsertCmdMeta
 	DiceCmds["TTL"] = ttlCmdMeta
 	DiceCmds["DEL"] = delCmdMeta
 	DiceCmds["EXPIRE"] = expireCmdMeta

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -372,6 +372,99 @@ func evalGETDEL(args []string, store *dstore.Store) []byte {
 	}
 }
 
+// evalJSONARRINSERT insert the json values into the array at path before the index (shifts to the right)
+// returns an array of integer replies for each path, the array's new size, or nil,
+func evalJSONARRINSERT(args []string, store *dstore.Store) []byte {
+	if len(args) < 4 {
+		return diceerrors.NewErrArity("JSON.ARRINSERT")
+	}
+	key := args[0]
+	obj := store.Get(key)
+	if obj == nil {
+		return diceerrors.NewErrWithMessage("could not perform this operation on a key that doesn't exist")
+	}
+
+	errWithMessage := object.AssertTypeAndEncoding(obj.TypeEncoding, object.ObjTypeJSON, object.ObjEncodingJSON)
+	if errWithMessage != nil {
+		return errWithMessage
+	}
+
+	jsonData := obj.Value
+	var err error
+	_, err = sonic.Marshal(jsonData)
+	if err != nil {
+		return diceerrors.NewErrWithMessage("Existing key has wrong Dice type")
+	}
+
+	path := args[1]
+	expr, err := jp.ParseString(path)
+	if err != nil {
+		return diceerrors.NewErrWithMessage("invalid JSONPath")
+	}
+
+	results := expr.Get(jsonData)
+	if len(results) == 0 {
+		return clientio.RespEmptyArray
+	}
+	index := args[2]
+	var idx int
+	idx, err = strconv.Atoi(index)
+	if err != nil {
+		return diceerrors.NewErrWithMessage("Couldn't parse as integer")
+	}
+
+	values := args[3:]
+	// Parse the input values as JSON
+	parsedValues := make([]interface{}, len(values))
+	for i, v := range values {
+		var parsedValue interface{}
+		err := sonic.UnmarshalString(v, &parsedValue)
+		if err != nil {
+			return diceerrors.NewErrWithMessage(err.Error())
+		}
+		parsedValues[i] = parsedValue
+	}
+
+	var resultsArray []interface{}
+	// Capture the modified data when modifying the root path
+	modified := false
+	newData, modifyErr := expr.Modify(jsonData, func(data any) (interface{}, bool) {
+		arr, ok := data.([]interface{})
+		if !ok {
+			// Not an array
+			resultsArray = append(resultsArray, nil)
+			return data, false
+		}
+
+		// Append the parsed values to the array
+		updatedArray, insertErr := insertElementAndUpdateArray(arr, idx, parsedValues)
+		if insertErr != nil {
+			err = insertErr
+			return data, false
+		}
+		modified = true
+		resultsArray = append(resultsArray, len(updatedArray))
+		return updatedArray, true
+	})
+	if err != nil {
+		return diceerrors.NewErrWithMessage(err.Error())
+	}
+
+	if modifyErr != nil {
+		return diceerrors.NewErrWithMessage(fmt.Sprintf("ERR failed to modify JSON data: %v", modifyErr))
+	}
+
+	if !modified {
+		return clientio.Encode(resultsArray, false)
+	}
+
+	jsonData = newData
+	obj.Value = jsonData
+
+	return clientio.Encode(resultsArray, false)
+
+}
+
 // evalJSONDEBUG reports value's memmory usage in bytes
 // Returns arity error if subcommand is missing
 // Supports only two subcommand as of now - HELP and MEMORY
@@ -686,6 +779,24 @@ func evalJSONARRPOP(args []string, store *dstore.Store) []byte {
 	return clientio.Encode(popArr, false)
 }
 
+// insertElementAndUpdateArray add an element at the given index
+// Returns remaining array and error
+func insertElementAndUpdateArray(arr []any, index int, elements []interface{}) (updatedArray []any, err error) {
+	length := len(arr)
+	var idx int
+	if index >= -length && index <= length {
+		idx = adjustIndex(index, arr)
+	} else {
+		return nil, errors.New("index out of bounds")
+	}
+
+	before := arr[:idx]
+	after := arr[idx:]
+	updatedArray = append(before, append(elements, after...)...)
+
+	return updatedArray, nil
+}
+
 // popElementAndUpdateArray removes an element at the given index
 // Returns popped element, remaining array and error
 func popElementAndUpdateArray(arr []any, index string) (popElem any, updatedArray []any, err error) {
@@ -908,7 +1019,7 @@ func evalJSONCLEAR(args []string, store *dstore.Store) []byte {
 		return diceerrors.NewErrWithMessage("invalid JSONPath")
 	}
 
-	_, err = expr.Modify(jsonData, func(element any) (altered any, changed bool) {
+	newData, err := expr.Modify(jsonData, func(element any) (altered any, changed bool) {
 		switch utils.GetJSONFieldType(element) {
 		case utils.IntegerType, utils.NumberType:
 			if element != utils.NumberZeroValue {
@@ -933,9 +1044,9 @@ func evalJSONCLEAR(args []string, store *dstore.Store) []byte {
 	if err != nil {
 		return diceerrors.NewErrWithMessage(err.Error())
 	}
-	// Create a new object with the updated JSON data
-	newObj := store.NewObj(jsonData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
-	store.Put(key, newObj)
+
+	jsonData = newData
+	obj.Value = jsonData
 	return clientio.Encode(countClear, false)
 }
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -44,6 +44,7 @@ func TestEval(t *testing.T) {
 	testEvalSET(t, store)
 	testEvalGET(t, store)
 	testEvalDebug(t, store)
+	testEvalJSONARRINSERT(t, store)
 	testEvalJSONARRPOP(t, store)
 	testEvalJSONARRLEN(t, store)
 	testEvalJSONDEL(t, store)
@@ -400,6 +401,113 @@ func testEvalEXPIREAT(t *testing.T, store *dstore.Store) {
 	}
 
 	runEvalTests(t, tests, evalEXPIREAT, store)
+}
+
+func testEvalJSONARRINSERT(t *testing.T, store *dstore.Store) {
+	tests := map[string]evalTestCase{
+		"nil value": {
+			setup:  func() {},
+			input:  nil,
+			output: []byte("-ERR wrong number of arguments for 'json.arrinsert' command\r\n"),
+		},
+		"key does not exist": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":2}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"NONEXISTENT_KEY", "$.a", "0", "1"},
+			output: []byte("-ERR could not perform this operation on a key that doesn't exist\r\n"),
+		},
+		"index is not integer": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":2}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.a", "a", "1"},
+			output: []byte("-ERR Couldn't parse as integer\r\n"),
+		},
+		"index out of bounds": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "[1,2,3]"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$", "4", "\"a\"", "1"},
+			output: []byte("-ERR index out of bounds\r\n"),
+		},
+		"root path is not array": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":2}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.a", "0", "6"},
+			output: []byte("*1\r\n$-1\r\n"),
+		},
+		"root path is array": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "[1,2]"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$", "0", "6", "\"a\"", "3.14"},
+			output: []byte("*1\r\n:5\r\n"),
+		},
+		"subpath array insert positive index": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"connection\":{\"wireless\":true,\"names\":[\"1\",\"2\"]},\"price\":99.98,\"names\":[3,4]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$..names", "2", "7", "8"},
+			output: []byte("*2\r\n:4\r\n:4\r\n"),
+		},
+		"subpath array insert negative index": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"connection\":{\"wireless\":true,\"names\":[\"1\",\"2\"]},\"price\":99.98,\"names\":[3,4]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$..names", "-1", "7", "8"},
+			output: []byte("*2\r\n:4\r\n:4\r\n"),
+		},
+		"array insert with multitype value": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":[1,2,3]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.a", "0", "1", "null", "3.14", "true", "{\"a\":123}"},
+			output: []byte("*1\r\n:8\r\n"),
+		},
+	}
+	runEvalTests(t, tests, evalJSONARRINSERT, store)
 }
 
 func testEvalJSONARRLEN(t *testing.T, store *dstore.Store) {


### PR DESCRIPTION
hello:
this pr is link issue: #487 

1.feature: add support for command **[JSON.ARRINSERT]** including integration test. refer to redis [**JSON.ARRINSERT**:](https://redis.io/docs/latest/commands/json.arrinsert/)
2.modify the **JSON.CLEAR**.

In redis. the **JSON.ARRINSERT** act as below:
`

      127.0.0.1:6379> JSON.SET user $ '[1,2,3,4,5]'
      OK
      127.0.0.1:6379> JSON.ARRINSERT user3 $ 0 1
      (error) Existing key has wrong Redis type
      127.0.0.1:6379> JSON.SET user $ '[1,2,3,4,5]'
      OK
      127.0.0.1:6379> JSON.ARRINSERT user5 $ 0 1
      (error) ERR could not perform this operation on a key that doesn't exist
      127.0.0.1:6379> JSON.ARRINSERT user $ 1 9
      1) (integer) 6
      127.0.0.1:6379> JSON.ARRINSERT user $ -1 '"a"'
      1) (integer) 7
      127.0.0.1:6379> JSON.GET user
      "[1,9,2,3,4,\"a\",5]"
      127.0.0.1:6379> JSON.SET user $ '{"connection":{"wireless":true,"names":["1","2"]},"price":99.98,"names":[3,4]}'
      OK
      127.0.0.1:6379> JSON.ARRINSERT user $..names 2 '"a"' 2 true null 3.14
      1) (integer) 7
      2) (integer) 7
      127.0.0.1:6379> JSON.GET user
      "{\"connection\":{\"wireless\":true,\"names\":[\"1\",\"2\",\"a\",2,true,null,3.14]},\"price\":99.98,\"names\":[3,4,\"a\",2,true,null,3.14]}"
      127.0.0.1:6379> JSON.ARRINSERT user $..names 2 '"a"' 2 true null 3.14
      127.0.0.1:6379> JSON.SET user $ '{"connection":{"wireless":true,"names":["1","2"]},"price":99.98,"names":"a"}'
      OK
      127.0.0.1:6379> JSON.ARRINSERT user $..names 2 '"a"' 2 true null 3.14
      1) (nil)
      2) (integer) 7
      127.0.0.1:6379> JSON.GET user
      "{\"connection\":{\"wireless\":true,\"names\":[\"1\",\"2\",\"a\",2,true,null,3.14]},\"price\":99.98,\"names\":\"a\"}"


`

when using JSONPath. this command use array to warp the return result. maintain the same return style.