### PR TITLE
update readme with adding port in the docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ With this, you can build truly real-time applications like [Leaderboard](https:/
 The easiest way to get started with DiceDB is using [Docker](https://www.docker.com/) by running the following command.
 
 ```
-$ docker run dicedb/dicedb
+$ docker run -p 7379:7379 dicedb/dicedb
 ```
 
 The above command will start the DiceDB server running locally on the port `7379` and you can connect


### PR DESCRIPTION
While setting up the Dice DB on my local machine, I noticed that the README file doesn’t include the full Docker command to run it on port 7379. To address this, I’ve updated the README in this PR.