### PR TITLE
#645 Add HDEL command

### DIFF
--- a/integration_tests/commands/async/hdel_test.go
+++ b/integration_tests/commands/async/hdel_test.go
@@ -1,0 +1,42 @@
+package async
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHDEL(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []TestCase{
+		{
+			commands: []string{"HSET key field value", "HDEL key field"},
+			expected: []interface{}{ONE, ONE},
+		},
+		{
+			commands: []string{"HSET key field1 value1", "HDEL key field1"},
+			expected: []interface{}{ONE, ONE},
+		},
+		{
+			commands: []string{"HSET key field2 value2 field3 value3", "HDEL key field2 field3"},
+			expected: []interface{}{TWO, TWO},
+		},
+		{
+			commands: []string{"HSET key_new field value", "HDEL key_new field", "HDEL key_new"},
+			expected: []interface{}{ONE, ONE, "ERR wrong number of arguments for 'hdel' command"},
+		},
+		{
+			commands: []string{"SET k v", "HDEL k f"},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+		},
+	}
+
+	for _, tc := range testCases {
+		for i, cmd := range tc.commands {
+			result := FireCommand(conn, cmd)
+			assert.DeepEqual(t, tc.expected[i], result)
+		}
+	}
+}

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -600,6 +600,18 @@ var (
 		Arity:    -3,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	hdelCmdMeta = DiceCmdMeta{
+		Name: "HDEL",
+		Info: `HDEL removes the specified fields from the hash stored at key.
+		Specified fields that do not exist within this hash are ignored.
+		Deletes the hash if no fields remain.
+		If key does not exist, it is treated as an empty hash and this command returns 0.
+		Returns
+		The number of fields that were removed from the hash, not including specified but non-existing fields.`,
+		Eval:     evalHDEL,
+		Arity:    -3,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	objectCmdMeta = DiceCmdMeta{
 		Name: "OBJECT",
 		Info: `OBJECT subcommand [arguments [arguments ...]]
@@ -940,6 +952,7 @@ func init() {
 	DiceCmds["TYPE"] = typeCmdMeta
 	DiceCmds["GETRANGE"] = getRangeCmdMeta
 	DiceCmds["SETEX"] = setexCmdMeta
+	DiceCmds["HDEL"] = hdelCmdMeta
 }
 
 // Function to convert DiceCmdMeta to []interface{}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2799,6 +2799,39 @@ func evalHGET(args []string, store *dstore.Store) []byte {
 	return val
 }
 
+func evalHDEL(args []string, store *dstore.Store) []byte {
+	if len(args) < 2 {
+		return diceerrors.NewErrArity("HDEL")
+	}
+
+	key := args[0]
+	fields := args[1:]
+
+	obj := store.Get(key)
+	if obj == nil {
+		return clientio.Encode(0, false)
+	}
+
+	if err := object.AssertTypeAndEncoding(obj.TypeEncoding, object.ObjTypeHashMap, object.ObjEncodingHashMap); err != nil {
+		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
+	}
+
+	hashMap := obj.Value.(HashMap)
+	count := 0
+	for _, field := range fields {
+		if _, ok := hashMap[field]; ok {
+			delete(hashMap, field)
+			count++
+		}
+	}
+
+	if count > 0 {
+		store.Put(key, obj)
+	}
+
+	return clientio.Encode(count, false)
+}
+
 // evalHSTRLEN returns the length of value associated with field in the hash stored at key.
 //
 // This command returns 0, if the specified field doesn't exist in the key


### PR DESCRIPTION
HDEL command implementation:
- Added input validation for minimum number of arguments
- Implemented deletion of multiple fields from a hash
- Added type checking to ensure the key is a hash
- Returns the count of successfully deleted fields
- Updates the store only if fields were actually deleted