### PR TITLE
#741: Add integration tests for KEYS, MGET, MSET, JSON commands using HTTP

### DIFF
--- a/integration_tests/commands/http/json_arrpop_test.go
+++ b/integration_tests/commands/http/json_arrpop_test.go
@@ -1,0 +1,118 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/dicedb/dice/testutils"
+	testifyAssert "github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
+)
+
+func TestJSONARRPOP(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	arrayAtRoot := []interface{}{0, 1, 2, 3}
+	nestedArray := map[string]interface{}{"a": 2, "b": []interface{}{0, 1, 2, 3}}
+	arrayWithinArray := map[string]interface{}{"a": 2, "b": []interface{}{0, 1, 2, []interface{}{3, 4, 5}}}
+
+	testCases := []TestCase{
+		{
+			name: "update array at root path",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body:    map[string]interface{}{"key": "k", "path": "$", "json": arrayAtRoot},
+				},
+				{
+					Command: "JSON.ARRPOP",
+					Body:    map[string]interface{}{"key": "k", "path": "$", "index": "2"},
+				},
+				{
+					Command: "JSON.GET",
+					Body:    map[string]interface{}{"key": "k"},
+				},
+			},
+			expected: []interface{}{"OK", float64(2), "[0,1,3]"},
+		},
+		{
+			name: "update nested array",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body:    map[string]interface{}{"key": "k", "path": "$", "json": nestedArray},
+				},
+				{
+					Command: "JSON.ARRPOP",
+					Body:    map[string]interface{}{"key": "k", "path": "$.b", "index": "2"},
+				},
+				{
+					Command: "JSON.GET",
+					Body:    map[string]interface{}{"key": "k"},
+				},
+			},
+			expected: []interface{}{"OK", []interface{}{float64(2)}, `{"a":2,"b":[0,1,3]}`},
+		},
+		{
+			name: "update array with default index",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body:    map[string]interface{}{"key": "k", "path": "$", "json": arrayAtRoot},
+				},
+				{
+					Command: "JSON.ARRPOP",
+					Body:    map[string]interface{}{"key": "k", "path": "$"},
+				},
+				{
+					Command: "JSON.GET",
+					Body:    map[string]interface{}{"key": "k"},
+				},
+			},
+			expected: []interface{}{"OK", float64(3), "[0,1,2]"},
+		},
+		{
+			name: "update array within array",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body:    map[string]interface{}{"key": "k", "path": "$", "json": arrayWithinArray},
+				},
+				{
+					Command: "JSON.ARRPOP",
+					Body:    map[string]interface{}{"key": "k", "path": "$.b[3]", "index": "1"},
+				},
+				{
+					Command: "JSON.GET",
+					Body:    map[string]interface{}{"key": "k"},
+				},
+			},
+			expected: []interface{}{"OK", []interface{}{float64(4)}, `{"a":2,"b":[0,1,2,[3,5]]}`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+				jsonResult, isString := result.(string)
+
+				if isString && testutils.IsJSONResponse(jsonResult) {
+					testifyAssert.JSONEq(t, tc.expected[i].(string), jsonResult)
+					continue
+				}
+
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					assert.Assert(t, testutils.UnorderedEqual(slice, result))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{
+		Command: "DEL",
+		Body:    map[string]interface{}{"key": "k"},
+	})
+}

--- a/integration_tests/commands/http/json_arrpop_test.go
+++ b/integration_tests/commands/http/json_arrpop_test.go
@@ -88,6 +88,34 @@ func TestJSONARRPOP(t *testing.T) {
 			},
 			expected: []interface{}{"OK", []interface{}{float64(4)}, `{"a":2,"b":[0,1,2,[3,5]]}`},
 		},
