### PR TITLE
#635: List Command Subcommands as separate commands

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -8,6 +8,7 @@ type DiceCmdMeta struct {
 	Eval  func([]string, *dstore.Store) []byte
 	Arity int // number of arguments, it is possible to use -N to say >= N
 	KeySpecs
+	SubCommands []string // list of sub-commands supported by the commmand
 
 	// IsMigrated indicates whether a command has been migrated to a new evaluation
 	// mechanism. If true, the command uses the newer evaluation logic represented by
@@ -34,7 +35,6 @@ type KeySpecs struct {
 
 var (
 	DiceCmds = map[string]DiceCmdMeta{}
-	CommandSubCommands []string
 
 	echoCmdMeta = DiceCmdMeta{
 		Name:  "ECHO",
@@ -476,10 +476,11 @@ var (
 		Eval: evalBITOP,
 	}
 	commandCmdMeta = DiceCmdMeta{
-		Name:  "COMMAND <subcommand>",
-		Info:  "Evaluates COMMAND <subcommand> command based on subcommand",
-		Eval:  evalCommand,
-		Arity: -1,
+		Name:        "COMMAND <subcommand>",
+		Info:        "Evaluates COMMAND <subcommand> command based on subcommand",
+		Eval:        evalCommand,
+		Arity:       -1,
+		SubCommands: []string{Count, GetKeys, List, Help, Info},
 	}
 	keysCmdMeta = DiceCmdMeta{
 		Name: "KEYS",
@@ -941,8 +942,6 @@ func init() {
 	DiceCmds["TYPE"] = typeCmdMeta
 	DiceCmds["GETRANGE"] = getRangeCmdMeta
 	DiceCmds["SETEX"] = setexCmdMeta
-
-	CommandSubCommands = []string{Count, GetKeys, List, Help}
 }
 
 // Function to convert DiceCmdMeta to []interface{}

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -34,6 +34,7 @@ type KeySpecs struct {
 
 var (
 	DiceCmds = map[string]DiceCmdMeta{}
+	CommandSubCommands []string
 
 	echoCmdMeta = DiceCmdMeta{
 		Name:  "ECHO",
@@ -940,6 +941,8 @@ func init() {
 	DiceCmds["TYPE"] = typeCmdMeta
 	DiceCmds["GETRANGE"] = getRangeCmdMeta
 	DiceCmds["SETEX"] = setexCmdMeta
+
+	CommandSubCommands = []string{Count, GetKeys, List, Help}
 }
 
 // Function to convert DiceCmdMeta to []interface{}

--- a/internal/eval/constants.go
+++ b/internal/eval/constants.go
@@ -32,5 +32,4 @@ const (
 	Null    string = "null"
 	null    string = "null"
 	NULL    string = "null"
-	Command string = "COMMAND"
 )

--- a/internal/eval/constants.go
+++ b/internal/eval/constants.go
@@ -32,4 +32,5 @@ const (
 	Null    string = "null"
 	null    string = "null"
 	NULL    string = "null"
+	Command string = "COMMAND"
 )

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2356,6 +2356,11 @@ func evalCommandList() []byte {
 	cmds := make([]string, 0, diceCommandsCount)
 	for k := range DiceCmds {
 		cmds = append(cmds, k)
+		if k == Command {
+			for _, sc := range CommandSubCommands {
+				cmds = append(cmds, fmt.Sprint(Command,"|",sc))
+			}
+		}
 	}
 	return clientio.Encode(cmds, false)
 }

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2356,10 +2356,8 @@ func evalCommandList() []byte {
 	cmds := make([]string, 0, diceCommandsCount)
 	for k := range DiceCmds {
 		cmds = append(cmds, k)
-		if k == Command {
-			for _, sc := range CommandSubCommands {
-				cmds = append(cmds, fmt.Sprint(Command,"|",sc))
-			}
+		for _, sc := range DiceCmds[k].SubCommands {
+			cmds = append(cmds, fmt.Sprint(k, "|", sc))
 		}
 	}
 	return clientio.Encode(cmds, false)


### PR DESCRIPTION
Resolves #635 -  Command Subcommands should be listed as separate commands

## Description 
This PR adds the sub-commands of `COMMAND` to the list of commands displayed on `COMMAND LIST` command.

## Screenshots
![image](https://github.com/user-attachments/assets/8c6d6da1-c332-43ea-b8b7-99625fe27ef2)
