### PR TITLE
#663: Fixed bitcount operations

### DIFF
--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2100,7 +2100,7 @@ func evalBITCOUNT(args []string, store *dstore.Store) []byte {
 		end = min(end, valueLength-1)
 		bitCount := 0
 		for i := start; i <= end; i++ {
-			bitCount += int(bits.OnesCount8(value[i]))
+			bitCount += bits.OnesCount8(value[i])
 		}
 		return clientio.Encode(bitCount, true)
 	case BIT:
@@ -2130,20 +2130,20 @@ func evalBITCOUNT(args []string, store *dstore.Store) []byte {
 		if startByte == endByte {
 			mask := byte(0xFF >> startBitOffset)
 			mask &= byte(0xFF << (7 - endBitOffset))
-			bitCount = int(bits.OnesCount8(value[startByte] & mask))
+			bitCount = bits.OnesCount8(value[startByte] & mask)
 		} else {
 			// Handle first byte
 			firstByteMask := byte(0xFF >> startBitOffset)
-			bitCount += int(bits.OnesCount8(value[startByte] & firstByteMask))
+			bitCount += bits.OnesCount8(value[startByte] & firstByteMask)
 
 			// Handle all the middle ones
 			for i := startByte + 1; i < endByte; i++ {
-				bitCount += int(bits.OnesCount8(value[i]))
+				bitCount += bits.OnesCount8(value[i])
 			}
 
 			// Handle last byte
 			lastByteMask := byte(0xFF << (7 - endBitOffset))
-			bitCount += int(bits.OnesCount8(value[endByte] & lastByteMask))
+			bitCount += bits.OnesCount8(value[endByte] & lastByteMask)
 		}
 		return clientio.Encode(bitCount, true)
 	default:

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2039,106 +2039,115 @@ func evalBITCOUNT(args []string, store *dstore.Store) []byte {
 	}
 
 	// fetching value of the key
-	var key string = args[0]
+	key := args[0]
 	obj := store.Get(key)
 	if obj == nil {
 		return clientio.Encode(0, false)
 	}
 
-	// Check for the type of the object
-	if object.AssertType(obj.TypeEncoding, object.ObjTypeSet) == nil {
+	var value []byte
+	var valueLength int64
+
+	switch {
+	case object.AssertType(obj.TypeEncoding, object.ObjTypeByteArray) == nil:
+		byteArray := obj.Value.(*ByteArray)
+		value = byteArray.data
+		valueLength = byteArray.Length
+	case object.AssertType(obj.TypeEncoding, object.ObjTypeString) == nil:
+		value = []byte(obj.Value.(string))
+		valueLength = int64(len(value))
+	case object.AssertType(obj.TypeEncoding, object.ObjTypeInt) == nil:
+		value = []byte(strconv.FormatInt(obj.Value.(int64), 10))
+		valueLength = int64(len(value))
+	default:
 		return diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
 	}
 
-	valueInterface := obj.Value
-	value := []byte{}
-	valueLength := int64(0)
-
-	if object.AssertType(obj.TypeEncoding, object.ObjTypeByteArray) == nil {
-		byteArray := obj.Value.(*ByteArray)
-		byteArrayObject := *byteArray
-		value = byteArrayObject.data
-		valueLength = byteArray.Length
-	}
-
-	if object.AssertType(obj.TypeEncoding, object.ObjTypeString) == nil {
-		value = []byte(valueInterface.(string))
-		valueLength = int64(len(value))
-	}
-
-	if object.AssertType(obj.TypeEncoding, object.ObjTypeInt) == nil {
-		value = []byte(strconv.FormatInt(valueInterface.(int64), 10))
-		valueLength = int64(len(value))
-	}
-
 	// defining constants of the function
-	start := int64(0)
-	end := valueLength - 1
+	start, end := int64(0), valueLength-1
 	unit := BYTE
 
-	// checking which arguments are present and according validating arguments
+	// checking which arguments are present and validating arguments
 	if len(args) > 1 {
 		start, err = strconv.ParseInt(args[1], 10, 64)
 		if err != nil {
 			return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
 		}
-		// Adjust start index if it is negative
-		if start < 0 {
-			start += valueLength
+		if len(args) <= 2 {
+			return diceerrors.NewErrWithMessage(diceerrors.SyntaxErr)
 		}
-	}
-	if len(args) > 2 {
 		end, err = strconv.ParseInt(args[2], 10, 64)
 		if err != nil {
 			return diceerrors.NewErrWithMessage(diceerrors.IntOrOutOfRangeErr)
 		}
-
-		// Adjust end index if it is negative
-		if end < 0 {
-			end += valueLength
-		}
 	}
 	if len(args) > 3 {
 		unit = strings.ToUpper(args[3])
-		if unit != BYTE && unit != BIT {
-			return diceerrors.NewErrWithMessage(diceerrors.SyntaxErr)
-		}
-	}
-	if start > end {
-		return clientio.Encode(0, true)
-	}
-	if start > valueLength && unit == BYTE {
-		return clientio.Encode(0, true)
-	}
-	if end > valueLength && unit == BYTE {
-		end = valueLength - 1
 	}
 
-	bitCount := 0
-	if unit == BYTE {
+	switch unit {
+	case "BYTE":
+		if start < 0 {
+			start += valueLength
+		}
+		if end < 0 {
+			end += valueLength
+		}
+		if start > end || start >= valueLength {
+			return clientio.Encode(0, true)
+		}
+		end = min(end, valueLength-1)
+		bitCount := 0
 		for i := start; i <= end; i++ {
 			bitCount += int(popcount(value[i]))
 		}
 		return clientio.Encode(bitCount, true)
-	}
-	startBitRange := start / 8
-	endBitRange := min(end/8, valueLength-1)
-	for i := startBitRange; i <= endBitRange; i++ {
-		if i == startBitRange {
-			considerBits := start % 8
-			for j := 8 - considerBits - 1; j >= 0; j-- {
-				bitCount += int(popcount(byte(int(value[i]) & (1 << j))))
-			}
-		} else if i == endBitRange {
-			considerBits := end % 8
-			for j := considerBits; j >= 0; j-- {
-				bitCount += int(popcount(byte(int(value[i]) & (1 << (8 - j - 1)))))
-			}
-		} else {
-			bitCount += int(popcount(value[i]))
+	case "BIT":
+		if start < 0 {
+			start += valueLength * 8
 		}
+		if end < 0 {
+			end += valueLength * 8
+		}
+		if start > end {
+			return clientio.Encode(0, true)
+		}
+		startByte, endByte := start/8, min(end/8, valueLength-1)
+		startBitOffset, endBitOffset := start%8, end%8
+
+		if endByte == valueLength-1 {
+			endBitOffset = 7
+		}
+
+		if startByte >= valueLength {
+			return clientio.Encode(0, true)
+		}
+
+		bitCount := 0
+
+		// Use bit masks to count the bits instead of a loop
+		if startByte == endByte {
+			mask := byte(0xFF >> startBitOffset)
+			mask &= byte(0xFF << (7 - endBitOffset))
+			bitCount = int(popcount(value[startByte] & mask))
+		} else {
+			// Handle first byte
+			firstByteMask := byte(0xFF >> startBitOffset)
+			bitCount += int(popcount(value[startByte] & firstByteMask))
+
+			// Handle all the middle ones
+			for i := startByte + 1; i < endByte; i++ {
+				bitCount += int(popcount(value[i]))
+			}
+
+			// Handle last byte
+			lastByteMask := byte(0xFF << (7 - endBitOffset))
+			bitCount += int(popcount(value[endByte] & lastByteMask))
+		}
+		return clientio.Encode(bitCount, true)
+	default:
+		return diceerrors.NewErrWithMessage(diceerrors.SyntaxErr)
 	}
-	return clientio.Encode(bitCount, true)
 }
 
 // BITOP <AND | OR | XOR | NOT> destkey key [key ...]

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2086,7 +2086,7 @@ func evalBITCOUNT(args []string, store *dstore.Store) []byte {
 	}
 
 	switch unit {
-	case "BYTE":
+	case BYTE:
 		if start < 0 {
 			start += valueLength
 		}
@@ -2102,7 +2102,7 @@ func evalBITCOUNT(args []string, store *dstore.Store) []byte {
 			bitCount += int(popcount(value[i]))
 		}
 		return clientio.Encode(bitCount, true)
-	case "BIT":
+	case BIT:
 		if start < 0 {
 			start += valueLength * 8
 		}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"math/bits"
 	"regexp"
 	"sort"
 	"strconv"
@@ -2099,7 +2100,7 @@ func evalBITCOUNT(args []string, store *dstore.Store) []byte {
 		end = min(end, valueLength-1)
 		bitCount := 0
 		for i := start; i <= end; i++ {
-			bitCount += int(popcount(value[i]))
+			bitCount += int(bits.OnesCount8(value[i]))
 		}
 		return clientio.Encode(bitCount, true)
 	case BIT:
@@ -2129,20 +2130,20 @@ func evalBITCOUNT(args []string, store *dstore.Store) []byte {
 		if startByte == endByte {
 			mask := byte(0xFF >> startBitOffset)
 			mask &= byte(0xFF << (7 - endBitOffset))
-			bitCount = int(popcount(value[startByte] & mask))
+			bitCount = int(bits.OnesCount8(value[startByte] & mask))
 		} else {
 			// Handle first byte
 			firstByteMask := byte(0xFF >> startBitOffset)
-			bitCount += int(popcount(value[startByte] & firstByteMask))
+			bitCount += int(bits.OnesCount8(value[startByte] & firstByteMask))
 
 			// Handle all the middle ones
 			for i := startByte + 1; i < endByte; i++ {
-				bitCount += int(popcount(value[i]))
+				bitCount += int(bits.OnesCount8(value[i]))
 			}
 
 			// Handle last byte
 			lastByteMask := byte(0xFF << (7 - endBitOffset))
-			bitCount += int(popcount(value[endByte] & lastByteMask))
+			bitCount += int(bits.OnesCount8(value[endByte] & lastByteMask))
 		}
 		return clientio.Encode(bitCount, true)
 	default:


### PR DESCRIPTION
This PR attempts to close #663 however I realised rewrite would be a better option. This passes all tests under tcl (only for bitcount) and all integration tests. While this also fixes other issues, I don't want to overstep.

I've added comments wherever necessary but can elaborate wherever necessary

What has changed?
* Added better argument validation
* Changed counting in a loop to count using a bitmask
* Added better handling of start and end indices.

@lucifercr07 as mentioned, this does fix the other bitcount issues, lmk what you think. I believe this is a better way to fix the errors (fixing a single test would've made it messier if you get what I mean)


Happy to change the approach just to fix the single test.