### PR TITLE
#613: Use latest dicedb tag instead of 0.0.2 in docker-compose.yaml file.

### DIFF
--- a/examples/leaderboard-go/docker-compose.yaml
+++ b/examples/leaderboard-go/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   dicedb:
-    image: dicedb/dicedb:0.0.2
+    image: dicedb/dicedb:latest
     ports:
       - "7379:7379"
 
@@ -11,7 +11,7 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-        - dicedb
+      - dicedb
     environment:
       - DICEDB_HOST=dicedb
       - DICEDB_PORT=7379


### PR DESCRIPTION
Fixes: #613 

1. Updates the image to `latest` from `0.0.2` in `docker-compose.yaml` file in `examples/leaderboard-go`. 