### PR TITLE
#622: Add ECHO command

### DIFF
--- a/integration_tests/commands/echo_test.go
+++ b/integration_tests/commands/echo_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestEcho(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []struct {
+		name     string
+		commands []string
+		expected []interface{}
+	}{
+		{
+			name:     "ECHO with invalid number of arguments",
+			commands: []string{"ECHO"},
+			expected: []interface{}{"ERR wrong number of arguments for 'echo' command"},
+		},
+		{
+			name:     "ECHO with one argument",
+			commands: []string{"ECHO \"hello world\""},
+			expected: []interface{}{"hello world"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result := FireCommand(conn, cmd)
+				assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -30,7 +30,6 @@ var (
 		Info:     `ECHO returns the string given as argument.`,
 		Eval:     evalECHO,
 		Arity:    1,
-		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
 	authCmdMeta = DiceCmdMeta{
 		Name: "AUTH",

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -25,6 +25,13 @@ var (
 		Eval:  evalPING,
 		Arity: -1,
 	}
+	echoCmdMeta = DiceCmdMeta{
+		Name:     "ECHO",
+		Info:     `ECHO returns the string given as argument.`,
+		Eval:     evalECHO,
+		Arity:    1,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	authCmdMeta = DiceCmdMeta{
 		Name: "AUTH",
 		Info: `AUTH returns with an encoded "OK" if the user is authenticated.
@@ -772,6 +779,7 @@ var (
 
 func init() {
 	DiceCmds["PING"] = pingCmdMeta
+	DiceCmds["ECHO"] = echoCmdMeta
 	DiceCmds["AUTH"] = authCmdMeta
 	DiceCmds["SET"] = setCmdMeta
 	DiceCmds["GET"] = getCmdMeta

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -72,6 +72,16 @@ func evalPING(args []string, store *dstore.Store) []byte {
 	return b
 }
 
+func evalECHO(args []string, store *dstore.Store) []byte {
+
+	if len(args) != 1 {
+		return diceerrors.NewErrArity("ECHO")
+	}
+
+	b := clientio.Encode(args[0], false)
+	return b
+}
+
 // EvalAUTH returns with an encoded "OK" if the user is authenticated
 // If the user is not authenticated, it returns with an encoded error message
 func EvalAUTH(args []string, c *comm.Client) []byte {

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -72,8 +72,8 @@ func evalPING(args []string, store *dstore.Store) []byte {
 	return b
 }
 
+// evalECHO returns the argument passed by the user 
 func evalECHO(args []string, store *dstore.Store) []byte {
-
 	if len(args) != 1 {
 		return diceerrors.NewErrArity("ECHO")
 	}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -78,8 +78,7 @@ func evalECHO(args []string, store *dstore.Store) []byte {
 		return diceerrors.NewErrArity("ECHO")
 	}
 
-	b := clientio.Encode(args[0], false)
-	return b
+	return clientio.Encode(args[0], false)
 }
 
 // EvalAUTH returns with an encoded "OK" if the user is authenticated

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -41,6 +41,7 @@ func TestEval(t *testing.T) {
 
 	testEvalMSET(t, store)
 	testEvalPING(t, store)
+	testEvalECHO(t, store)
 	testEvalHELLO(t, store)
 	testEvalSET(t, store)
 	testEvalGET(t, store)
@@ -88,6 +89,17 @@ func testEvalPING(t *testing.T, store *dstore.Store) {
 	}
 
 	runEvalTests(t, tests, evalPING, store)
+}
+
+func testEvalECHO(t *testing.T, store *dstore.Store) {
+	tests := map[string]evalTestCase{
+		"nil value":            {input: nil, output: []byte("-ERR wrong number of arguments for 'echo' command\r\n")},
+		"empty args":           {input: []string{}, output: []byte("-ERR wrong number of arguments for 'echo' command\r\n")},
+		"one value":            {input: []string{"HEY"}, output: []byte("$3\r\nHEY\r\n")},
+		"more than one values": {input: []string{"HEY", "HELLO"}, output: []byte("-ERR wrong number of arguments for 'echo' command\r\n")},
+	}
+
+	runEvalTests(t, tests, evalECHO, store)
 }
 
 func testEvalHELLO(t *testing.T, store *dstore.Store) {


### PR DESCRIPTION
Resolves #622 : Add support for ECHO command.

## Description
- This  PR adds support for [ECHO](https://redis.io/docs/latest/commands/echo/) command to DiceDB.
- Added unit tests (internal/eval/eval_test.go)  
- Added integration tests (integration_tests/commands/echo_test.go)  

## Screenshots
![image](https://github.com/user-attachments/assets/4a3c231e-2434-434b-a649-f6ff38ba0fad)
