### PR TITLE
#671: Inconsistent EXPIRE: EXPIRE with empty string as TTL should report an…

### DIFF
--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1424,11 +1424,11 @@ func evalEXPIRE(args []string, store *dstore.Store) []byte {
 
 	var key string = args[0]
 	exDurationSec, err := strconv.ParseInt(args[1], 10, 64)
-	if exDurationSec < 0 || exDurationSec > maxExDuration {
-		return diceerrors.NewErrExpireTime("EXPIRE")
+	if err != nil {
+		return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
 	}
 
-	if err != nil {
+	if exDurationSec < 0 || exDurationSec > maxExDuration {
 		return diceerrors.NewErrExpireTime("EXPIRE")
 	}
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -473,6 +473,34 @@ func testEvalEXPIRE(t *testing.T, store *dstore.Store) {
 			input:  []string{"EXISTING_KEY", strconv.FormatInt(-1, 10)},
 			output: []byte("-ERR invalid expire time in 'expire' command\r\n"),
 		},
+		"invalid expiry time exists - empty string": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &object.Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store.Put(key, obj)
+
+			},
+			input:  []string{"EXISTING_KEY", ""},
+			output: []byte("-ERR value is not an integer or out of range\r\n"),
+		},
+		"invalid expiry time exists - with float number": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "mock_value"
+				obj := &object.Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store.Put(key, obj)
+
+			},
+			input:  []string{"EXISTING_KEY", "0.456"},
+			output: []byte("-ERR value is not an integer or out of range\r\n"),
+		},
 	}
 
 	runEvalTests(t, tests, evalEXPIRE, store)


### PR DESCRIPTION
PR For https://github.com/DiceDB/dice/issues/671
@lucifercr07 @AshwinKul28 
After these changes behaviour with expire time mentioned below.
For empty string and not integer value error would be `ERR value is not an integer or out of range`
And for remaining values like -ve and larger values and etc error would be `invalid expire time in EXPIRE command`