### PR TITLE
#762: Defined config file def and returning nil

### DIFF
--- a/internal/eval/eval_linux_arm64.go
+++ b/internal/eval/eval_linux_arm64.go
@@ -5,6 +5,7 @@ package eval
 import (
 	"syscall"
 
+	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/internal/clientio"
 	diceerrors "github.com/dicedb/dice/internal/errors"
 	"github.com/dicedb/dice/internal/server/utils"
@@ -26,7 +27,7 @@ func EvalBGREWRITEAOF(args []string, store *dstore.Store) []byte {
 	// TODO: Each child process would now have a copy of the network file descriptor thus resulting in resource leaks.
 	// TODO: We need to find an alternative approach for the multi-threaded environment.
 	if config.EnableMultiThreading {
-		nil
+		return nil
 	}
 	childThreadID, _, _ := syscall.Syscall(syscall.SYS_GETTID, 0, 0, 0)
 	newChild, _, _ := syscall.Syscall(syscall.SYS_CLONE, syscall.CLONE_PARENT_SETTID|syscall.CLONE_CHILD_CLEARTID|uintptr(syscall.SIGCHLD), 0, childThreadID)


### PR DESCRIPTION
Fixes #762 

Verification steps
```bash
~/dice fix/762_linux_arm_support !1 ?1 > git commit -a -m "Defined config file def and returning nil"                                                                                                                                23:32:02
[fix/762_linux_arm_support a12808a] Defined config file def and returning nil
 1 file changed, 2 insertions(+), 1 deletion(-)
~/dice fix/762_linux_arm_support ?1 > GOARCH=arm64 GOOS=linux go build -o dice-arm64 main.go                                                                                                                                         23:32:06
~/dice fix/762_linux_arm_support ?1 > go build -o dice main.go                                                                                                                                                                       23:32:18
~/dice fix/762_linux_arm_support ?2 > ./dice                                                                                                                                                                                         23:32:24
{"level":"info","version":"0.0.4","port":7379,"time":"2024-09-28T23:32:31+05:30","message":"DiceDB server is running"}
{"level":"warn","time":"2024-09-28T23:32:31+05:30","message":"DiceDB is running without authentication. Consider setting a password."}
{"level":"info","addr":":8082","time":"2024-09-28T23:32:31+05:30","message":"HTTP Server running"}
{"level":"info","port":"8379","time":"2024-09-28T23:32:31+05:30","message":"Websocket Server running"}
^C{"level":"error","error":"http: Server closed","time":"2024-09-28T23:32:33+05:30","message":"Websocket Server error"}
{"level":"error","error":"http: Server closed","time":"2024-09-28T23:32:33+05:30","message":"HTTP Server error"}
{"level":"info","time":"2024-09-28T23:32:33+05:30","message":"Skipping AOF dump."}
~/dice fix/762_linux_arm_support ?2 >
```