### PR TITLE
#490: feat:add support for command [JSON.ARRTRIM]

### DIFF
--- a/integration_tests/commands/async/json_test.go
+++ b/integration_tests/commands/async/json_test.go
@@ -1302,6 +1302,9 @@ func TestJsonARRTRIM(t *testing.T) {
 	a := `[0,1,2]`
 	b := `{"connection":{"wireless":true,"names":[0,1,2,3,4]},"names":[0,1,2,3,4]}`
 
+        FireCommand(conn, "DEL a b")
+        defer FireCommand(conn, "DEL a b")
+
 	testCases := []struct {
 		name       string
 		commands   []string

--- a/integration_tests/commands/async/json_test.go
+++ b/integration_tests/commands/async/json_test.go
@@ -1312,7 +1312,7 @@ func TestJsonARRTRIM(t *testing.T) {
 			name:       "JSON.ARRTRIM not array",
 			commands:   []string{"JSON.SET b $ " + b, `JSON.ARRTRIM b $ 0 10`, "JSON.GET b"},
 			expected:   []interface{}{"OK", []interface{}{"(nil)"}, b},
-			assertType: []string{"equal", "equal", "jsoneq"},
+			assertType: []string{"equal", "deep_equal", "jsoneq"},
 		},
 		{
 			name:       "JSON.ARRTRIM stop index out of bounds",

--- a/integration_tests/commands/async/json_test.go
+++ b/integration_tests/commands/async/json_test.go
@@ -1302,8 +1302,8 @@ func TestJsonARRTRIM(t *testing.T) {
 	a := `[0,1,2]`
 	b := `{"connection":{"wireless":true,"names":[0,1,2,3,4]},"names":[0,1,2,3,4]}`
 
-        FireCommand(conn, "DEL a b")
-        defer FireCommand(conn, "DEL a b")
+	FireCommand(conn, "DEL a b")
+	defer FireCommand(conn, "DEL a b")
 
 	testCases := []struct {
 		name       string

--- a/integration_tests/commands/async/json_test.go
+++ b/integration_tests/commands/async/json_test.go
@@ -1119,7 +1119,7 @@ func TestJsonARRINSERT(t *testing.T) {
 		assertType []string
 	}{
 		{
-			name:       "JSON.ARRINSERT index out if bounds",
+			name:       "JSON.ARRINSERT index out of bounds",
 			commands:   []string{"json.set a $ " + a, `JSON.ARRINSERT a $ 4 3`, "JSON.GET a"},
 			expected:   []interface{}{"OK", "ERR index out of bounds", "[1,2]"},
 			assertType: []string{"equal", "equal", "equal"},
@@ -1295,4 +1295,83 @@ func TestJsonObjKeys(t *testing.T) {
 		})
 	}
 
+}
+func TestJsonARRTRIM(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+	a := `[0,1,2]`
+	b := `{"connection":{"wireless":true,"names":[0,1,2,3,4]},"names":[0,1,2,3,4]}`
+
+	testCases := []struct {
+		name       string
+		commands   []string
+		expected   []interface{}
+		assertType []string
+	}{
+		{
+			name:       "JSON.ARRTRIM not array",
+			commands:   []string{"JSON.SET b $ " + b, `JSON.ARRTRIM b $ 0 10`, "JSON.GET b"},
+			expected:   []interface{}{"OK", []interface{}{"(nil)"}, b},
+			assertType: []string{"equal", "equal", "jsoneq"},
+		},
+		{
+			name:       "JSON.ARRTRIM stop index out of bounds",
+			commands:   []string{"JSON.SET a $ " + a, `JSON.ARRTRIM a $ -10 10`, "JSON.GET a"},
+			expected:   []interface{}{"OK", []interface{}{int64(3)}, "[0,1,2]"},
+			assertType: []string{"equal", "deep_equal", "equal"},
+		},
+		{
+			name:       "JSON.ARRTRIM start&stop are postive",
+			commands:   []string{"JSON.SET a $ " + a, `JSON.ARRTRIM a $ 1 2`, "JSON.GET a"},
+			expected:   []interface{}{"OK", []interface{}{int64(2)}, "[1,2]"},
+			assertType: []string{"equal", "deep_equal", "equal"},
+		},
+		{
+			name:       "JSON.ARRTRIM start&stop are negative",
+			commands:   []string{"JSON.SET a $ " + a, `JSON.ARRTRIM a $ -2 -1 `, "JSON.GET a"},
+			expected:   []interface{}{"OK", []interface{}{int64(2)}, "[1,2]"},
+			assertType: []string{"equal", "deep_equal", "equal"},
+		},
+
+		{
+			name:       "JSON.ARRTRIM subpath trim",
+			commands:   []string{"JSON.SET b $ " + b, `JSON.ARRTRIM b $..names 1 4`, "JSON.GET b"},
+			expected:   []interface{}{"OK", []interface{}{int64(4), int64(4)}, `{"connection":{"wireless":true,"names":[1,2,3,4]},"names":[1,2,3,4]}`},
+			assertType: []string{"equal", "deep_equal", "jsoneq"},
+		},
+		{
+			name:       "JSON.ARRTRIM subpath not array",
+			commands:   []string{"JSON.SET b $ " + b, `JSON.ARRTRIM b $.connection 0 1`, "JSON.GET b"},
+			expected:   []interface{}{"OK", []interface{}{"(nil)"}, b},
+			assertType: []string{"equal", "deep_equal", "jsoneq"},
+		},
+		{
+			name:       "JSON.ARRTRIM postive start larger than stop",
+			commands:   []string{"JSON.SET b $ " + b, `JSON.ARRTRIM b $.names 3 1`, "JSON.GET b"},
+			expected:   []interface{}{"OK", []interface{}{int64(0)}, `{"names":[],"connection":{"wireless":true,"names":[0,1,2,3,4]}}`},
+			assertType: []string{"equal", "deep_equal", "jsoneq"},
+		},
+		{
+			name:       "JSON.ARRTRIM negative start larger than stop",
+			commands:   []string{"JSON.SET b $ " + b, `JSON.ARRTRIM b $.names -1 -3`, "JSON.GET b"},
+			expected:   []interface{}{"OK", []interface{}{int64(0)}, `{"names":[],"connection":{"wireless":true,"names":[0,1,2,3,4]}}`},
+			assertType: []string{"equal", "deep_equal", "jsoneq"},
+		},
+	}
+	for _, tcase := range testCases {
+		t.Run(tcase.name, func(t *testing.T) {
+			for i := 0; i < len(tcase.commands); i++ {
+				cmd := tcase.commands[i]
+				out := tcase.expected[i]
+				result := FireCommand(conn, cmd)
+				if tcase.assertType[i] == "equal" {
+					assert.Equal(t, out, result)
+				} else if tcase.assertType[i] == "deep_equal" {
+					assert.Assert(t, arraysArePermutations(out.([]interface{}), result.([]interface{})))
+				} else if tcase.assertType[i] == "jsoneq" {
+					testifyAssert.JSONEq(t, out.(string), result.(string))
+				}
+			}
+		})
+	}
 }

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -288,6 +288,17 @@ var (
 		Arity:    -5,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	jsonarrtrimCmdMeta = DiceCmdMeta{
+		Name: "JSON.ARRTRIM",
+		Info: `JSON.ARRTRIM key path start stop
+		Trim an array so that it contains only the specified inclusive range of elements
+		Returns an array of integer replies for each path.
+		Returns error response if the key doesn't exist or key is expired.
+		Error reply: If the number of arguments is incorrect.`,
+		Eval:     evalJSONARRTRIM,
+		Arity:    -5,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 	ttlCmdMeta = DiceCmdMeta{
 		Name: "TTL",
 		Info: `TTL returns Time-to-Live in secs for the queried key in args
@@ -973,6 +984,7 @@ func init() {
 	DiceCmds["JSON.ARRPOP"] = jsonarrpopCmdMeta
 	DiceCmds["JSON.INGEST"] = jsoningestCmdMeta
 	DiceCmds["JSON.ARRINSERT"] = jsonarrinsertCmdMeta
+	DiceCmds["JSON.ARRTRIM"] = jsonarrtrimCmdMeta
 	DiceCmds["TTL"] = ttlCmdMeta
 	DiceCmds["DEL"] = delCmdMeta
 	DiceCmds["EXPIRE"] = expireCmdMeta

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -2160,7 +2160,7 @@ func testEvalHVALS(t *testing.T, store *dstore.Store) {
 				field1 := "mock_field_name_1"
 				newMap := make(HashMap)
 				newMap[field] = "mock_field_value"
-				newMap[field1] = "mock_field_value_1"
+				newMap[field1] = "mock_field_value"
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2171,7 +2171,7 @@ func testEvalHVALS(t *testing.T, store *dstore.Store) {
 				store.Put(key, obj)
 			},
 			input:  []string{"KEY_MOCK"},
-			output: clientio.Encode([]string{"mock_field_value", "mock_field_value_1"}, false),
+			output: clientio.Encode([]string{"mock_field_value", "mock_field_value"}, false),
 		},
 	}
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -2157,10 +2157,8 @@ func testEvalHVALS(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				field1 := "mock_field_name_1"
 				newMap := make(HashMap)
 				newMap[field] = "mock_field_value"
-				newMap[field1] = "mock_field_value"
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2171,7 +2169,7 @@ func testEvalHVALS(t *testing.T, store *dstore.Store) {
 				store.Put(key, obj)
 			},
 			input:  []string{"KEY_MOCK"},
-			output: clientio.Encode([]string{"mock_field_value", "mock_field_value"}, false),
+			output: clientio.Encode([]string{"mock_field_value"}, false),
 		},
 	}
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -49,6 +49,7 @@ func TestEval(t *testing.T) {
 	testEvalGET(t, store)
 	testEvalGETEX(t, store)
 	testEvalDebug(t, store)
+	testEvalJSONARRTRIM(t, store)
 	testEvalJSONARRINSERT(t, store)
 	testEvalJSONARRPOP(t, store)
 	testEvalJSONARRLEN(t, store)
@@ -655,6 +656,137 @@ func testEvalEXPIREAT(t *testing.T, store *dstore.Store) {
 	}
 
 	runEvalTests(t, tests, evalEXPIREAT, store)
+}
+
+func testEvalJSONARRTRIM(t *testing.T, store *dstore.Store) {
+	tests := map[string]evalTestCase{
+		"nil value": {
+			setup:  func() {},
+			input:  nil,
+			output: []byte("-ERR wrong number of arguments for 'json.arrtrim' command\r\n"),
+		},
+		"key does not exist": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":2}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"NONEXISTENT_KEY", "$.a", "0", "1"},
+			output: []byte("-ERR could not perform this operation on a key that doesn't exist\r\n"),
+		},
+		"index is not integer": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":2}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$", "a", "1"},
+			output: []byte("-ERR Couldn't parse as integer\r\n"),
+		},
+		"index out of bounds": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "[1,2,3]"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$", "0", "10"},
+			output: []byte("*1\r\n:3\r\n"),
+		},
+		"root path is not array": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"a\":2}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.a", "0", "6"},
+			output: []byte("*1\r\n$-1\r\n"),
+		},
+		"root path is array": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "[1,2,3,4,5]"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$", "1", "3"},
+			output: []byte("*1\r\n:3\r\n"),
+		},
+		"subpath array": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"connection\":{\"wireless\":true,\"names\":[0,1,2,3,4]},\"names\":[0,1,2,3,4]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.names", "1", "3"},
+			output: []byte("*1\r\n:3\r\n"),
+		},
+		"subpath two array": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"connection\":{\"wireless\":true,\"names\":[0,1,2,3,4]},\"names\":[0,1,2,3,4]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$..names", "1", "3"},
+			output: []byte("*2\r\n:3\r\n:3\r\n"),
+		},
+		"subpath not array": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"connection\":{\"wireless\":true,\"names\":[0,1,2,3,4]},\"names\":[0,1,2,3,4]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.connection", "1", "2"},
+			output: []byte("*1\r\n$-1\r\n"),
+		},
+		"subpath array index negative": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"connection\":{\"wireless\":true,\"names\":[0,1,2,3,4]},\"names\":[0,1,2,3,4]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.names", "-3", "-1"},
+			output: []byte("*1\r\n:3\r\n"),
+		},
+		"index negative start larger than stop": {
+			setup: func() {
+				key := "EXISTING_KEY"
+				value := "{\"connection\":{\"wireless\":true,\"names\":[0,1,2,3,4]},\"names\":[0,1,2,3,4]}"
+				var rootData interface{}
+				_ = sonic.Unmarshal([]byte(value), &rootData)
+				obj := store.NewObj(rootData, -1, object.ObjTypeJSON, object.ObjEncodingJSON)
+				store.Put(key, obj)
+			},
+			input:  []string{"EXISTING_KEY", "$.names", "-1", "-3"},
+			output: []byte("*1\r\n:0\r\n"),
+		},
+	}
+	runEvalTests(t, tests, evalJSONARRTRIM, store)
 }
 
 func testEvalJSONARRINSERT(t *testing.T, store *dstore.Store) {


### PR DESCRIPTION
hello:
this pr is link issue: #490 

feature: add support for command [JSON.ARRTRIM] including integration test. refer to [redis.arrtrim](https://redis.io/docs/latest/commands/json.arrtrim/)


In redis. the JSON.ARRTRIM act as below:

`

    127.0.0.1:6379> JSON.SET user $ '{"connection":{"wireless":true,"names":["a","b","c","d","e"]},"price":99.98,"stock":25,"colors":["black","silver"],"names":[0,1,2,3,4,5,6]}'
    OK
    127.0.0.1:6379> JSON.ARRTRIM user $ a 3
    (error) Couldn't parse as integer
    127.0.0.1:6379> JSON.ARRTRIM user123 $ 0 3
    (error) ERR could not perform this operation on a key that doesn't exist
    127.0.0.1:6379> JSON.ARRTRIM user $.names 1 4
    1) (integer) 4
    127.0.0.1:6379> JSON.GET user
    "{\"connection\":{\"wireless\":true,\"names\":[\"a\",\"b\",\"c\",\"d\",\"e\"]},\"price\":99.98,\"stock\":25,\"colors\":[\"black\",\"silver\"],\"names\":[1,2,3,4]}"
    127.0.0.1:6379> JSON.SET user $ '{"connection":{"wireless":true,"names":["a","b","c","d","e"]},"price":99.98,"stock":25,"colors":["black","silver"],"names":[0,1,2,3,4,5,6]}'
    OK
    127.0.0.1:6379> JSON.ARRTRIM user $..names 1 4
    1) (integer) 4
    2) (integer) 4
    127.0.0.1:6379> JSON.GET user
    "{\"connection\":{\"wireless\":true,\"names\":[\"b\",\"c\",\"d\",\"e\"]},\"price\":99.98,\"stock\":25,\"colors\":[\"black\",\"silver\"],\"names\":[1,2,3,4]}"
    127.0.0.1:6379> JSON.SET user $ '{"connection":{"wireless":true,"names":["a","b","c","d","e"]},"price":99.98,"stock":25,"colors":["black","silver"],"names":[0,1,2,3,4,5,6]}'
    OK
    127.0.0.1:6379> JSON.ARRTRIM user $.names -4 -1
    1) (integer) 4
    127.0.0.1:6379> JSON.GET user
    "{\"connection\":{\"wireless\":true,\"names\":[\"a\",\"b\",\"c\",\"d\",\"e\"]},\"price\":99.98,\"stock\":25,\"colors\":[\"black\",\"silver\"],\"names\":[3,4,5,6]}"
    127.0.0.1:6379> JSON.ARRTRIM user $.names 1 100
    1) (integer) 3
    127.0.0.1:6379> JSON.GET user
    "{\"connection\":{\"wireless\":true,\"names\":[\"a\",\"b\",\"c\",\"d\",\"e\"]},\"price\":99.98,\"stock\":25,\"colors\":[\"black\",\"silver\"],\"names\":[4,5,6]}"
    127.0.0.1:6379> JSON.ARRTRIM user $.names -3 -2
    1) (integer) 2
    127.0.0.1:6379> JSON.GET user
    "{\"connection\":{\"wireless\":true,\"names\":[\"a\",\"b\",\"c\",\"d\",\"e\"]},\"price\":99.98,\"stock\":25,\"colors\":[\"black\",\"silver\"],\"names\":[4,5]}"
    127.0.0.1:6379> JSON.ARRTRIM user $.names 4 2
    1) (integer) 0
    127.0.0.1:6379> JSON.GET user
    "{\"connection\":{\"wireless\":true,\"names\":[\"a\",\"b\",\"c\",\"d\",\"e\"]},\"price\":99.98,\"stock\":25,\"colors\":[\"black\",\"silver\"],\"names\":[]}"
    127.0.0.1:6379> JSON.SET user $ [1,2,3,4,5]
    OK
    127.0.0.1:6379> JSON.ARRTRIM user $ 2 4
    1) (integer) 3
    127.0.0.1:6379> JSON.GET user
    "[3,4,5]"
    127.0.0.1:6379> JSON.ARRTRIM user $ -100  2
    1) (integer) 3
    127.0.0.1:6379> JSON.GET user
    "[3,4,5]"


`
in diceDB, keep the same logic as redis.