### PR TITLE
#738: Added Http Integration Tests: Create tests to support for GET, GETDEL, GETEX, GETSET commands

### DIFF
--- a/integration_tests/commands/http/get_test.go
+++ b/integration_tests/commands/http/get_test.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGet(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	testCases := []struct {
+		name     string
+		commands []HTTPCommand
+		expected []interface{}
+		delays   []time.Duration
+	}{
+		{
+			name: "Get with expiration",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "k", "value": "v", "ex": 4}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k"}},
+				{Command: "SLEEP", Body: map[string]interface{}{"key": 5}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "v", "OK", "(nil)"},
+			delays:   []time.Duration{0, 0, 5 * time.Second, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, _ := exec.FireCommand(cmd)
+				assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}

--- a/integration_tests/commands/http/getdel_test.go
+++ b/integration_tests/commands/http/getdel_test.go
@@ -1,0 +1,108 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGetDel(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	testCases := []struct {
+		name     string
+		commands []HTTPCommand
+		expected []interface{}
+		delays   []time.Duration
+	}{
+		{
+			name: "GetDel",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "k", "value": "v"}},
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "k"}},
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "k"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "v", "(nil)", "(nil)"},
+			delays:   []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "GetDel with expiration, checking if key exist and is already expired",
+			commands: []HTTPCommand{
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "k"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "k", "value": "v", "ex": 2}},
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"(nil)", "OK", "(nil)"},
+			delays:   []time.Duration{0, 0, 3 * time.Second},
+		},
+		{
+			name: "GetDel with expiration, checking if key exist and is not yet expired",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "k", "value": "v", "ex": 40}},
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "v"},
+			delays:   []time.Duration{0, 2 * time.Second},
+		},
+		{
+			name: "GetDel with invalid command",
+			commands: []HTTPCommand{
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "k", "value": "v"}},
+			},
+			expected: []interface{}{
+				"ERR wrong number of arguments for 'getdel' command",
+			},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "Getdel with value created from Setbit",
+			commands: []HTTPCommand{
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "k", "offset": 1, "value": 1}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k"}},
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "k"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{float64(0), "@", "@", "(nil)"},
+			delays:   []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "GetDel with Set object should return wrong type error",
+			commands: []HTTPCommand{
+				{Command: "SADD", Body: map[string]interface{}{"key": "myset", "member": "member1"}},
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "myset"}},
+			},
+			expected: []interface{}{float64(1), "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays:   []time.Duration{0, 0},
+		},
+		{
+			name: "GetDel with JSON object should return wrong type error",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "k", "path": "$", "value": 1}},
+				{Command: "GETDEL", Body: map[string]interface{}{"key": "k"}},
+				{Command: "JSON.GET", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value", "1"},
+			delays:   []time.Duration{0, 0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "k"}})
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, err := exec.FireCommand(cmd)
+				if err != nil {
+					// Check if the error message matches the expected result
+					assert.Equal(t, tc.expected[i], err.Error(), "Error message mismatch for cmd %s", cmd)
+				} else {
+					assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s, expected %v, got %v", cmd, tc.expected[i], result)
+				}
+			}
+		})
+	}
+}

