### PR TITLE
fix: Allows users to customize the KeysLimit value at server start

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,8 @@ const (
 	EvictAllKeysRandom = "allkeys-random"
 	EvictAllKeysLRU    = "allkeys-lru"
 	EvictAllKeysLFU    = "allkeys-lfu"
+
+	DefaultKeysLimit int = 200000000
 )
 
 var (
@@ -44,6 +46,8 @@ var (
 	FileLocation         = utils.EmptyStr
 
 	InitConfigCmd = false
+
+	KeysLimit = DefaultKeysLimit
 )
 
 type Config struct {
@@ -114,7 +118,7 @@ var baseConfig = Config{
 		MaxMemory:              0,
 		EvictionPolicy:         EvictAllKeysLFU,
 		EvictionRatio:          0.9,
-		KeysLimit:              200000000,
+		KeysLimit:              DefaultKeysLimit,
 		AOFFile:                "./dice-master.aof",
 		PersistenceEnabled:     true,
 		WriteAOFOnCleanup:      false,
@@ -292,6 +296,10 @@ func mergeFlagsWithConfig() {
 
 	if Port != DefaultPort {
 		DiceConfig.Server.Port = Port
+	}
+
+	if KeysLimit != DefaultKeysLimit {
+		DiceConfig.Server.KeysLimit = KeysLimit
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,9 @@ func init() {
 	flag.StringVar(&config.CustomConfigFilePath, "o", config.CustomConfigFilePath, "dir path to create the config file")
 	flag.StringVar(&config.FileLocation, "c", config.FileLocation, "file path of the config file")
 	flag.BoolVar(&config.InitConfigCmd, "init-config", false, "initialize a new config file")
-	flag.IntVar(&config.KeysLimit, "keys-limit", config.KeysLimit, "keys limit for the dice server. This flag controls the number of keys each shard holds at startup. You can multiply this number with the total number of shard threads to estimate how much memory will be required at system start up.")
+	flag.IntVar(&config.KeysLimit, "keys-limit", config.KeysLimit, "keys limit for the dice server. "+
+		"This flag controls the number of keys each shard holds at startup. You can multiply this number with the "+
+		"total number of shard threads to estimate how much memory will be required at system start up.")
 	flag.Parse()
 
 	config.SetupConfig()

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func init() {
 	flag.StringVar(&config.CustomConfigFilePath, "o", config.CustomConfigFilePath, "dir path to create the config file")
 	flag.StringVar(&config.FileLocation, "c", config.FileLocation, "file path of the config file")
 	flag.BoolVar(&config.InitConfigCmd, "init-config", false, "initialize a new config file")
+	flag.IntVar(&config.KeysLimit, "keys-limit", config.KeysLimit, "keys limit for the dice server")
 	flag.Parse()
 
 	config.SetupConfig()

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func init() {
 	flag.StringVar(&config.CustomConfigFilePath, "o", config.CustomConfigFilePath, "dir path to create the config file")
 	flag.StringVar(&config.FileLocation, "c", config.FileLocation, "file path of the config file")
 	flag.BoolVar(&config.InitConfigCmd, "init-config", false, "initialize a new config file")
-	flag.IntVar(&config.KeysLimit, "keys-limit", config.KeysLimit, "keys limit for the dice server")
+	flag.IntVar(&config.KeysLimit, "keys-limit", config.KeysLimit, "keys limit for the dice server. This flag controls the number of keys each shard holds at startup. You can multiply this number with the total number of shard threads to estimate how much memory will be required at system start up.")
 	flag.Parse()
 
 	config.SetupConfig()


### PR DESCRIPTION
Allows users to customize the KeysLimit value at server start improving control over memory allocation and preventing previous runtime out-of-memory issues.