### PR TITLE
Fix: BITCOUNT no key provided

### DIFF
--- a/integration_tests/commands/async/bit_operation_test.go
+++ b/integration_tests/commands/async/bit_operation_test.go
@@ -133,6 +133,10 @@ func TestBitCount(t *testing.T) {
 			InCmds: []string{"BITCOUNT mykey 0 0"},
 			Out:    []interface{}{int64(1)},
 		},
+		{
+			InCmds: []string{"BITCOUNT"},
+			Out:    []interface{}{"ERR wrong number of arguments for 'bitcount' command"},
+		},
 	}
 
 	for _, tcase := range testcases {

--- a/integration_tests/commands/async/bit_operation_test.go
+++ b/integration_tests/commands/async/bit_operation_test.go
@@ -137,6 +137,14 @@ func TestBitCount(t *testing.T) {
 			InCmds: []string{"BITCOUNT"},
 			Out:    []interface{}{"ERR wrong number of arguments for 'bitcount' command"},
 		},
+		{
+			InCmds: []string{"BITCOUNT mykey"},
+			Out:    []interface{}{int64(1)},
+		},
+		{
+			InCmds: []string{"BITCOUNT mykey 0"},
+			Out:    []interface{}{"ERR syntax error"},
+		},
 	}
 
 	for _, tcase := range testcases {

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -465,9 +465,10 @@ var (
 		Eval: evalGETBIT,
 	}
 	bitCountCmdMeta = DiceCmdMeta{
-		Name: "BITCOUNT",
-		Info: "BITCOUNT counts the number of set bits in the string value stored at key",
-		Eval: evalBITCOUNT,
+		Name:  "BITCOUNT",
+		Info:  "BITCOUNT counts the number of set bits in the string value stored at key",
+		Eval:  evalBITCOUNT,
+		Arity: -1,
 	}
 	bitOpCmdMeta = DiceCmdMeta{
 		Name: "BITOP",

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2034,6 +2034,11 @@ func evalGETBIT(args []string, store *dstore.Store) []byte {
 func evalBITCOUNT(args []string, store *dstore.Store) []byte {
 	var err error
 
+	// if no key is provided, return error
+	if len(args) == 0 {
+		return diceerrors.NewErrArity("BITCOUNT")
+	}
+
 	// if more than 4 arguments are provided, return error
 	if len(args) > 4 {
 		return diceerrors.NewErrWithMessage(diceerrors.SyntaxErr)


### PR DESCRIPTION
## Description
This pull request addresses the issue where the `BITCOUNT` command in DiceDB was not validating that a key is passed along with the command leading to a runtime error in the server.
<img width="677" alt="Screenshot 2024-09-25 at 12 33 48 AM" src="https://github.com/user-attachments/assets/74ba4c1d-6d29-40e8-9637-35f8e173002a">

## Changes made:
 - Added Arity of -1 to the `BITCOUNT` command
 - Added a check for the number of arguments in the `BITCOUNT` command to ensure at least 1 argument is provided
 - The command returns an arity error when no argument is passed, consistent with Redis
 - Added integration tests to validate the number of arguments

## Output
<img width="578" alt="Screenshot 2024-09-25 at 12 25 02 AM" src="https://github.com/user-attachments/assets/998338b1-de48-453f-8072-9a525d9f48b8">

## Tests run
<img width="731" alt="Screenshot 2024-09-25 at 12 30 18 AM" src="https://github.com/user-attachments/assets/3c4f5f89-b9d7-4715-b265-d8f16e2df0b8">
