### PR TITLE
fix startup statement

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,7 +106,7 @@ func (s *AsyncServer) FindPortAndBind() (socketErr error) {
 		return err
 	}
 	s.logger.Info(
-		"DiceDB is running",
+		"DiceDB server is running",
 		slog.String("version", "0.0.4"),
 		slog.Int("port", config.DiceConfig.Server.Port),
 	)

--- a/main.go
+++ b/main.go
@@ -55,11 +55,11 @@ func main() {
 	// If not enabled multithreading, server will run on a single core.
 	var numCores int
 	if config.EnableMultiThreading {
-		logr.Debug("Running server in multi-threaded mode")
 		numCores = runtime.NumCPU()
+		logr.Info("The DiceDB server has started in multi-threaded mode.", slog.Int("number of cores", numCores))
 	} else {
-		logr.Debug("Running server in single-threaded mode")
 		numCores = 1
+		logr.Info("The DiceDB server has started in single-threaded mode.")
 	}
 
 	// The runtime.GOMAXPROCS(numCores) call limits the number of operating system


### PR DESCRIPTION
The startup statement related to multithreading has changed from debug to info with a more concise message. 