### PR TITLE
Reverting back evalPING command for HTTP server

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -47,6 +47,7 @@ var (
 		Info:       `PING returns with an encoded "PONG" If any message is added with the ping command,the message will be returned.`,
 		Arity:      -1,
 		IsMigrated: true,
+		Eval:       evalPING,
 	}
 
 	setCmdMeta = DiceCmdMeta{
@@ -227,7 +228,7 @@ var (
 		Name: "JSON.OBJLEN",
 		Info: `JSON.OBJLEN key [path]
 		Report the number of keys in the JSON object at path in key
-		Returns error response if the key doesn't exist or key is expired or the matching value is not an array. 
+		Returns error response if the key doesn't exist or key is expired or the matching value is not an array.
 		Error reply: If the number of arguments is incorrect.`,
 		Eval:     evalJSONOBJLEN,
 		Arity:    -2,

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -64,6 +64,25 @@ func init() {
 	serverID = fmt.Sprintf("%s:%d", config.DiceConfig.Server.Addr, config.DiceConfig.Server.Port)
 }
 
+// evalPING returns with an encoded "PONG"
+// If any message is added with the ping command,
+// the message will be returned.
+func evalPING(args []string, store *dstore.Store) []byte {
+	var b []byte
+
+	if len(args) >= 2 {
+		return diceerrors.NewErrArity("PING")
+	}
+
+	if len(args) == 0 {
+		b = clientio.Encode("PONG", true)
+	} else {
+		b = clientio.Encode(args[0], false)
+	}
+
+	return b
+}
+
 // evalECHO returns the argument passed by the user
 func evalECHO(args []string, store *dstore.Store) []byte {
 	if len(args) != 1 {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -81,6 +81,18 @@ func TestEval(t *testing.T) {
 	testEvalTYPE(t, store)
 	testEvalCOMMAND(t, store)
 	testEvalGETRANGE(t, store)
+	testEvalPING(t, store)
+}
+
+func testEvalPING(t *testing.T, store *dstore.Store) {
+	tests := map[string]evalTestCase{
+		"nil value":            {input: nil, output: []byte("+PONG\r\n")},
+		"empty args":           {input: []string{}, output: []byte("+PONG\r\n")},
+		"one value":            {input: []string{"HEY"}, output: []byte("$3\r\nHEY\r\n")},
+		"more than one values": {input: []string{"HEY", "HELLO"}, output: []byte("-ERR wrong number of arguments for 'ping' command\r\n")},
+	}
+
+	runEvalTests(t, tests, evalPING, store)
 }
 
 func testEvalECHO(t *testing.T, store *dstore.Store) {

--- a/internal/server/multitherading.go
+++ b/internal/server/multitherading.go
@@ -75,7 +75,7 @@ func (s *AsyncServer) gather(redisCmd *cmd.RedisCmd, buf *bytes.Buffer, numShard
 	switch c {
 	case SingleShard, Custom:
 		if evalResp[0].Error != nil {
-			buf.WriteString(evalResp[0].Error.Error())
+			buf.Write([]byte(evalResp[0].Error.Error()))
 			return
 		}
 		buf.Write(evalResp[0].Result.([]byte))

--- a/internal/server/multitherading.go
+++ b/internal/server/multitherading.go
@@ -75,7 +75,7 @@ func (s *AsyncServer) gather(redisCmd *cmd.RedisCmd, buf *bytes.Buffer, numShard
 	switch c {
 	case SingleShard, Custom:
 		if evalResp[0].Error != nil {
-			buf.Write([]byte(evalResp[0].Error.Error()))
+			buf.WriteString(evalResp[0].Error.Error())
 			return
 		}
 		buf.Write(evalResp[0].Result.([]byte))


### PR DESCRIPTION
- Currently HTTPServer was breaking in case of `PING` command as it was talking directly to shard and `executeCommandsToBuffer` is only implemented for `AsyncServer` to handle the `Global` defined commands.
- As for stop gap fix, so that HTTPServer doesn't break incase of `PING` command evaluation adding it back to `eval`.
- Going forward once the worker changes are done and we've a common layer for HTTPServer to interact with for executing all types of command i.e. `Global, SingleShard` etc. we'll remove this.

```
❯ curl --location --request POST 'localhost:8082/ping'
"PONG"
```

```
❯ redis-cli -h 0.0.0.0 -p 7379                                                                       
0.0.0.0:7379> ping
PONG
```