+		{
+			name: "non-array path",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body:    map[string]interface{}{"key": "k", "path": "$", "json": nestedArray},
+				},
+				{
+					Command: "JSON.ARRPOP",
+					Body:    map[string]interface{}{"key": "k", "path": "$.a", "index": "1"},
+				},
+			},
+			expected: []interface{}{"OK", []interface{}{"(nil)"}},
+		},
+		{
+			name: "invalid json path",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body:    map[string]interface{}{"key": "k", "path": "$", "json": arrayAtRoot},
+				},
+				{
+					Command: "JSON.ARRPOP",
+					Body:    map[string]interface{}{"key": "k", "path": "$..invalid*path", "index": "1"},
+				},
+			},
+			expected: []interface{}{"OK", "ERR invalid JSONPath"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/integration_tests/commands/http/json_arrpop_test.go
+++ b/integration_tests/commands/http/json_arrpop_test.go
@@ -15,6 +15,12 @@ func TestJSONARRPOP(t *testing.T) {
 	nestedArray := map[string]interface{}{"a": 2, "b": []interface{}{0, 1, 2, 3}}
 	arrayWithinArray := map[string]interface{}{"a": 2, "b": []interface{}{0, 1, 2, []interface{}{3, 4, 5}}}
 
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{
+		Command: "DEL",
+		Body:    map[string]interface{}{"key": "k"},
+	})
+
 	testCases := []TestCase{
 		{
 			name: "update array at root path",

--- a/integration_tests/commands/http/json_test.go
+++ b/integration_tests/commands/http/json_test.go
@@ -1,0 +1,1340 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/dicedb/dice/testutils"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	testifyAssert "github.com/stretchr/testify/assert"
+
+	// testifyAssert "github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
+)
+
+func TestJSONOperations(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	simpleJsonString := `{"name":"John","age":30}`
+	nestedJsonString := `{"name":"Alice","address":{"city":"New York","zip":"10001"},"array":[1,2,3,4,5]}`
+	specialCharsJsonString := `{"key":"value with spaces","emoji":"😀"}`
+	unicodeJsonString := `{"unicode":"こんにちは世界"}`
+	escapedCharsJsonString := `{"escaped":"\"quoted\", \\backslash\\ and /forward/slash"}`
+	complexJsonString := `{"inventory":{"mountain_bikes":[{"id":"bike:1","model":"Phoebe","price":1920,"specs":{"material":"carbon","weight":13.1},"colors":["black","silver"]},{"id":"bike:2","model":"Quaoar","price":2072,"specs":{"material":"aluminium","weight":7.9},"colors":["black","white"]},{"id":"bike:3","model":"Weywot","price":3264,"specs":{"material":"alloy","weight":13.8}}],"commuter_bikes":[{"id":"bike:4","model":"Salacia","price":1475,"specs":{"material":"aluminium","weight":16.6},"colors":["black","silver"]},{"id":"bike:5","model":"Mimas","price":3941,"specs":{"material":"alloy","weight":11.6}}]}}`
+
+	var simpleJson map[string]interface{}
+	var nestedJson map[string]interface{}
+	var specialCharsJson map[string]interface{}
+	var unicodeJson map[string]interface{}
+	var escapedCharsJson map[string]interface{}
+	var complexJson map[string]interface{}
+
+	json.Unmarshal([]byte(simpleJsonString), &simpleJson)
+	json.Unmarshal([]byte(nestedJsonString), &nestedJson)
+	json.Unmarshal([]byte(specialCharsJsonString), &specialCharsJson)
+	json.Unmarshal([]byte(unicodeJsonString), &unicodeJson)
+	json.Unmarshal([]byte(escapedCharsJsonString), &escapedCharsJson)
+	json.Unmarshal([]byte(complexJsonString), &complexJson)
+
+	singleOrderedTestCases := []TestCase{
+		{
+			name: "Set and Get Integer",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "value": "2"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "2"},
+		},
+		{
+			name: "Set and Get Boolean True",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "value": true}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "true"},
+		},
+		{
+			name: "Set and Get Boolean False",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "value": false}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "false"},
+		},
+		{
+			name: "Set and Get Simple JSON",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": simpleJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", simpleJsonString},
+		},
+		{
+			name: "Set and Get Nested JSON",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": nestedJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", nestedJsonString},
+		},
+		{
+			name: "Set and Get JSON Array",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": []interface{}{0, 1, 2, 3, 4}}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", `[0,1,2,3,4]`},
+		},
+		{
+			name: "Set and Get JSON with Special Characters",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": specialCharsJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", specialCharsJsonString},
+		},
+		{
+			name: "Set Non-JSON Value",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "k1", "value": "1"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k1"}},
+			},
+			expected: []interface{}{"OK", "ERR Existing key has wrong Dice type"},
+		},
+		{
+			name: "Set Empty JSON Object",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{}}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", `{}`},
+		},
+		{
+			name: "Set Empty JSON Array",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": []interface{}{}}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", `[]`},
+		},
+		{
+			name: "Set JSON with Unicode",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": unicodeJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", unicodeJsonString},
+		},
+		{
+			name: "Set JSON with Escaped Characters",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": escapedCharsJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", escapedCharsJsonString},
+		},
+		{
+			name: "Set and Get Complex JSON",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": complexJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", complexJsonString},
+		},
+		{
+			name: "Get Nested Array",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": complexJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.inventory.mountain_bikes[*].model"}},
+			},
+			expected: []interface{}{"OK", `["Phoebe","Quaoar","Weywot"]`},
+		},
+		{
+			name: "Get Nested Object",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": complexJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.inventory.mountain_bikes[0].specs"}},
+			},
+			expected: []interface{}{"OK", `{"material":"carbon","weight":13.1}`},
+		},
+		{
+			name: "Set Nested Value",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$.inventory.mountain_bikes[0].price", "value": 2000}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.inventory.mountain_bikes[0].price"}},
+			},
+			expected: []interface{}{"OK", "2000"},
+		},
+	}
+
+	multipleOrderedTestCases := []TestCase{
+		{
+			name: "Get All Prices",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": complexJson}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$..price"}},
+			},
+			expected: []interface{}{"OK", []interface{}{1475.0, 3941.0, 1920.0, 2072.0, 3264.0}},
+		},
+		{
+			name: "Set Multiple Nested Values",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$.inventory.*[?(@.price<2000)].price", "value": 1500}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$..price"}},
+			},
+			expected: []interface{}{"OK", []interface{}{1500.0, 3941.0, 1500.0, 2072.0, 3264.0}},
+		},
+	}
+
+	t.Run("Single Ordered Test Cases", func(t *testing.T) {
+		for _, tc := range singleOrderedTestCases {
+			t.Run(tc.name, func(t *testing.T) {
+				for i, cmd := range tc.commands {
+					result, _ := exec.FireCommand(cmd)
+
+					if jsonResult, ok := result.(string); ok && testutils.IsJSONResponse(jsonResult) {
+						testifyAssert.JSONEq(t, tc.expected[i].(string), jsonResult)
+					} else {
+						assert.Equal(t, tc.expected[i], result)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("Multiple Ordered Test Cases", func(t *testing.T) {
+		for _, tc := range multipleOrderedTestCases {
+			t.Run(tc.name, func(t *testing.T) {
+				for i, cmd := range tc.commands {
+					result, _ := exec.FireCommand(cmd)
+
+					if jsonResult, ok := result.(string); ok && testutils.IsJSONResponse(jsonResult) {
+						var jsonPayload []interface{}
+						json.Unmarshal([]byte(jsonResult), &jsonPayload)
+						assert.Assert(t, testutils.UnorderedEqual(tc.expected[i], jsonPayload))
+					} else {
+						assert.DeepEqual(t, tc.expected[i], result)
+					}
+				}
+			})
+		}
+	})
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{
+		Command: "DEL",
+		Body: map[string]interface{}{
+			"keys": []interface{}{"k", "k1"},
+		},
+	})
+}
+
+func TestJSONSetWithInvalidCases(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	testCases := []TestCase{
+		{
+			name: "Set Invalid JSON",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "value": `{invalid:json}`}},
+			},
+			expected: []interface{}{"ERR invalid JSON"},
+		},
+		{
+			name: "Set JSON with Wrong Number of Arguments",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"ERR wrong number of arguments for 'json.set' command"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+				assert.Check(t, strings.HasPrefix(result.(string), tc.expected[i].(string)), fmt.Sprintf("Expected: %s, Got: %s", tc.expected[i], result))
+			}
+		})
+	}
+}
+
+func TestJSONSetWithNXAndXX(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	user1JsonString := `{"name": "John", "age": 30}`
+	user2JsonString := `{"name": "Rahul", "age": 28}`
+
+	var user1, user2 map[string]interface{}
+	json.Unmarshal([]byte(user1JsonString), &user1)
+	json.Unmarshal([]byte(user2JsonString), &user2)
+
+	testCases := []TestCase{
+		{
+			name: "Set with XX on non-existent key",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": user1, "xx": "true"}},
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": user2, "nx": "true"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"(nil)", "OK", user2JsonString},
+		},
+		{
+			name: "Set with NX on existing key",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": user1}},
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": user2, "nx": "true"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "(nil)", user1JsonString},
+		},
+		{
+			name: "Set with XX on existing key",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": user1}},
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": user2, "xx": "true"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "OK", user2JsonString},
+		},
+		{
+			name: "Set with NX on non-existent key",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": user1, "nx": "true"}},
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": user2, "nx": "true"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "(nil)", user1JsonString},
+		},
+		{
+			name: "Invalid combinations of NX and XX",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k1", "path": "$", "json": user1, "nx": "true", "xx": "true"}},
+			},
+			expected: []interface{}{"ERR syntax error"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+				jsonResult, isString := result.(string)
+				if isString && testutils.IsJSONResponse(jsonResult) {
+					testifyAssert.JSONEq(t, tc.expected[i].(string), jsonResult)
+				} else {
+					assert.Equal(t, tc.expected[i], result)
+				}
+			}
+
+			exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"keys": []interface{}{"k", "k1"}}})
+		})
+
+		// // Deleting the used keys
+		// exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"keys": []interface{}{"k", "k1"}}})
+	}
+}
+
+func TestJSONClearOperations(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	testCases := []TestCase{
+		{
+			name: "Clear root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"a": 1}}},
+				{Command: "JSON.CLEAR", Body: map[string]interface{}{"key": "k", "path": "$"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), "{}"},
+		},
+		{
+			name: "Clear string type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "Tom"}}},
+				{Command: "JSON.CLEAR", Body: map[string]interface{}{"key": "k", "path": "$.name"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.name"}},
+			},
+			expected: []interface{}{"OK", float64(0), `"Tom"`},
+		},
+		{
+			name: "Clear array type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"names": []interface{}{"Tom", "Jerry"}}}},
+				{Command: "JSON.CLEAR", Body: map[string]interface{}{"key": "k", "path": "$.names"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.names"}},
+			},
+			expected: []interface{}{"OK", float64(1), "[]"},
+		},
+		{
+			name: "clear bool type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"flag": true}}},
+				{Command: "JSON.CLEAR", Body: map[string]interface{}{"key": "k", "path": "$.flag"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.flag"}},
+			},
+			expected: []interface{}{"OK", float64(0), "true"},
+		},
+		{
+			name: "clear null type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": nil}}},
+				{Command: "JSON.CLEAR", Body: map[string]interface{}{"key": "k", "path": "$.name"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.name"}},
+			},
+			expected: []interface{}{"OK", float64(0), "null"},
+		},
+		{
+			name: "clear integer type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"age": 30}}},
+				{Command: "JSON.CLEAR", Body: map[string]interface{}{"key": "k", "path": "$.age"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.age"}},
+			},
+			expected: []interface{}{"OK", float64(1), "0"},
+		},
+		{
+			name: "clear float type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"price": 3.14}}},
+				{Command: "JSON.CLEAR", Body: map[string]interface{}{"key": "k", "path": "$.price"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$.price"}},
+			},
+			expected: []interface{}{"OK", float64(1), "0"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+				assert.Equal(t, tc.expected[i], result)
+			}
+		})
+
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"keys": []interface{}{"k", "k1"}}})
+}
+
+func TestJSONDelOperations(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	testCases := []TestCase{
+		{
+			name: "Delete root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "Rahul"}}},
+				{Command: "JSON.DEL", Body: map[string]interface{}{"key": "k", "path": "$"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), "(nil)"},
+		},
+		{
+			name: "Delete nested field",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "Tom", "address": map[string]interface{}{"city": "New York", "zip": "10001"}}}},
+				{Command: "JSON.DEL", Body: map[string]interface{}{"key": "k", "path": "$.address.city"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"name":"Tom","address":{"zip":"10001"}}`},
+		},
+		{
+			name: "del string type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"flag": true, "name": "Tom"}}},
+				{Command: "JSON.DEL", Body: map[string]interface{}{"key": "k", "path": "$.name"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"flag":true}`},
+		},
+		{
+			name: "del bool type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"flag": true, "name": "Tom"}}},
+				{Command: "JSON.DEL", Body: map[string]interface{}{"key": "k", "path": "$.flag"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"name":"Tom"}`},
+		},
+		{
+			name: "del null type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": nil, "age": 28}}},
+				{Command: "JSON.DEL", Body: map[string]interface{}{"key": "k", "path": "$.name"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"age":28}`},
+		},
+		{
+			name: "del array type",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body: map[string]interface{}{
+						"key":  "k",
+						"path": "$",
+						"json": map[string]interface{}{
+							"names":  []interface{}{"Rahul", "Tom"},
+							"bosses": map[string]interface{}{"names": []interface{}{"Jerry", "Rocky"}, "hobby": "swim"},
+						},
+					},
+				},
+				{Command: "JSON.DEL", Body: map[string]interface{}{"key": "k", "path": "$..names"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(2), `{"bosses":{"hobby":"swim"}}`},
+		},
+		{
+			name: "del integer type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "Tom", "age": 28}}},
+				{Command: "JSON.DEL", Body: map[string]interface{}{"key": "k", "path": "$.age"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"name":"Tom"}`},
+		},
+		{
+			name: "del float type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "sugar", "price": 3.14}}},
+				{Command: "JSON.DEL", Body: map[string]interface{}{"key": "k", "path": "$.price"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"name":"sugar"}`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+				jsonResult, isString := result.(string)
+				if isString && testutils.IsJSONResponse(jsonResult) {
+					testifyAssert.JSONEq(t, tc.expected[i].(string), jsonResult)
+				} else {
+					assert.Equal(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "k"}})
+}
+
+func TestJSONForgetOperations(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	testCases := []TestCase{
+		{
+			name: "forget root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "Rahul"}}},
+				{Command: "JSON.FORGET", Body: map[string]interface{}{"key": "k", "path": "$"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), "(nil)"},
+		},
+		{
+			name: "forget nested field",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "Tom", "address": map[string]interface{}{"city": "New York", "zip": "10001"}}}},
+				{Command: "JSON.FORGET", Body: map[string]interface{}{"key": "k", "path": "$.address.city"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"name":"Tom","address":{"zip":"10001"}}`},
+		},
+		{
+			name: "forget string type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"flag": true, "name": "Tom"}}},
+				{Command: "JSON.FORGET", Body: map[string]interface{}{"key": "k", "path": "$.name"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"flag":true}`},
+		},
+		{
+			name: "forget bool type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"flag": true, "name": "Tom"}}},
+				{Command: "JSON.FORGET", Body: map[string]interface{}{"key": "k", "path": "$.flag"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"name":"Tom"}`},
+		},
+		{
+			name: "forget null type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": nil, "age": 28}}},
+				{Command: "JSON.FORGET", Body: map[string]interface{}{"key": "k", "path": "$.name"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"age":28}`},
+		},
+		{
+			name: "forget array type",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body: map[string]interface{}{
+						"key":  "k",
+						"path": "$",
+						"json": map[string]interface{}{
+							"names":  []interface{}{"Rahul", "Tom"},
+							"bosses": map[string]interface{}{"names": []interface{}{"Jerry", "Rocky"}, "hobby": "swim"},
+						},
+					},
+				},
+				{Command: "JSON.FORGET", Body: map[string]interface{}{"key": "k", "path": "$..names"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(2), `{"bosses":{"hobby":"swim"}}`},
+		},
+		{
+			name: "forget integer type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "Tom", "age": 28}}},
+				{Command: "JSON.FORGET", Body: map[string]interface{}{"key": "k", "path": "$.age"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"name":"Tom"}`},
+		},
+		{
+			name: "forget float type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "sugar", "price": 3.14}}},
+				{Command: "JSON.FORGET", Body: map[string]interface{}{"key": "k", "path": "$.price"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", float64(1), `{"name":"sugar"}`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+				jsonResult, isString := result.(string)
+				if isString && testutils.IsJSONResponse(jsonResult) {
+					testifyAssert.JSONEq(t, tc.expected[i].(string), jsonResult)
+				} else {
+					assert.Equal(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "k"}})
+}
+
+func TestJsonStrlen(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	testCases := []TestCase{
+		{
+			name: "STRLEN with root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": []string{"hello", "world"}}},
+				{Command: "JSON.STRLEN", Body: map[string]interface{}{"key": "k", "path": "$"}},
+			},
+			expected: []interface{}{"OK", []interface{}{"(nil)"}},
+		},
+		{
+			name: "STRLEN nested",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": map[string]interface{}{"name": "jerry", "partner": map[string]interface{}{"name": "tom"}}}},
+				{Command: "JSON.STRLEN", Body: map[string]interface{}{"key": "k", "path": "$..name"}},
+			},
+			expected: []interface{}{"OK", []interface{}{float64(5), float64(3)}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				if stringResult, ok := result.(string); ok {
+					assert.Equal(t, tc.expected[i], stringResult)
+				} else {
+					assert.Assert(t, testutils.UnorderedEqual(tc.expected[i], result.([]interface{})))
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "k"}})
+}
+
+func TestJSONMGET(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	setupData := map[string]string{
+		"xx":   `["hehhhe","hello"]`,
+		"yy":   `{"name":"jerry","partner":{"name":"jerry","language":["rust"]},"partner2":{"language":["rust"]}}`,
+		"zz":   `{"name":"tom","partner":{"name":"tom","language":["rust"]},"partner2":{"age":12,"language":["rust"]}}`,
+		"doc1": `{"a":1,"b":2,"nested":{"a":3},"c":null}`,
+		"doc2": `{"a":4,"b":5,"nested":{"a":6},"c":null}`,
+	}
+
+	for key, value := range setupData {
+		var jsonPayload interface{}
+		json.Unmarshal([]byte(value), &jsonPayload)
+		resp, _ := exec.FireCommand(HTTPCommand{
+			Command: "JSON.SET",
+			Body: map[string]interface{}{
+				"key":  key,
+				"path": "$",
+				"json": jsonPayload,
+			},
+		})
+		assert.Equal(t, "OK", resp)
+	}
+
+	testCases := []TestCase{
+		{
+			name: "MGET with root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.MGET", Body: map[string]interface{}{"keys": []interface{}{"xx", "yy", "zz"}, "path": "$"}},
+			},
+			expected: []interface{}{[]interface{}{setupData["xx"], setupData["yy"], setupData["zz"]}},
+		},
+		{
+			name: "MGET with specific path",
+			commands: []HTTPCommand{
+				{Command: "JSON.MGET", Body: map[string]interface{}{"keys": []interface{}{"xx", "yy", "zz"}, "path": "$.name"}},
+			},
+			expected: []interface{}{[]interface{}{"(nil)", `"jerry"`, `"tom"`}},
+		},
+		{
+			name: "MGET with nested path",
+			commands: []HTTPCommand{
+				{Command: "JSON.MGET", Body: map[string]interface{}{"keys": []interface{}{"xx", "yy", "zz"}, "path": "$.partner2.age"}},
+			},
+			expected: []interface{}{[]interface{}{"(nil)", "(nil)", "12"}},
+		},
+		{
+			name: "MGET error",
+			commands: []HTTPCommand{
+				{Command: "JSON.MGET", Body: map[string]interface{}{"path": ""}},
+			},
+			expected: []interface{}{"ERR wrong number of arguments for 'json.mget' command"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+				results, ok := result.([]interface{})
+				if ok {
+					expectedResults := tc.expected[i].([]interface{})
+					assert.Equal(t, len(expectedResults), len(results))
+
+					for j := range results {
+						if testutils.IsJSONResponse(expectedResults[j].(string)) {
+							testifyAssert.JSONEq(t, expectedResults[j].(string), results[j].(string))
+						} else {
+							assert.Equal(t, expectedResults[j], results[j])
+						}
+					}
+				} else {
+					assert.Equal(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	t.Run("MGET with recursive path", func(t *testing.T) {
+		result, _ := exec.FireCommand(HTTPCommand{Command: "JSON.MGET", Body: map[string]interface{}{"keys": []interface{}{"doc1", "doc2"}, "path": "$..a"}})
+		results, ok := result.([]interface{})
+		assert.Assert(t, ok, "Expected result to be a slice of interface{}")
+		expectedResults := [][]int{{1, 3}, {4, 6}}
+		assert.Equal(t, len(expectedResults), len(results), "Expected 2 results")
+
+		for i, result := range results {
+			testutils.UnorderedEqual(expectedResults[i], result)
+		}
+	})
+
+	// Deleting the used keys
+	for key, _ := range setupData {
+		exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": key}})
+	}
+}
+
+func TestJsonARRAPPEND(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	a := []int{1, 2}
+	b := map[string]interface{}{
+		"name":     "jerry",
+		"partner":  map[string]interface{}{"name": "tom", "score": []int{10}},
+		"partner2": map[string]interface{}{"score": []int{10, 20}},
+	}
+	c := map[string]interface{}{
+		"name":     []string{"jerry"},
+		"partner":  map[string]interface{}{"name": "tom", "score": []int{10}},
+		"partner2": map[string]interface{}{"name": 12, "score": "rust"},
+	}
+
+	testCases := []TestCase{
+		{
+			name: "JSON.ARRAPPEND with root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.ARRAPPEND", Body: map[string]interface{}{"key": "k", "path": "$", "value": 3}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{3.0}, `[1,2,3]`},
+		},
+		{
+			name: "JSON.ARRAPPEND nested",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": b}},
+				{Command: "JSON.ARRAPPEND", Body: map[string]interface{}{"key": "k", "path": "$..score", "value": 10}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{2.0, 3.0}, `{"name":"jerry","partner":{"name":"tom","score":[10,10]},"partner2":{"score":[10,20,10]}}`},
+		},
+		{
+			name: "JSON.ARRAPPEND nested with nil",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": c}},
+				{Command: "JSON.ARRAPPEND", Body: map[string]interface{}{"key": "k", "path": "$..score", "value": 10}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{2.0, "(nil)"}, `{"name":["jerry"],"partner":{"name":"tom","score":[10,10]},"partner2":{"name":12,"score":"rust"}}`},
+		},
+		{
+			name: "JSON.ARRAPPEND with different datatypes",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": c}},
+				{Command: "JSON.ARRAPPEND", Body: map[string]interface{}{"key": "k", "path": "$.name", "value": 1}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{2.0}, `{"name":["jerry", 1],"partner":{"name":"tom","score":[10]},"partner2":{"name":12,"score":"rust"}}`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				// because the order of keys is not guaranteed, we need to check if the result is an array
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					assert.Assert(t, testutils.UnorderedEqual(slice, result))
+				} else if testutils.IsJSONResponse(tc.expected[i].(string)) {
+					testifyAssert.JSONEq(t, tc.expected[i].(string), result.(string))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "k"}})
+}
+
+func TestJsonNummultby(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	a := map[string]interface{}{
+		"a": "b",
+		"b": []interface{}{
+			map[string]interface{}{"a": 2},
+			map[string]interface{}{"a": 5},
+			map[string]interface{}{"a": "c"},
+		},
+	}
+	invalidArgMessage := "ERR wrong number of arguments for 'json.nummultby' command"
+
+	testCases := []TestCase{
+		{
+			name: "Invalid number of arguments",
+			commands: []HTTPCommand{
+				{Command: "JSON.NUMMULTBY", Body: map[string]interface{}{"key": "k"}},
+				{Command: "JSON.NUMMULTBY", Body: map[string]interface{}{"path": "$"}},
+				{Command: "JSON.NUMMULTBY", Body: map[string]interface{}{"value": "k"}},
+			},
+			expected: []interface{}{invalidArgMessage, invalidArgMessage, invalidArgMessage},
+		},
+		{
+			name: "MultBy at non-existent key",
+			commands: []HTTPCommand{
+				{Command: "JSON.NUMMULTBY", Body: map[string]interface{}{"key": "k", "path": "$", "value": 1}},
+			},
+			expected: []interface{}{"ERR could not perform this operation on a key that doesn't exist"},
+		},
+		{
+			name: "Invalid value of multiplier on non-existent key",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.NUMMULTBY", Body: map[string]interface{}{"key": "k", "path": "$.fe", "value": "a"}},
+			},
+			expected: []interface{}{"OK", "[]"},
+		},
+		{
+			name: "Invalid value of multiplier on existent key",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.NUMMULTBY", Body: map[string]interface{}{"key": "k", "path": "$.a", "value": "a"}},
+			},
+			expected: []interface{}{"OK", "ERR expected value at line 1 column 1"},
+		},
+		{
+			name: "MultBy at recursive path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.NUMMULTBY", Body: map[string]interface{}{"key": "k", "path": "$..a", "value": 2}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$"}},
+			},
+			expected: []interface{}{"OK", []interface{}{4.0, 10.0, nil, nil}, `{"a":"b","b":[{"a":4},{"a":10},{"a":"c"}]}`},
+		},
+		{
+			name: "MultBy at root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.NUMMULTBY", Body: map[string]interface{}{"key": "k", "path": "$.a", "value": 2}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$"}},
+			},
+			expected: []interface{}{"OK", []interface{}{nil}, `{"a":"b","b":[{"a":2},{"a":5},{"a":"c"}]}`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					var resultPayload []interface{}
+					sonic.UnmarshalString(result.(string), &resultPayload)
+					assert.Assert(t, testutils.UnorderedEqual(slice, resultPayload))
+				} else if testutils.IsJSONResponse(tc.expected[i].(string)) {
+					testifyAssert.JSONEq(t, tc.expected[i].(string), result.(string))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "k"}})
+}
+
+func TestJsonObjLen(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	setupData := map[string]string{
+		"a": `{"name":"jerry","partner":{"name":"tom","language":["rust"]}}`,
+		"b": `{"name":"jerry","partner":{"name":"tom","language":["rust"]},"partner2":{"name":"spike","language":["go","rust"]}}`,
+		"c": `{"name":"jerry","partner":{"name":"tom","language":["rust"]},"partner2":{"name":12,"language":["rust"]}}`,
+		"d": `["this","is","an","array"]`,
+	}
+
+	for key, value := range setupData {
+		var jsonPayload interface{}
+		json.Unmarshal([]byte(value), &jsonPayload)
+		resp, _ := exec.FireCommand(HTTPCommand{
+			Command: "JSON.SET",
+			Body: map[string]interface{}{
+				"key":  key,
+				"path": "$",
+				"json": jsonPayload,
+			},
+		})
+		assert.Equal(t, resp, "OK")
+	}
+
+	testCases := []TestCase{
+		{
+			name: "JSON.OBJLEN with root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "a", "path": "$"}},
+			},
+			expected: []interface{}{[]interface{}{2.0}},
+		},
+		{
+			name: "JSON.OBJLEN with nested path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "b", "path": "$.partner"}},
+			},
+			expected: []interface{}{[]interface{}{2.0}},
+		},
+		{
+			name: "JSON.OBJLEN with non-object path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "d", "path": "$"}},
+			},
+			expected: []interface{}{[]interface{}{"(nil)"}},
+		},
+		{
+			name: "JSON.OBJLEN with nested non-object path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "c", "path": "$.partner2.name"}},
+			},
+			expected: []interface{}{[]interface{}{"(nil)"}},
+		},
+		{
+			name: "JSON.OBJLEN nested objects",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "b", "path": "$..language"}},
+			},
+			expected: []interface{}{[]interface{}{"(nil)", "(nil)"}},
+		},
+		{
+			name: "JSON.OBJLEN invalid json path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "b", "path": "$..language*something"}},
+			},
+			expected: []interface{}{"ERR parse error at 13 in $..language*something"},
+		},
+		{
+			name: "JSON.OBJLEN with non-existant key",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "non_existing_key", "path": "$"}},
+			},
+			expected: []interface{}{"(nil)"},
+		},
+		{
+			name: "JSON.OBJLEN with empty path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "a"}},
+			},
+			expected: []interface{}{2.0},
+		},
+		{
+			name: "JSON.OBJLEN invalid json path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "c", "path": "$[1"}},
+			},
+			expected: []interface{}{"ERR expected a number at 4 in $[1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					assert.Assert(t, testutils.UnorderedEqual(slice, result))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	for key, _ := range setupData {
+		exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": key}})
+	}
+}
+
+func TestJSONNumIncrBy(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	invalidArgMessage := "ERR wrong number of arguments for 'json.numincrby' command"
+
+	testCases := []TestCase{
+		{
+			name: "Invalid number of arguments",
+			commands: []HTTPCommand{
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"key": "k"}},
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"path": "$"}},
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"value": "k"}},
+			},
+			expected: []interface{}{invalidArgMessage, invalidArgMessage, invalidArgMessage},
+		},
+		{
+			name: "Non-existant key",
+			commands: []HTTPCommand{
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"key": "non_existant_key", "path": "$", "value": 1}},
+			},
+			expected: []interface{}{"ERR could not perform this operation on a key that doesn't exist"},
+		},
+		{
+			name: "Invalid value of increment",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "value": 1}},
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"key": "k", "path": "$", "value": "@"}},
+			},
+			expected: []interface{}{"OK", "ERR expected value at line 1 column 1"},
+		},
+		{
+			name: "incrby at non root path",
+			commands: []HTTPCommand{
+				{
+					Command: "JSON.SET",
+					Body: map[string]interface{}{
+						"key":  "k",
+						"path": "$",
+						"json": map[string]interface{}{
+							"a": "b",
+							"b": []interface{}{
+								map[string]interface{}{"a": 2.2},
+								map[string]interface{}{"a": 5},
+								map[string]interface{}{"a": "c"},
+							},
+						},
+					},
+				},
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"key": "k", "path": "$..a", "value": 2}},
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"key": "k", "path": "$.a", "value": 2}},
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"key": "k", "path": "$..a", "value": -1}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$"}},
+			},
+			expected: []interface{}{"OK", []interface{}{nil, 4.2, 7.0, nil}, []interface{}{nil}, []interface{}{nil, 3.2, 6.0, nil}, `{"a":"b","b":[{"a":3.2},{"a":6},{"a":"c"}]}`},
+		},
+		{
+			name: "incrby at root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "value": 1}},
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"key": "k", "path": "$", "value": 2}},
+				{Command: "JSON.NUMINCRBY", Body: map[string]interface{}{"key": "k", "path": "$", "value": -1}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k", "path": "$"}},
+			},
+			expected: []interface{}{"OK", []interface{}{3.0}, []interface{}{2.0}, "2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					var resultPayload []interface{}
+					sonic.UnmarshalString(result.(string), &resultPayload)
+					assert.Assert(t, testutils.UnorderedEqual(slice, resultPayload))
+				} else if testutils.IsJSONResponse(tc.expected[i].(string)) {
+					testifyAssert.JSONEq(t, tc.expected[i].(string), result.(string))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "k"}})
+}
+
+func TestJsonARRINSERT(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	a := []interface{}{1, 2}
+	b := map[string]interface{}{
+		"name":     "tom",
+		"score":    []interface{}{10, 20},
+		"partner2": map[string]interface{}{"score": []interface{}{10, 20}},
+	}
+
+	testCases := []TestCase{
+		{
+			name: "JSON.ARRINSERT index out if bounds",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.ARRINSERT", Body: map[string]interface{}{"key": "k", "path": "$", "index": 4, "value": 3}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "ERR index out of bounds", "[1,2]"},
+		},
+		{
+			name: "JSON.ARRINSERT index is not integer",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.ARRINSERT", Body: map[string]interface{}{"key": "k", "path": "$", "index": "ss", "value": 3}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "ERR Couldn't parse as integer", "[1,2]"},
+		},
+		{
+			name: "JSON.ARRINSERT with postive index in root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.ARRINSERT", Body: map[string]interface{}{"key": "k", "path": "$", "index": 2, "values": []int{3, 4, 5}}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{5.0}, "[1,2,3,4,5]"},
+		},
+		{
+			name: "JSON.ARRINSERT with negative index in root path",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": a}},
+				{Command: "JSON.ARRINSERT", Body: map[string]interface{}{"key": "k", "path": "$", "index": -2, "values": []int{3, 4, 5}}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{5.0}, "[3,4,5,1,2]"},
+		},
+		{
+			name: "JSON.ARRINSERT nested with postive index",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": b}},
+				{Command: "JSON.ARRINSERT", Body: map[string]interface{}{"key": "k", "path": "$..score", "index": 1, "values": []interface{}{5, 6, true}}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{5.0, 5.0}, `{"name":"tom","score":[10,5,6,true,20],"partner2":{"score":[10,5,6,true,20]}}`},
+		},
+		{
+			name: "JSON.ARRINSERT nested with negative index",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "json": b}},
+				{Command: "JSON.ARRINSERT", Body: map[string]interface{}{"key": "k", "path": "$..score", "index": -2, "values": []interface{}{5, 6, true}}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{5.0, 5.0}, `{"name":"tom","score":[5,6,true,10,20],"partner2":{"score":[5,6,true,10,20]}}`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				// because the order of keys is not guaranteed, we need to check if the result is an array
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					assert.Assert(t, testutils.UnorderedEqual(slice, result))
+				} else if testutils.IsJSONResponse(tc.expected[i].(string)) {
+					testifyAssert.JSONEq(t, tc.expected[i].(string), result.(string))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "k"}})
+}
+
+func TestJsonObjKeys(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	setupData := map[string]string{
+		"a": `{"name":"jerry","partner":{"name":"tom","language":["rust"]},"partner2":{"language":["rust"]}}`,
+		"b": `{"name":"jerry","partner":{"name":"tom","language":["rust"]},"partner2":{"name":12,"language":["rust"]}}`,
+		"c": `{"name":"jerry","partner":{"name":"tom","language":["rust"]},"partner2":{"name":12,"language":["rust"],"extra_key":"value"}}`,
+		"d": `{"a":[3],"nested":{"a":{"b":2,"c":1}}}`,
+	}
+
+	for key, value := range setupData {
+		var jsonPayload interface{}
+		json.Unmarshal([]byte(value), &jsonPayload)
+		resp, _ := exec.FireCommand(HTTPCommand{
+			Command: "JSON.SET",
+			Body: map[string]interface{}{
+				"key":  key,
+				"path": "$",
+				"json": jsonPayload,
+			},
+		})
+		assert.Equal(t, resp, "OK")
+	}
+
+	testCases := []TestCase{
+		{
+			name: "JSON.OBJKEYS root object",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "a", "path": "$"}},
+			},
+			expected: []interface{}{
+				[]interface{}{[]interface{}{"name", "partner", "partner2"}},
+			},
+		},
+		{
+			name: "JSON.OBJKEYS with nested path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "b", "path": "$.partner"}},
+			},
+			expected: []interface{}{
+				[]interface{}{[]interface{}{"name", "language"}},
+			},
+		},
+		{
+			name: "JSON.OBJKEYS with non-object path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "c", "path": "$.name"}},
+			},
+			expected: []interface{}{[]interface{}{"(nil)"}},
+		},
+		{
+			name: "JSON.OBJKEYS with nested non-object path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "b", "path": "$.partner.language"}},
+			},
+			expected: []interface{}{[]interface{}{"(nil)"}},
+		},
+		{
+			name: "JSON.OBJKEYS with invalid json path - 1",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "b", "path": "$..invalidpath*somethingrandomadded"}},
+			},
+			expected: []interface{}{"ERR parse error at 16 in $..invalidpath*somethingrandomadded"},
+		},
+		{
+			name: "JSON.OBJKEYS with invalid json path - 2",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "c", "path": "$[1"}},
+			},
+			expected: []interface{}{"ERR expected a number at 4 in $[1"},
+		},
+		{
+			name: "JSON.OBJKEYS with invalid json path - 3",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "c", "path": "$[random"}},
+			},
+			expected: []interface{}{"ERR parse error at 3 in $[random"},
+		},
+		{
+			name: "JSON.OBJKEYS with only key",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "a"}},
+			},
+			expected: []interface{}{
+				[]interface{}{[]interface{}{"name", "partner", "partner2"}},
+			},
+		},
+		{
+			name: "JSON.OBJKEYS with non-existing key",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "thisdoesnotexist"}},
+			},
+			expected: []interface{}{"ERR could not perform this operation on a key that doesn't exist"},
+		},
+		{
+			name: "JSON.OBJKEYS with multiple json path",
+			commands: []HTTPCommand{
+				{Command: "JSON.OBJKEYS", Body: map[string]interface{}{"key": "d", "path": "$..a"}},
+			},
+			expected: []interface{}{
+				[]interface{}{
+					[]interface{}{"b", "c"},
+					"(nil)",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					assert.DeepEqual(t, slice, tc.expected[i], cmpopts.SortSlices(func(a, b interface{}) bool {
+						return fmt.Sprintf("%v", a) < fmt.Sprintf("%v", b)
+					}))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	for key, _ := range setupData {
+		exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": key}})
+	}
+}

--- a/integration_tests/commands/http/json_test.go
+++ b/integration_tests/commands/http/json_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	testifyAssert "github.com/stretchr/testify/assert"
 
-	// testifyAssert "github.com/stretchr/testify/assert"
 	"gotest.tools/v3/assert"
 )
 

--- a/integration_tests/commands/http/keys_test.go
+++ b/integration_tests/commands/http/keys_test.go
@@ -1,0 +1,92 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/dicedb/dice/testutils"
+	"gotest.tools/v3/assert"
+)
+
+func TestKeys(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	testCases := []TestCase{
+		{
+			name: "k matches with k",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "k", "value": "v1"}},
+				{Command: "KEYS", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", []interface{}{"k"}},
+		},
+		{
+			name: "g* matches good and great",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "good", "value": "v"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "great", "value": "v"}},
+				{Command: "KEYS", Body: map[string]interface{}{"key": "g*"}},
+			},
+			expected: []interface{}{"OK", "OK", []interface{}{"good", "great"}},
+		},
+		{
+			name: "g?od matches good",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "good", "value": "v"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "great", "value": "v"}},
+				{Command: "KEYS", Body: map[string]interface{}{"key": "g?od"}},
+			},
+			expected: []interface{}{"OK", "OK", []interface{}{"good"}},
+		},
+		{
+			name: "g?eat matches great",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "good", "value": "v"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "great", "value": "v"}},
+				{Command: "KEYS", Body: map[string]interface{}{"key": "g?eat"}},
+			},
+			expected: []interface{}{"OK", "OK", []interface{}{"great"}},
+		},
+		{
+			name: "h[^e]llo matches hallo and hbllo",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "hallo", "value": "v"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "hbllo", "value": "v"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "hello", "value": "v"}},
+				{Command: "KEYS", Body: map[string]interface{}{"key": "h[^e]llo"}},
+			},
+			expected: []interface{}{"OK", "OK", "OK", []interface{}{"hallo", "hbllo"}},
+		},
+		{
+			name: "h[a-b]llo matches hallo and hbllo",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "hallo", "value": "v"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "hbllo", "value": "v"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "hello", "value": "v"}},
+				{Command: "KEYS", Body: map[string]interface{}{"key": "h[a-b]llo"}},
+			},
+			expected: []interface{}{"OK", "OK", "OK", []interface{}{"hallo", "hbllo"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				// because the order of keys is not guaranteed, we need to check if the result is an array
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					assert.Assert(t, testutils.UnorderedEqual(slice, result))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{
+		Command: "DEL",
+		Body: map[string]interface{}{
+			"keys": []interface{}{"k", "good", "great", "hallo", "hbllo", "hello"},
+		},
+	})
+}

--- a/integration_tests/commands/http/mget_test.go
+++ b/integration_tests/commands/http/mget_test.go
@@ -1,0 +1,72 @@
+package http
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dicedb/dice/testutils"
+	"gotest.tools/v3/assert"
+)
+
+func TestMGET(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	exec.FireCommand(HTTPCommand{
+		Command: "DEL",
+		Body: map[string]interface{}{
+			"keys": []interface{}{"k1", "k2"},
+		},
+	})
+
+	testCases := []TestCase{
+		{
+			name: "MGET With non-existing keys",
+			commands: []HTTPCommand{
+				{Command: "MGET", Body: map[string]interface{}{"keys": []interface{}{"k1", "k2"}}},
+			},
+			expected: []interface{}{[]interface{}{"(nil)", "(nil)"}},
+		},
+		{
+			name: "MGET With existing keys",
+			commands: []HTTPCommand{
+				{
+					Command: "MSET",
+					Body:    map[string]interface{}{"key_values": map[string]interface{}{"k1": "v1", "k2": "v2"}},
+				},
+				{Command: "MGET", Body: map[string]interface{}{"keys": []interface{}{"k1", "k2"}}},
+			},
+			expected: []interface{}{"OK", []interface{}{"v1", "v2"}},
+		},
+		{
+			name: "MGET with existing and non existing keys",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "k1", "value": "v1"}},
+				{Command: "MGET", Body: map[string]interface{}{"keys": []interface{}{"k1", "k3"}}},
+			},
+			expected: []interface{}{"OK", []interface{}{"v1", "(nil)"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				fmt.Println(result)
+				// because the order of keys is not guaranteed, we need to check if the result is an array
+				if slice, ok := tc.expected[i].([]interface{}); ok {
+					assert.Assert(t, testutils.UnorderedEqual(slice, result))
+				} else {
+					assert.DeepEqual(t, tc.expected[i], result)
+				}
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{
+		Command: "DEL",
+		Body: map[string]interface{}{
+			"keys": []interface{}{"k1", "k2"},
+		},
+	})
+}

--- a/integration_tests/commands/http/mset_test.go
+++ b/integration_tests/commands/http/mset_test.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMSET(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	testCases := []TestCase{
+		{
+			name: "MSET with one key-value pair",
+			commands: []HTTPCommand{
+				{Command: "MSET", Body: map[string]interface{}{"key_values": map[string]interface{}{"k1": "v1"}}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k1"}},
+			},
+			expected: []interface{}{"OK", "v1"},
+		},
+		{
+			name: "MSET with multiple key-value pairs",
+			commands: []HTTPCommand{
+				{Command: "MSET", Body: map[string]interface{}{"key_values": map[string]interface{}{"k1": "v1", "k2": "v2"}}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k1"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k2"}},
+			},
+			expected: []interface{}{"OK", "v1", "v2"},
+		},
+		{
+			name: "MSET with integers arguments",
+			commands: []HTTPCommand{
+				{Command: "MSET", Body: map[string]interface{}{"key_values": map[string]interface{}{"k1": 12345, "k2": 12345}}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k1"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k2"}},
+			},
+			expected: []interface{}{"OK", float64(12345), float64(12345)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec.FireCommand(HTTPCommand{
+				Command: "DEL",
+				Body:    map[string]interface{}{"keys": []interface{}{"k1"}},
+			})
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				assert.DeepEqual(t, tc.expected[i], result)
+			}
+		})
+	}
+
+	// Deleting the used keys
+	exec.FireCommand(HTTPCommand{
+		Command: "DEL",
+		Body: map[string]interface{}{
+			"keys": []interface{}{"k1", "k2"},
+		},
+	})
+}

--- a/internal/server/utils/redisCmdAdapter.go
+++ b/internal/server/utils/redisCmdAdapter.go
@@ -30,6 +30,7 @@ const (
 	Member      = "member"
 	Members     = "members"
 	Index       = "index"
+	Json        = "json"
 )
 
 func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
@@ -72,6 +73,8 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 				Keys,
 				Field,
 				Path,
+				Json,
+				Index,
 				Value,
 				Values,
 				Seconds,
@@ -82,7 +85,6 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 				Offset,
 				Member,
 				Members,
-				Index,
 			}
 			for _, key := range priorityKeys {
 				if val, exists := jsonBody[key]; exists {
@@ -90,6 +92,15 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 						for _, v := range val.([]interface{}) {
 							args = append(args, fmt.Sprintf("%v", v))
 						}
+						delete(jsonBody, key)
+						continue
+					}
+					if key == Json {
+						jsonValue, err := json.Marshal(val)
+						if err != nil {
+							return nil, err
+						}
+						args = append(args, string(jsonValue))
 						delete(jsonBody, key)
 						continue
 					}

--- a/internal/server/utils/redisCmdAdapter.go
+++ b/internal/server/utils/redisCmdAdapter.go
@@ -29,6 +29,7 @@ const (
 	Offset      = "offset"
 	Member      = "member"
 	Members     = "members"
+	Index       = "index"
 )
 
 func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
@@ -81,6 +82,7 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 				Offset,
 				Member,
 				Members,
+				Index,
 			}
 			for _, key := range priorityKeys {
 				if val, exists := jsonBody[key]; exists {

--- a/internal/server/utils/redisCmdAdapter.go
+++ b/internal/server/utils/redisCmdAdapter.go
@@ -30,7 +30,7 @@ const (
 	Member      = "member"
 	Members     = "members"
 	Index       = "index"
-	Json        = "json"
+	JSON        = "json"
 )
 
 func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
@@ -73,7 +73,7 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 				Keys,
 				Field,
 				Path,
-				Json,
+				JSON,
 				Index,
 				Value,
 				Values,
@@ -95,7 +95,7 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 						delete(jsonBody, key)
 						continue
 					}
-					if key == Json {
+					if key == JSON {
 						jsonValue, err := json.Marshal(val)
 						if err != nil {
 							return nil, err

--- a/internal/server/utils/redisCmdAdapter_test.go
+++ b/internal/server/utils/redisCmdAdapter_test.go
@@ -162,6 +162,14 @@ func TestParseHTTPRequest(t *testing.T) {
 			expectedCmd:  "QWATCH",
 			expectedArgs: []string{"SELECT $key, $value WHERE $key LIKE \"player:*\" AND \"$value.score\" > 10 ORDER BY $value.score DESC LIMIT 5"},
 		},
+		{
+			name:         "Test JSON.ARRPOP command",
+			method:       "POST",
+			url:          "/json.arrpop",
+			body:         `{"key": "k1", "path": "$", "index": 1}`,
+			expectedCmd:  "JSON.ARRPOP",
+			expectedArgs: []string{"k1", "$", "1"},
+		},
 	}
 
 	for _, tc := range commands {


### PR DESCRIPTION
Fixes #741

- Added integration tests for KEYS, MGET, MSET, JSON commands using HTTP
- Added `json` and `index` to priorityKeys at [redisCmdAdapter.go](https://github.com/DiceDB/dice/blob/master/internal/server/utils/redisCmdAdapter.go#L76). `index` was added to support commands with index in the arguments. `json` was added to support `JSON.SET`  with `nx` and `xx` flag, as `json` needs to be parsed before those flags. 