### PR TITLE
fix: log error messages instead of values 

### DIFF
--- a/internal/logger/zerolog.go
+++ b/internal/logger/zerolog.go
@@ -36,8 +36,12 @@ func (h *ZerologHandler) Handle(ctx context.Context, record slog.Record) error {
 		case slog.KindBool:
 			event = event.Bool(attr.Key, attr.Value.Bool())
 		default:
-			// Log unknown types generically
-			event = event.Interface(attr.Key, attr.Value.Any())
+			switch v := attr.Value.Any().(type) {
+			case error:
+				event = event.Err(v)
+			default:
+				event = event.Interface(attr.Key, attr.Value.Any())
+			}
 		}
 		return true
 	})

--- a/internal/logger/zerolog.go
+++ b/internal/logger/zerolog.go
@@ -37,6 +37,7 @@ func (h *ZerologHandler) Handle(ctx context.Context, record slog.Record) error {
 			event = event.Bool(attr.Key, attr.Value.Bool())
 		default:
 			switch v := attr.Value.Any().(type) {
+			// error is a special case since zerlog has a dedicated method for it but it's not part of the slog.Kind
 			case error:
 				event = event.Err(v)
 			default:


### PR DESCRIPTION
Closes #685 

# Problem

The new logger missed handling conversion of err values to the messages.


# Old Output
<img width="503" alt="image" src="https://github.com/user-attachments/assets/9192480d-cc47-49f1-95a8-c5f9725bdb63">


# New Output
<img width="536" alt="image" src="https://github.com/user-attachments/assets/daeabf6c-bc81-4e6b-96b2-2814d9260768">
