### PR TITLE
#648: feat: adding HINCRBYFLOAT command implementation

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -948,6 +948,18 @@ var (
 		Arity:    -4,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	hincrbyFloatCmdMeta = DiceCmdMeta{
+		Name: "HINCRBYFLOAT",
+		Info: `HINCRBYFLOAT increments the specified field of a hash stored at the key, 
+		and representing a floating point number, by the specified increment.
+		If the field does not exist, it is set to 0 before performing the operation.
+		If the field contains a value of wrong type or specified increment
+		is not parsable as floating point number, then an error occurs.
+		`,
+		Eval:     evalHINCRBYFLOAT,
+		Arity:    -4,
+		KeySpecs: KeySpecs{BeginIndex: 1},
+	}
 )
 
 func init() {
@@ -1054,6 +1066,7 @@ func init() {
 	DiceCmds["HVALS"] = hValsCmdMeta
 	DiceCmds["ZADD"] = zaddCmdMeta
 	DiceCmds["ZRANGE"] = zrangeCmdMeta
+	DiceCmds["HINCRBYFLOAT"] = hincrbyFloatCmdMeta
 }
 
 // Function to convert DiceCmdMeta to []interface{}

--- a/internal/eval/hmap.go
+++ b/internal/eval/hmap.go
@@ -107,3 +107,27 @@ func (h HashMap) incrementValue(field string, increment int64) (int64, error) {
 
 	return total, nil
 }
+
+func (h HashMap) incrementFloatValue(field string, incr float64) (string, error) {
+	val, ok := h[field]
+	if !ok {
+		h[field] = fmt.Sprintf("%v", incr)
+		strValue := formatFloat(incr, false)
+		return strValue, nil
+	}
+
+	i, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return "-1", diceerrors.NewErr(diceerrors.IntOrFloatErr)
+	}
+
+	if (i > 0 && incr > 0 && i > math.MaxFloat64-incr) || (i < 0 && incr < 0 && i < -math.MaxFloat64-incr) {
+		return "-1", diceerrors.NewErr(diceerrors.IncrDecrOverflowErr)
+	}
+
+	total := i + incr
+	strValue := formatFloat(total, false)
+	h[field] = fmt.Sprintf("%v", total)
+
+	return strValue, nil
+}


### PR DESCRIPTION
Closes #648 

This PR adds support for the `HINCRBYFLOAT` command. It also adds unit tests and a basic benchmark test.