### PR TITLE
#548: feature: query fingerprinting

### DIFF
--- a/internal/sql/dsql.go
+++ b/internal/sql/dsql.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	hash "github.com/dgryski/go-farm"
-
 	"github.com/xwb1989/sqlparser"
 )
 
@@ -154,7 +152,7 @@ func ParseQuery(sql string) (DSQLQuery, error) {
 		Where:       where,
 		OrderBy:     orderBy,
 		Limit:       limit,
-		Fingerprint: generateFingerprint(where),
+		Fingerprint: GenerateFingerprint(where),
 	}, nil
 }
 
@@ -274,10 +272,4 @@ func parseWhere(selectStmt *sqlparser.Select) sqlparser.Expr {
 		return nil
 	}
 	return selectStmt.Where.Expr
-}
-
-func generateFingerprint(where sqlparser.Expr) string {
-	// Generate a unique fingerprint for the query
-	// TODO: Add logic to ensure that logically equivalent WHERE clause expressions generate the same fingerprint.
-	return fmt.Sprintf("f_%d", hash.Hash64([]byte(sqlparser.String(where))))
 }

--- a/internal/sql/dsql.go
+++ b/internal/sql/dsql.go
@@ -152,7 +152,7 @@ func ParseQuery(sql string) (DSQLQuery, error) {
 		Where:       where,
 		OrderBy:     orderBy,
 		Limit:       limit,
-		Fingerprint: GenerateFingerprint(where),
+		Fingerprint: generateFingerprint(where),
 	}, nil
 }
 