--- a/integration_tests/commands/http/getex_test.go
+++ b/integration_tests/commands/http/getex_test.go
@@ -1,0 +1,271 @@
+package http
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGetEx(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	Etime5 := strconv.FormatInt(time.Now().Unix()+5, 10)
+	Etime10 := strconv.FormatInt(time.Now().Unix()+10, 10)
+
+	testCases := []struct {
+		name        string
+		commands    []HTTPCommand
+		expected    []interface{}
+		assert_type []string
+		delay       []time.Duration
+	}{
+		{
+			name: "GetEx Simple Value",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", "bar", float64(-1)},
+			assert_type: []string{"equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "GetEx Non-Existent Key",
+			commands: []HTTPCommand{
+				{Command: "GETEX", Body: map[string]interface{}{"key": "nonexistent"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "nonexistent"}},
+			},
+			expected:    []interface{}{"(nil)", float64(-2)},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name: "GetEx with EX option",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "ex": 2}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(-1), "bar", float64(2), "(nil)", float64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 2 * time.Second, 0},
+		},
+		{
+			name: "GetEx with PX option",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "px": 2000}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(-1), "bar", float64(2), "(nil)", float64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 2 * time.Second, 0},
+		},
+
+		{
+			name: "GetEx with EX option and invalid value",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "ex": -1}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(-1), "ERR invalid expire time in 'getex' command", float64(-1), "bar", float64(-1)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with PX option and invalid value",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "px": -1}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(-1), "ERR invalid expire time in 'getex' command", float64(-1), "bar", float64(-1)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with EXAT option",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "exat": Etime5}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(-1), "bar", float64(5), "(nil)", float64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 5 * time.Second, 0},
+		},
+		{
+			name: "GetEx with PXAT option",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "pxat": Etime10 + "000"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(-1), "bar", float64(10), "(nil)", float64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 10 * time.Second, 0},
+		},
+		{
+			name: "GetEx with EXAT option and invalid value",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "exat": 123123}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(-1), "bar", "(nil)", float64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with PXAT option and invalid value",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "pxat": 123123}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(-1), "bar", "(nil)", float64(-2)},
+			assert_type: []string{"equal", "equal", "equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with PERSIST option",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar", "ex": 10}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "persist": true}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", float64(10), "bar", float64(-1)},
+			assert_type: []string{"equal", "assert", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with multiple expiry options",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "ex": 2, "px": 123123}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "ERR syntax error", float64(-1), "bar"},
+			assert_type: []string{"equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with persist and ex options",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "ex": 2}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "persist": true, "ex": 2}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(2), "ERR syntax error", float64(2)},
+			assert_type: []string{"equal", "equal", "assert", "equal", "assert"},
+			delay:       []time.Duration{0, 0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with persist and px options",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "foo", "value": "bar"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "px": 2000}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "foo", "px": 2000, "persist": true}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "foo"}},
+			},
+			expected:    []interface{}{"OK", "bar", float64(2), "ERR syntax error", float64(2)},
+			assert_type: []string{"equal", "equal", "assert", "equal", "assert"},
+			delay:       []time.Duration{0, 0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with key holding JSON type",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "KEY", "path": "$", "value": "1"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "KEY"}},
+			},
+			expected:    []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+		{
+			name: "GetEx with key holding JSON type with multiple set commands",
+			commands: []HTTPCommand{
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "MJSONKEY", "path": "$", "value": "{\"a\":2}"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "MJSONKEY"}},
+				{Command: "JSON.SET", Body: map[string]interface{}{"key": "MJSONKEY", "path": "$.a", "value": "3"}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "MJSONKEY"}},
+			},
+			expected: []interface{}{
+				"OK",
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+				"OK",
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+			},
+			assert_type: []string{"equal", "equal", "equal", "equal"},
+			delay:       []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "GetEx with key holding SET type",
+			commands: []HTTPCommand{
+				{Command: "SADD", Body: map[string]interface{}{"key": "SKEY", "members": []interface{}{1, 2, 3}}},
+				{Command: "GETEX", Body: map[string]interface{}{"key": "SKEY"}},
+			},
+			expected:    []interface{}{float64(3), "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			assert_type: []string{"equal", "equal"},
+			delay:       []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"key": "foo"}})
+
+			for i, cmd := range tc.commands {
+				if tc.delay[i] > 0 {
+					time.Sleep(tc.delay[i])
+				}
+				result, err := exec.FireCommand(cmd)
+				assert.NilError(t, err)
+				if tc.assert_type[i] == "equal" {
+					assert.DeepEqual(t, tc.expected[i], result)
+				} else if tc.assert_type[i] == "assert" {
+					assert.Assert(t, result.(float64) <= tc.expected[i].(float64), "Expected %v to be less than or equal to %v", result, tc.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/integration_tests/commands/http/getset_test.go
+++ b/integration_tests/commands/http/getset_test.go
@@ -1,0 +1,71 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGetSet(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	testCases := []struct {
+		name     string
+		commands []HTTPCommand
+		expected []interface{}
+		delays   []time.Duration
+	}{
+		{
+			name: "GETSET with INCR",
+			commands: []HTTPCommand{
+				{Command: "INCR", Body: map[string]interface{}{"key": "mycounter"}},
+				{Command: "GETSET", Body: map[string]interface{}{"key": "mycounter", "value": "0"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "mycounter"}},
+			},
+			expected: []interface{}{float64(1), float64(1), float64(0)},
+			delays:   []time.Duration{0, 0, 0},
+		},
+		{
+			name: "GETSET with SET",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "mykey", "value": "Hello"}},
+				{Command: "GETSET", Body: map[string]interface{}{"key": "mykey", "value": "world"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "mykey"}},
+			},
+			expected: []interface{}{"OK", "Hello", "world"},
+			delays:   []time.Duration{0, 0, 0},
+		},
+		{
+			name: "GETSET with TTL",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "k", "value": "v", "ex": 60}},
+				{Command: "GETSET", Body: map[string]interface{}{"key": "k", "value": "v1"}},
+				{Command: "TTL", Body: map[string]interface{}{"key": "k"}},
+			},
+			expected: []interface{}{"OK", "v", float64(-1)},
+			delays:   []time.Duration{0, 0, 0},
+		},
+		{
+			name: "GETSET error when key exists but does not hold a string value",
+			commands: []HTTPCommand{
+				{Command: "LPUSH", Body: map[string]interface{}{"key": "k1", "value": "val"}},
+				{Command: "GETSET", Body: map[string]interface{}{"key": "k1", "value": "v1"}},
+			},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays:   []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for i, cmd := range tc.commands {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, _ := exec.FireCommand(cmd)
+				assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}

--- a/internal/server/utils/redisCmdAdapter.go
+++ b/internal/server/utils/redisCmdAdapter.go
@@ -25,6 +25,9 @@ const (
 	KeyValues   = "key_values"
 	True        = "true"
 	QwatchQuery = "query"
+	Offset      = "offset"
+	Member      = "member"
+	Members     = "members"
 )
 
 func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
@@ -62,7 +65,7 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 
 			// Define keys to exclude and process their values first
 			// Update as we support more commands
-			var priorityKeys = [11]string{
+			var priorityKeys = []string{
 				Key,
 				Keys,
 				Field,
@@ -74,6 +77,9 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 				Password,
 				KeyValues,
 				QwatchQuery,
+				Offset,
+				Member,
+				Members,
 			}
 			for _, key := range priorityKeys {
 				if val, exists := jsonBody[key]; exists {
@@ -96,6 +102,13 @@ func ParseHTTPRequest(r *http.Request) (*cmd.RedisCmd, error) {
 						// Handle KeyValues separately
 						for k, v := range val.(map[string]interface{}) {
 							args = append(args, k, fmt.Sprintf("%v", v))
+						}
+						delete(jsonBody, key)
+						continue
+					}
+					if key == Members {
+						for _, v := range val.([]interface{}) {
+							args = append(args, fmt.Sprintf("%v", v))
 						}
 						delete(jsonBody, key)
 						continue


### PR DESCRIPTION
FIxes #738 

### Description

This pull request adds the Http Integration Tests for GET, GETDEL, GETEX, GETSET commands.
