### PR TITLE
feat - JSON.ARRINDEX

### DIFF
--- a/integration_tests/commands/async/json_arrindex_test.go
+++ b/integration_tests/commands/async/json_arrindex_test.go
@@ -1,0 +1,97 @@
+package async
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestJSONARRINDEX(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	normalArray := `[0,1,2,3,4,3]`
+	nestedArray := `{"arrays":[{"arr":[1,2,3]},{"arr":[2,3,4]},{"arr":[1]}]}`
+
+	tests := []struct {
+		name     string
+		commands []string
+		expected []interface{}
+	}{
+		{
+			name:     "should return error if key is not present",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex nonExistentKey $ 3"},
+			expected: []interface{}{"OK", "ERR object with key does not exist"},
+		},
+		{
+			name:     "should return error if json path is invalid",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $invalid_path 3"},
+			expected: []interface{}{"OK", "ERR invalid JSONPath"},
+		},
+		{
+			name:     "should return error if provided path does not have any data",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $.some_path 3"},
+			expected: []interface{}{"OK", []interface{}{}},
+		},
+		{
+			name:     "should return error if invalid start index provided",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $ 3 abc"},
+			expected: []interface{}{"OK", "ERR invalid start index"},
+		},
+		{
+			name:     "should return empty list if invalid stop index provided",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $ 3 4 abc"},
+			expected: []interface{}{"OK", "ERR invalid stop index"},
+		},
+		{
+			name:     "should return array index when given element is present",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $ 3"},
+			expected: []interface{}{"OK", []interface{}{int64(3)}},
+		},
+		{
+			name:     "should return -1 when given element is not present",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $ 10"},
+			expected: []interface{}{"OK", []interface{}{int64(-1)}},
+		},
+		{
+			name:     "should return array index with start optional param provided",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $ 3 4"},
+			expected: []interface{}{"OK", []interface{}{int64(5)}},
+		},
+		{
+			name:     "should return array index with start and stop optional param provided",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $ 3 4 5"},
+			expected: []interface{}{"OK", []interface{}{int64(5)}},
+		},
+		{
+			name:     "should return -1 with start and stop optional param provided where start > stop",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $ 3 2 1"},
+			expected: []interface{}{"OK", []interface{}{int64(-1)}},
+		},
+		{
+			name:     "should return -1 with start (out of boud) and stop (out of bound) optional param provided",
+			commands: []string{"json.set key $ " + normalArray, "json.arrindex key $ 3 6 10"},
+			expected: []interface{}{"OK", []interface{}{int64(-1)}},
+		},
+		{
+			name:     "should return list of array indexes for nested json",
+			commands: []string{"json.set key $ " + nestedArray, "json.arrindex key $.arrays.*.arr 3"},
+			expected: []interface{}{"OK", []interface{}{int64(2), int64(1), int64(-1)}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			FireCommand(conn, "DEL nonExistentKey")
+			FireCommand(conn, "DEL key")
+
+			for i, cmd := range tc.commands {
+				result := FireCommand(conn, cmd)
+				expected := tc.expected[i]
+
+				if !reflect.DeepEqual(result, expected) {
+					t.Fatalf("Assertion failed: the expected value is different than result: %s", tc.name)
+				}
+			}
+		})
+	}
+}

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -858,6 +858,14 @@ var (
 		Arity:    -2,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	jsonArrIndexCmdMeta = DiceCmdMeta{
+		Name: "JSON.ARRINDEX",
+		Info: `JSON.ARRINDEX key path value [start [stop]]
+		Search for the first occurrence of a JSON value in an array`,
+		Eval:     evalJSONARRINDEX,
+		Arity:    -3,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	hlenCmdMeta = DiceCmdMeta{
 		Name: "HLEN",
 		Info: `HLEN key
@@ -951,6 +959,7 @@ func init() {
 	DiceCmds["JSON.ARRPOP"] = jsonarrpopCmdMeta
 	DiceCmds["JSON.INGEST"] = jsoningestCmdMeta
 	DiceCmds["JSON.ARRINSERT"] = jsonarrinsertCmdMeta
+	DiceCmds["JSON.ARRINDEX"] = jsonArrIndexCmdMeta
 	DiceCmds["TTL"] = ttlCmdMeta
 	DiceCmds["DEL"] = delCmdMeta
 	DiceCmds["EXPIRE"] = expireCmdMeta

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -4191,6 +4191,107 @@ func evalHRANDFIELD(args []string, store *dstore.Store) []byte {
 	return selectRandomFields(hashMap, count, withValues)
 }
 
+func evalJSONARRINDEX(args []string, store *dstore.Store) []byte {
+	if len(args) < 3 || len(args) > 5 {
+		return diceerrors.NewErrArity("JSONARRINDEX")
+	}
+
+	key := args[0]
+	path := args[1]
+	start := 0
+	stop := 0
+
+	var value interface{}
+	var err error
+
+	if strings.Contains(args[2], `"`) {
+		// user has provided string argument
+		value = args[2]
+	} else {
+		// parse it to float since default arg type would be string
+		value, err = strconv.ParseFloat(args[2], 64)
+
+		if err != nil {
+			return diceerrors.NewErrWithMessage("invalid value provided")
+		}
+	}
+
+	// Convert start to integer if provided
+	if len(args) >= 4 {
+		var err error
+		start, err = strconv.Atoi(args[3])
+		if err != nil {
+			return diceerrors.NewErrWithMessage("invalid start index")
+		}
+	}
+
+	// Convert stop to integer if provided
+	if len(args) == 5 {
+		var err error
+		stop, err = strconv.Atoi(args[4])
+		if err != nil {
+			return diceerrors.NewErrWithMessage("invalid stop index")
+		}
+	}
+
+	obj := store.Get(key)
+	if obj == nil {
+		return diceerrors.NewErrWithMessage("object with key does not exist")
+	}
+
+	jsonData := obj.Value
+
+	// Check if the value stored is JSON type
+	_, err = sonic.Marshal(jsonData)
+	if err != nil {
+		return diceerrors.NewErrWithMessage("existing key has wrong Dice type")
+	}
+
+	// Check if the path specified is valid
+	expr, err := jp.ParseString(path)
+	if err != nil {
+		return diceerrors.NewErrWithMessage("invalid JSONPath")
+	}
+
+	results := expr.Get(jsonData)
+	arrIndexList := make([]interface{}, 0, len(results))
+
+	for _, result := range results {
+		switch utils.GetJSONFieldType(result) {
+		case utils.ArrayType:
+			elementFound := false
+			arr := result.([]interface{})
+
+			// stop 0 means end of the array
+			if stop > 0 && start > stop {
+				arrIndexList = append(arrIndexList, -1)
+				continue
+			}
+
+			// Ensure stop is within bounds
+			if stop == 0 || stop >= len(arr) {
+				stop = len(arr) - 1
+			}
+
+			for i := start; i <= stop; i++ {
+				if arr[i] == value {
+					arrIndexList = append(arrIndexList, i)
+					elementFound = true
+					break
+				}
+			}
+
+			if !elementFound {
+				arrIndexList = append(arrIndexList, -1)
+			}
+		default:
+			arrIndexList = append(arrIndexList, nil)
+		}
+	}
+
+	return clientio.Encode(arrIndexList, false)
+}
+
 // selectRandomFields returns random fields from a hashmap.
 func selectRandomFields(hashMap HashMap, count int, withValues bool) []byte {
 	keys := make([]string, 0, len(hashMap))


### PR DESCRIPTION
This PR adds support for `JSON.ARRINDEX`

https://redis.io/docs/latest/commands/json.arrindex/#:~:text=ARRINDEX%20returns%20an%20array%20of,see%20Redis%20serialization%20protocol%20specification.

closes: https://github.com/DiceDB/dice/issues/486