### PR TITLE
Add support for GETRANGE

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -804,6 +804,13 @@ var (
 		Arity:    1,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	getRangeCmdMeta = DiceCmdMeta{
+		Name:     "GETRANGE",
+		Info:     `Returns a substring of the string stored at a key.`,
+		Eval:     evalGETRANGE,
+		Arity:    4,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 )
 
 func init() {
@@ -896,6 +903,7 @@ func init() {
 	DiceCmds["SELECT"] = selectCmdMeta
 	DiceCmds["JSON.NUMINCRBY"] = jsonnumincrbyCmdMeta
 	DiceCmds["TYPE"] = typeCmdMeta
+	DiceCmds["GETRANGE"] = getRangeCmdMeta
 }
 
 // Function to convert DiceCmdMeta to []interface{}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -3560,6 +3560,10 @@ func evalGETRANGE(args []string, store *dstore.Store) []byte {
 	}
 	key := args[0]
 	obj := store.Get(key)
+	if obj == nil {
+		return clientio.Encode("", false)
+	}
+
 	start, err := strconv.Atoi(args[1])
 	if err != nil {
 		return diceerrors.NewErrWithFormattedMessage(diceerrors.IntOrOutOfRangeErr)
@@ -3567,10 +3571,6 @@ func evalGETRANGE(args []string, store *dstore.Store) []byte {
 	end, err := strconv.Atoi(args[2])
 	if err != nil {
 		return diceerrors.NewErrWithFormattedMessage(diceerrors.IntOrOutOfRangeErr)
-	}
-
-	if obj == nil {
-		return clientio.Encode("", false)
 	}
 
 	var str string
@@ -3587,6 +3587,10 @@ func evalGETRANGE(args []string, store *dstore.Store) []byte {
 		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
+	if str == "" {
+		return clientio.Encode("", false)
+	}
+
 	if start < 0 {
 		start = len(str) + start
 	}
@@ -3595,7 +3599,7 @@ func evalGETRANGE(args []string, store *dstore.Store) []byte {
 		end = len(str) + end
 	}
 
-	if str == "" || start >= len(str) || end < 0 || start > end {
+	if start >= len(str) || end < 0 || start > end {
 		return clientio.Encode("", false)
 	}
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -3549,6 +3549,11 @@ func evalTYPE(args []string, store *dstore.Store) []byte {
 	return clientio.Encode(typeStr, false)
 }
 
+// evalGETRANGE returns the substring of the string value stored at key, determined by the offsets start and end
+// The offsets are zero-based and can be negative values to index from the end of the string
+//
+// If the start offset is larger than the end offset, or if the start or end offset is greater than the length of the string,
+// an empty string is returned
 func evalGETRANGE(args []string, store *dstore.Store) []byte {
 	if len(args) != 3 {
 		return diceerrors.NewErrArity("GETRANGE")

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -3590,7 +3590,7 @@ func evalGETRANGE(args []string, store *dstore.Store) []byte {
 		end = len(str) + end
 	}
 
-	if len(str) == 0 || start >= len(str) || end < 0 || start > end {
+	if str == "" || start >= len(str) || end < 0 || start > end {
 		return clientio.Encode("", false)
 	}
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -3024,6 +3024,32 @@ func testEvalGETRANGE(t *testing.T, store *dstore.Store) {
 	runEvalTests(t, tests, evalGETRANGE, store)
 }
 
+func BenchmarkEvalGETRANGE(b *testing.B) {
+	store := dstore.NewStore(nil) // Initialize your store
+	store.Put("BENCHMARK_KEY", store.NewObj("Hello World", maxExDuration, object.ObjTypeString, object.ObjEncodingRaw))
+
+	// Define the inputs for the benchmark
+	inputs := []struct {
+		start string
+		end   string
+	}{
+		{"0", "3"},
+		{"0", "-1"},
+		{"-4", "-1"},
+		{"5", "3"},
+		{"5", "5000"},
+		{"-5000", "10000"},
+	}
+
+	for _, input := range inputs {
+		b.Run(fmt.Sprintf("GETRANGE start=%s end=%s", input.start, input.end), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = evalGETRANGE([]string{"BENCHMARK_KEY", input.start, input.end}, store)
+			}
+		})
+	}
+}
+
 func TestMSETConsistency(t *testing.T) {
 	store := dstore.NewStore(nil)
 	evalMSET([]string{"KEY", "VAL", "KEY2", "VAL2"}, store)

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -3025,10 +3025,9 @@ func testEvalGETRANGE(t *testing.T, store *dstore.Store) {
 }
 
 func BenchmarkEvalGETRANGE(b *testing.B) {
-	store := dstore.NewStore(nil) // Initialize your store
+	store := dstore.NewStore(nil)
 	store.Put("BENCHMARK_KEY", store.NewObj("Hello World", maxExDuration, object.ObjTypeString, object.ObjEncodingRaw))
 
-	// Define the inputs for the benchmark
 	inputs := []struct {
 		start string
 		end   string

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -80,6 +80,7 @@ func TestEval(t *testing.T) {
 	testEvalJSONNUMINCRBY(t, store)
 	testEvalTYPE(t, store)
 	testEvalCOMMAND(t, store)
+	testEvalGETRANGE(t, store)
 }
 
 func testEvalECHO(t *testing.T, store *dstore.Store) {
@@ -2883,6 +2884,146 @@ func testEvalCOMMAND(t *testing.T, store *dstore.Store) {
 
 	runEvalTests(t, tests, evalCommand, store)
 }
+func testEvalGETRANGE(t *testing.T, store *dstore.Store) {
+	setupForStringValue := func() {
+		store.Put("STRING_KEY", store.NewObj("Hello World", maxExDuration, object.ObjTypeString, object.ObjEncodingRaw))
+	}
+	setupForIntegerValue := func() {
+		store.Put("INTEGER_KEY", store.NewObj("1234", maxExDuration, object.ObjTypeString, object.ObjEncodingRaw))
+	}
+	tests := map[string]evalTestCase{
+		"GETRANGE against non-existing key": {
+			setup:  func() {},
+			input:  []string{"NON_EXISTING_KEY", "0", "-1"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against wrong key type": {
+			setup: func() {
+				evalLPUSH([]string{"LKEY1", "list"}, store)
+			},
+			input:  []string{"LKEY1", "0", "-1"},
+			output: diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr),
+		},
+		"GETRANGE against string value: 0, 3": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "0", "3"},
+			output: clientio.Encode("Hell", false),
+		},
+		"GETRANGE against string value: 0, -1": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "0", "-1"},
+			output: clientio.Encode("Hello World", false),
+		},
+		"GETRANGE against string value: -4, -1": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "-4", "-1"},
+			output: clientio.Encode("orld", false),
+		},
+		"GETRANGE against string value: 5, 3": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "5", "3"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against string value: 5, 5000": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "5", "5000"},
+			output: clientio.Encode(" World", false),
+		},
+		"GETRANGE against string value: -5000, 10000": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "-5000", "10000"},
+			output: clientio.Encode("Hello World", false),
+		},
+		"GETRANGE against string value: 0, -100": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "0", "-100"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against string value: 1, -100": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "1", "-100"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against string value: -1, -100": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "-1", "-100"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against string value: -100, -100": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "-100", "-100"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against string value: -100, -101": {
+			setup:  setupForStringValue,
+			input:  []string{"STRING_KEY", "-100", "-101"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against integer value: 0, 2": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "0", "2"},
+			output: clientio.Encode("123", false),
+		},
+		"GETRANGE against integer value: 0, -1": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "0", "-1"},
+			output: clientio.Encode("1234", false),
+		},
+		"GETRANGE against integer value: -3, -1": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "-3", "-1"},
+			output: clientio.Encode("234", false),
+		},
+		"GETRANGE against integer value: 5, 3": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "5", "3"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against integer value: 3, 5000": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "3", "5000"},
+			output: clientio.Encode("4", false),
+		},
+
+		"GETRANGE against integer value: -5000, 10000": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "-5000", "10000"},
+			output: clientio.Encode("1234", false),
+		},
+		"GETRANGE against integer value: 0, -100": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "0", "-100"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against integer value: 1, -100": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "1", "-100"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against integer value: -1, -100": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "-1", "-100"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against integer value: -100, -99": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "-100", "-99"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against integer value: -100, -100": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "-100", "-100"},
+			output: clientio.Encode("", false),
+		},
+		"GETRANGE against integer value: -100, -101": {
+			setup:  setupForIntegerValue,
+			input:  []string{"INTEGER_KEY", "-100", "-101"},
+			output: clientio.Encode("", false),
+		},
+	}
+	runEvalTests(t, tests, evalGETRANGE, store)
+}
+
 func TestMSETConsistency(t *testing.T) {
 	store := dstore.NewStore(nil)
 	evalMSET([]string{"KEY", "VAL", "KEY2", "VAL2"}, store)


### PR DESCRIPTION
Closes #644 .

This PR adds support for the `GETRANGE` command. It also adds tests from the TCL unit tests on redis. along with a basic benchmark test.


> [!NOTE]
> I skipped porting a [fuzz test from tcl](https://github.com/redis/redis/blob/3a3cacfefabf8ced79b448169319ce49cca2bfb7/tests/unit/type/string.tcl#L491) since it essentially reimplements the command logic in a test (our tests are also in go, so it seems redundand). Please let me know if i should port it or there is another approach to fuzz test it.