--- a/internal/sql/fingerprint.go
+++ b/internal/sql/fingerprint.go
@@ -52,13 +52,15 @@ func combineAnd(a, b expression) expression {
 	result := make(expression, 0, len(a)+len(b))
 	for _, termA := range a {
 		for _, termB := range b {
-			combined := append(termA, termB...)
+			combined := make([]string, len(termA), len(termA)+len(termB))
+			copy(combined, termA)
+			combined = append(combined, termB...)
 			uniqueCombined := removeDuplicates(combined)
 			sort.Strings(uniqueCombined)
 			result = append(result, uniqueCombined)
 		}
 	}
-	return expression(result)
+	return result
 }
 
 func combineOr(a, b expression) expression {

--- a/internal/sql/fingerprint.go
+++ b/internal/sql/fingerprint.go
@@ -34,7 +34,7 @@ func ParseAstExpression(expr sqlparser.Expr) Expression {
 	case *sqlparser.AndExpr:
 		leftExpr := ParseAstExpression(expr.Left)
 		rightExpr := ParseAstExpression(expr.Right)
-		return combineAnd(leftExpr, rightExpr)
+		return CombineAnd(leftExpr, rightExpr)
 	case *sqlparser.OrExpr:
 		leftExpr := ParseAstExpression(expr.Left)
 		rightExpr := ParseAstExpression(expr.Right)
@@ -48,11 +48,13 @@ func ParseAstExpression(expr sqlparser.Expr) Expression {
 	}
 }
 
-func combineAnd(a, b Expression) Expression {
-	var result [][]string
+func CombineAnd(a, b Expression) Expression {
+	result := [][]string{}
 	for _, termA := range a {
 		for _, termB := range b {
-			result = append(result, append(termA, termB...))
+			combined := append(termA, termB...)
+			uniqueCombined := removeDuplicates(combined)
+			result = append(result, uniqueCombined)
 		}
 	}
 	return Expression(result)
@@ -61,4 +63,17 @@ func combineAnd(a, b Expression) Expression {
 func combineOr(a, b Expression) Expression {
 	result := append(a, b...)
 	return Expression(result)
+}
+
+// helper
+func removeDuplicates(input []string) []string {
+	seen := make(map[string]struct{})
+	var result []string
+	for _, v := range input {
+		if _, exists := seen[v]; !exists {
+			seen[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+	return result
 }

--- a/internal/sql/fingerprint.go
+++ b/internal/sql/fingerprint.go
@@ -54,6 +54,7 @@ func CombineAnd(a, b Expression) Expression {
 		for _, termB := range b {
 			combined := append(termA, termB...)
 			uniqueCombined := removeDuplicates(combined)
+			sort.Strings(uniqueCombined)
 			result = append(result, uniqueCombined)
 		}
 	}

--- a/internal/sql/fingerprint.go
+++ b/internal/sql/fingerprint.go
@@ -1,0 +1,64 @@
+package sql
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	hash "github.com/dgryski/go-farm"
+	"github.com/xwb1989/sqlparser"
+)
+
+// OR terms containing AND expressions
+type Expression [][]string
+
+func (expr Expression) String() string {
+	var orTerms []string
+	for _, andTerm := range expr {
+		// Sort AND terms within OR
+		sort.Strings(andTerm)
+		orTerms = append(orTerms, strings.Join(andTerm, " AND "))
+	}
+	// Sort the OR terms
+	sort.Strings(orTerms)
+	return strings.Join(orTerms, " OR ")
+}
+
+func GenerateFingerprint(where sqlparser.Expr) string {
+	expr := ParseAstExpression(where)
+	return fmt.Sprintf("f_%d", hash.Hash64([]byte(expr.String())))
+}
+
+func ParseAstExpression(expr sqlparser.Expr) Expression {
+	switch expr := expr.(type) {
+	case *sqlparser.AndExpr:
+		leftExpr := ParseAstExpression(expr.Left)
+		rightExpr := ParseAstExpression(expr.Right)
+		return combineAnd(leftExpr, rightExpr)
+	case *sqlparser.OrExpr:
+		leftExpr := ParseAstExpression(expr.Left)
+		rightExpr := ParseAstExpression(expr.Right)
+		return combineOr(leftExpr, rightExpr)
+	case *sqlparser.ParenExpr:
+		return ParseAstExpression(expr.Expr)
+	case *sqlparser.ComparisonExpr:
+		return Expression([][]string{{expr.Operator + sqlparser.String(expr.Left) + sqlparser.String(expr.Right)}})
+	default:
+		return Expression{}
+	}
+}
+
+func combineAnd(a, b Expression) Expression {
+	var result [][]string
+	for _, termA := range a {
+		for _, termB := range b {
+			result = append(result, append(termA, termB...))
+		}
+	}
+	return Expression(result)
+}
+
+func combineOr(a, b Expression) Expression {
+	result := append(a, b...)
+	return Expression(result)
+}

--- a/internal/sql/fingerprint_test.go
+++ b/internal/sql/fingerprint_test.go
@@ -45,6 +45,16 @@ func TestParseAstExpression(t *testing.T) {
 			expression: "like_key'match:1:*'",
 		},
 		{
+			name: "aa",
+			similarEq: []string{
+				"_key like 'match:1:*'",
+				"(_key like 'match:1:*')",
+				"((_key like 'match:1:*'))",
+				"(((_key like 'match:1:*')))",
+			},
+			expression: "like_key'match:1:*'",
+		},
+		{
 			name: "dcdjfhcdipp",
 			similarEq: []string{
 				"(_key LIKE 'test:*') AND (_value > 10 OR _value < 5)",
@@ -109,6 +119,16 @@ func TestGenerateFingerprint(t *testing.T) {
 			name: "aa",
 			similarEq: []string{
 				"_key like 'match:1:*'",
+			},
+			fingerprint: "f_5313097907453016110",
+		},
+		{
+			name: "aa",
+			similarEq: []string{
+				"_key like 'match:1:*'",
+				"(_key like 'match:1:*')",
+				"((_key like 'match:1:*'))",
+				"(((_key like 'match:1:*')))",
 			},
 			fingerprint: "f_5313097907453016110",
 		},

--- a/internal/sql/fingerprint_test.go
+++ b/internal/sql/fingerprint_test.go
@@ -65,12 +65,6 @@ func TestCombineOr(t *testing.T) {
 			b:        expression([][]string{}),
 			expected: expression([][]string{}),
 		},
-		// {
-		// 	name:     "Annulment law",
-		// 	a:        Expression([][]string{{"_value > 10"}}),
-		// 	b:        Expression([][]string{{}}), // equivalent to 1
-		// 	expected: Expression([][]string{{}}),
-		// },
 		{
 			name:     "Identity law",
 			a:        expression([][]string{{"_value > 10"}}),

--- a/internal/sql/fingerprint_test.go
+++ b/internal/sql/fingerprint_test.go
@@ -281,6 +281,15 @@ func TestGenerateFingerprintAndParseAstExpression(t *testing.T) {
 			fingerprint: "f_5313097907453016110",
 		},
 		{
+			name: "expression with exactly 1 term, multiple AND OR (Idempotent law)",
+			similarExpr: []string{
+				"_value > 10 AND _value > 10 OR _value > 10 AND _value > 10",
+				"_value > 10",
+			},
+			expression:  ">_value10",
+			fingerprint: "f_11845737393789912467",
+		},
+		{
 			name: "Expression in form 'A AND (B OR C)' which can reduce to 'A AND B OR A AND C' etc (or Distributive law)",
 			similarExpr: []string{
 				"(_key LIKE 'test:*') AND (_value > 10 OR _value < 5)",

--- a/internal/sql/fingerprint_test.go
+++ b/internal/sql/fingerprint_test.go
@@ -328,6 +328,15 @@ func TestGenerateFingerprintAndParseAstExpression(t *testing.T) {
 			expression:  "<_value5 AND >_value10 OR <_value5 AND like_key'test:*' OR >_value10 AND like_key'test:*' OR like_key'test:*'",
 			fingerprint: "f_1509117529358989129",
 		},
+		{
+			name: "Test Precedence: AND before OR with LIKE and Value Comparison",
+			similarExpr: []string{
+				"_key LIKE 'test:*' AND _value > 10 OR _value < 5",
+				"(_key LIKE 'test:*' AND _value > 10) OR _value < 5",
+			},
+			expression:  "<_value5 OR >_value10 AND like_key'test:*'",
+			fingerprint: "f_8791273852316817684",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/sql/fingerprint_test.go
+++ b/internal/sql/fingerprint_test.go
@@ -1,0 +1,145 @@
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/dicedb/dice/internal/sql"
+	"github.com/xwb1989/sqlparser"
+	"gotest.tools/v3/assert"
+)
+
+func TestParseAstExpression(t *testing.T) {
+	tests := []struct {
+		name       string
+		similarEq  []string // logically same where expressions
+		expression string
+	}{
+		{
+			name: "aa",
+			similarEq: []string{
+				"_value > 10 OR _value < 5",
+				" _value < 5 OR _value > 10",
+			},
+			expression: "<_value5 OR >_value10",
+		},
+		{
+			name: "aa",
+			similarEq: []string{
+				"_value > 10 AND _value < 5",
+				"_value < 5 AND _value > 10",
+			},
+			expression: "<_value5 AND >_value10",
+		},
+		{
+			name: "aa",
+			similarEq: []string{
+				"_key like `match:1:*`",
+			},
+			expression: "like_key`match:1:*`",
+		},
+		{
+			name: "aa",
+			similarEq: []string{
+				"_key like 'match:1:*'",
+			},
+			expression: "like_key'match:1:*'",
+		},
+		{
+			name: "dcdjfhcdipp",
+			similarEq: []string{
+				"(_key LIKE 'test:*') AND (_value > 10 OR _value < 5)",
+				"(_value > 10 OR _value < 5) AND (_key LIKE 'test:*')",
+				"(_value < 5 OR _value > 10) AND (_key LIKE 'test:*')",
+				"(_key LIKE 'test:*' AND _value > 10) OR (_key LIKE 'test:*' AND _value < 5)",
+				"((_key LIKE 'test:*') AND _value > 10) OR ((_key LIKE 'test:*') AND _value < 5)",
+				"(_key LIKE 'test:*') AND ((_value > 10) OR (_value < 5))",
+				"(_value > 10 AND _key LIKE 'test:*') OR (_value < 5 AND _key LIKE 'test:*')",
+				"(_value < 5 AND _key LIKE 'test:*') OR (_value > 10 AND _key LIKE 'test:*')",
+			},
+			expression: "<_value5 AND like_key'test:*' OR >_value10 AND like_key'test:*'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, query := range tt.similarEq {
+				statement, err := sqlparser.Parse("SELECT * WHERE " + query)
+				if err != nil {
+					t.Fail()
+				}
+				selectStmt, ok := statement.(*sqlparser.Select)
+				if !ok {
+					t.Fail()
+				}
+				assert.DeepEqual(t, tt.expression, sql.ParseAstExpression(selectStmt.Where.Expr).String())
+			}
+		})
+	}
+}
+
+func TestGenerateFingerprint(t *testing.T) {
+	tests := []struct {
+		name        string
+		similarEq   []string // logically same where expressions
+		fingerprint string   // expected fingerprint
+	}{
+		{
+			name: "aa",
+			similarEq: []string{
+				"_value > 10 OR _value < 5",
+				" _value < 5 OR _value > 10",
+			},
+			fingerprint: "f_5731466836575684070",
+		},
+		{
+			name: "aa",
+			similarEq: []string{
+				"_value > 10 AND _value < 5",
+				"_value < 5 AND _value > 10",
+			},
+			fingerprint: "f_8696580727138087340",
+		},
+		{
+			name: "aa",
+			similarEq: []string{
+				"_key like `match:1:*`",
+			},
+			fingerprint: "f_15929225480754059748",
+		},
+		{
+			name: "aa",
+			similarEq: []string{
+				"_key like 'match:1:*'",
+			},
+			fingerprint: "f_5313097907453016110",
+		},
+		{
+			name: "dcdjfhcdipp",
+			similarEq: []string{
+				"(_key LIKE 'test:*') AND (_value > 10 OR _value < 5)",
+				"(_value > 10 OR _value < 5) AND (_key LIKE 'test:*')",
+				"(_value < 5 OR _value > 10) AND (_key LIKE 'test:*')",
+				"(_key LIKE 'test:*' AND _value > 10) OR (_key LIKE 'test:*' AND _value < 5)",
+				"((_key LIKE 'test:*') AND _value > 10) OR ((_key LIKE 'test:*') AND _value < 5)",
+				"(_key LIKE 'test:*') AND ((_value > 10) OR (_value < 5))",
+				"(_value > 10 AND _key LIKE 'test:*') OR (_value < 5 AND _key LIKE 'test:*')",
+				"(_value < 5 AND _key LIKE 'test:*') OR (_value > 10 AND _key LIKE 'test:*')",
+			},
+			fingerprint: "f_6936111135456499050",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, query := range tt.similarEq {
+				statement, err := sqlparser.Parse("SELECT * WHERE " + query)
+				if err != nil {
+					t.Fail()
+				}
+				selectStmt, ok := statement.(*sqlparser.Select)
+				if !ok {
+					t.Fail()
+				}
+				assert.DeepEqual(t, tt.fingerprint, sql.GenerateFingerprint(selectStmt.Where.Expr))
+			}
+		})
+	}
+}

--- a/internal/sql/fingerprint_test.go
+++ b/internal/sql/fingerprint_test.go
@@ -337,6 +337,16 @@ func TestGenerateFingerprintAndParseAstExpression(t *testing.T) {
 			expression:  "<_value5 OR >_value10 AND like_key'test:*'",
 			fingerprint: "f_8791273852316817684",
 		},
+		{
+			name: "Simple JSON expression",
+			similarExpr: []string{
+				"'_value.age' > 30 and _key like 'user:*' and '_value.age' > 30",
+				"'_value.age' > 30 and _key like 'user:*'",
+				"_key like 'user:*' and '_value.age' > 30 ",
+			},
+			expression:  ">'_value.age'30 AND like_key'user:*'",
+			fingerprint: "f_5016002712062179335",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# DSQL Fingerprinting Implementation

### Overview
This PR implements generating same fingerprint for logically same WHERE clause of a DSQL query.

### Implementation Details
Expression in WHERE clause of DSQL can be representated in boolean algebra.
`$key like 'match:1:*' AND $value > 100` can be representated as `A AND B`. With this approach we can simplify complex boolean algebra into its simplified version using [laws of boolean algebra](https://en.wikipedia.org/wiki/Boolean_algebra#Laws).
Example
`$key like 'match:1:*' AND $value > 100` and `$value > 100 AND $key like 'match:1:*'` are logically same.

We represent each comparison expression(`$key like 'match:1:*'`) in form _operator + leftOperand + rightOperand_, then this can be assumed as `A` in boolean algebra representation.
Now each comparison expression can be considered as an operand, then we sort these operands.
Why sort? for above example we will get output as `A AND B` and `B AND A`, post sorting both will be represented as `A AND B` - a common structural expression for logically same expressions.

sorting performance - For this use case sorting won't affect performance as input size is very small.

Representation of operands associated with `AND` and `OR` operator are represented in an array of arrays, in form _OR terms containing AND expressions_.
Example - `A AND B OR C` would be represented as 
```
[
    [A, B],
    [C]
]
```

Above logic can be used for more complex expression involving _parenthesis_ and requiring expansion/simplification the original expression.
Few examples-
`(A)` = `A`
 `(A AND B) OR C` = `A AND B OR C`
`A AND (B OR C)` = `A AND B OR A AND C`

JSON Support - Since each operand is represented in form _operator + leftOperand + rightOperand_. JSON filter query wouldn't need any special handling. `('$value.age' > 18)` would be converted to `>'_value.age'18` and so on.



### Coverage 
This solution would cover alot of the use cases and query patterns that we are expecting.


### Limitations
When we say different expressions are logically same it means there truth table is same. There could be infinite number of expression which can result same truth table. Following is an example.
Expression `(_key LIKE 'test:*') OR (_value > 10 AND _value < 5)` and `(_key LIKE 'test:*' OR _value > 10) AND (_key LIKE 'test:*' OR _value < 5)` are logically same but not addressed in current solution. 




resolves  #548 

