### PR TITLE
Add flag to enable/disable multi-threading on server

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -10,7 +10,7 @@ tmp_dir = "tmp"
   exclude_regex = []
   exclude_unchanged = false
   follow_symlink = false
-  full_bin = "GO_ENV=development ./dicedb"
+  full_bin = "GO_ENV=development ./dicedb --enable-multithreading=false"
   include_dir = []
   include_ext = ["go", "tpl", "tmpl", "yaml", "env"]
   kill_delay = "1s"

--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ var (
 	Host = DefaultHost
 	Port = DefaultPort
 
-	EnableMultiThreading = true
+	EnableMultiThreading = false
 	EnableHTTP           = true
 	HTTPPort             = 8082
 	// if RequirePass is set to an empty string, no authentication is required
@@ -114,7 +114,7 @@ var baseConfig = Config{
 		LFULogFactor:           10,
 		LogLevel:               "info",
 		PrettyPrintLogs:        false,
-		EnableMultiThreading:   true,
+		EnableMultiThreading:   false,
 	},
 	Auth: struct {
 		UserName string `mapstructure:"username"`

--- a/config/config.go
+++ b/config/config.go
@@ -29,8 +29,9 @@ var (
 	Host = DefaultHost
 	Port = DefaultPort
 
-	EnableHTTP = true
-	HTTPPort   = 8082
+	EnableMultiThreading = true
+	EnableHTTP           = true
+	HTTPPort             = 8082
 	// if RequirePass is set to an empty string, no authentication is required
 	RequirePass = utils.EmptyStr
 
@@ -60,6 +61,7 @@ type Config struct {
 		LFULogFactor           int           `mapstructure:"lfulogfactor"`
 		LogLevel               string        `mapstructure:"loglevel"`
 		PrettyPrintLogs        bool          `mapstructure:"prettyprintlogs"`
+		EnableMultiThreading   bool          `mapstructure:"enablemultithreading"`
 	} `mapstructure:"server"`
 	Auth struct {
 		UserName string `mapstructure:"username"`
@@ -92,6 +94,7 @@ var baseConfig = Config{
 		LFULogFactor           int           `mapstructure:"lfulogfactor"`
 		LogLevel               string        `mapstructure:"loglevel"`
 		PrettyPrintLogs        bool          `mapstructure:"prettyprintlogs"`
+		EnableMultiThreading   bool          `mapstructure:"enablemultithreading"`
 	}{
 		Addr:                   DefaultHost,
 		Port:                   DefaultPort,
@@ -111,6 +114,7 @@ var baseConfig = Config{
 		LFULogFactor:           10,
 		LogLevel:               "info",
 		PrettyPrintLogs:        false,
+		EnableMultiThreading:   true,
 	},
 	Auth: struct {
 		UserName string `mapstructure:"username"`

--- a/internal/server/multitherading.go
+++ b/internal/server/multitherading.go
@@ -75,7 +75,7 @@ func (s *AsyncServer) gather(redisCmd *cmd.RedisCmd, buf *bytes.Buffer, numShard
 	switch c {
 	case SingleShard, Custom:
 		if evalResp[0].Error != nil {
-			buf.WriteString(evalResp[0].Error.Error())
+			buf.Write([]byte(evalResp[0].Error.Error()))
 			return
 		}
 		buf.Write(evalResp[0].Result.([]byte))

--- a/internal/server/multitherading.go
+++ b/internal/server/multitherading.go
@@ -75,7 +75,7 @@ func (s *AsyncServer) gather(redisCmd *cmd.RedisCmd, buf *bytes.Buffer, numShard
 	switch c {
 	case SingleShard, Custom:
 		if evalResp[0].Error != nil {
-			buf.Write([]byte(evalResp[0].Error.Error()))
+			buf.WriteString(evalResp[0].Error.Error())
 			return
 		}
 		buf.Write(evalResp[0].Result.([]byte))

--- a/main.go
+++ b/main.go
@@ -55,17 +55,17 @@ func main() {
 	// If not enabled multithreading, server will run on a single core.
 	var numCores int
 	if config.EnableMultiThreading {
-		logr.Info("Running server in multi-threaded mode")
+		logr.Debug("Running server in multi-threaded mode")
 		numCores = runtime.NumCPU()
 	} else {
-		logr.Info("Running server in single-threaded mode")
+		logr.Debugg("Running server in single-threaded mode")
 		numCores = 1
 	}
 
 	// The runtime.GOMAXPROCS(numCores) call limits the number of operating system
 	// threads that can execute Go code simultaneously to the number of CPU cores.
 	// This enables Go to run more efficiently, maximizing CPU utilization and
-	// improving concurrency performance across multiple goroutineags.
+	// improving concurrency performance across multiple goroutines.
 	runtime.GOMAXPROCS(numCores)
 
 	shardManager := shard.NewShardManager(int8(numCores), watchChan, logr)

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		logr.Debug("Running server in multi-threaded mode")
 		numCores = runtime.NumCPU()
 	} else {
-		logr.Debugg("Running server in single-threaded mode")
+		logr.Debug("Running server in single-threaded mode")
 		numCores = 1
 	}
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func init() {
 	flag.StringVar(&config.Host, "host", "0.0.0.0", "host for the dice server")
 	flag.IntVar(&config.Port, "port", 7379, "port for the dice server")
 	flag.BoolVar(&config.EnableHTTP, "enable-http", true, "run server in HTTP mode as well")
-	flag.BoolVar(&config.EnableMultiThreading, "enable-multithreading", true, "run server in multithreading mode")
+	flag.BoolVar(&config.EnableMultiThreading, "enable-multithreading", false, "run server in multithreading mode")
 	flag.IntVar(&config.HTTPPort, "http-port", 8082, "HTTP port for the dice server")
 	flag.StringVar(&config.RequirePass, "requirepass", config.RequirePass, "enable authentication for the default user")
 	flag.StringVar(&config.CustomConfigFilePath, "o", config.CustomConfigFilePath, "dir path to create the config file")
@@ -55,17 +55,17 @@ func main() {
 	// If not enabled multithreading, server will run on a single core.
 	var numCores int
 	if config.EnableMultiThreading {
-		logr.Debug("Running server in multi-threaded mode")
+		logr.Info("Running server in multi-threaded mode")
 		numCores = runtime.NumCPU()
 	} else {
-		logr.Debug("Running server in single-threaded mode")
+		logr.Info("Running server in single-threaded mode")
 		numCores = 1
 	}
 
 	// The runtime.GOMAXPROCS(numCores) call limits the number of operating system
 	// threads that can execute Go code simultaneously to the number of CPU cores.
 	// This enables Go to run more efficiently, maximizing CPU utilization and
-	// improving concurrency performance across multiple goroutines.
+	// improving concurrency performance across multiple goroutineags.
 	runtime.GOMAXPROCS(numCores)
 
 	shardManager := shard.NewShardManager(int8(numCores), watchChan, logr)

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func init() {
 	flag.StringVar(&config.Host, "host", "0.0.0.0", "host for the dice server")
 	flag.IntVar(&config.Port, "port", 7379, "port for the dice server")
 	flag.BoolVar(&config.EnableHTTP, "enable-http", true, "run server in HTTP mode as well")
+	flag.BoolVar(&config.EnableMultiThreading, "enable-multithreading", true, "run server in multithreading mode")
 	flag.IntVar(&config.HTTPPort, "http-port", 8082, "HTTP port for the dice server")
 	flag.StringVar(&config.RequirePass, "requirepass", config.RequirePass, "enable authentication for the default user")
 	flag.StringVar(&config.CustomConfigFilePath, "o", config.CustomConfigFilePath, "dir path to create the config file")
@@ -51,7 +52,15 @@ func main() {
 	// This determines the total number of logical processors that can be utilized
 	// for parallel execution. Setting the maximum number of CPUs to the available
 	// core count ensures the application can make full use of all available hardware.
-	numCores := runtime.NumCPU()
+	// If not enabled multithreading, server will run on a single core.
+	var numCores int
+	if config.EnableMultiThreading {
+		logr.Debug("Running server in multi-threaded mode")
+		numCores = runtime.NumCPU()
+	} else {
+		logr.Debug("Running server in single-threaded mode")
+		numCores = 1
+	}
 
 	// The runtime.GOMAXPROCS(numCores) call limits the number of operating system
 	// threads that can execute Go code simultaneously to the number of CPU cores.


### PR DESCRIPTION
```
 ❯ go run main.go --enable-multithreading=false 
{"level":"info","time":"2024-09-22T01:38:35+05:30","message":"Running server in single-threaded mode"}
{"level":"info","version":"0.0.4","port":7379,"time":"2024-09-22T01:38:35+05:30","message":"DiceDB is running"}
{"level":"warn","time":"2024-09-22T01:38:35+05:30","message":"DiceDB is running without authentication. Consider setting a password."}
{"level":"info","addr":":8082","time":"2024-09-22T01:38:35+05:30","message":"HTTP Server running"}
```