### PR TITLE
fix(json.del): add missing syntax, update example path & error message

### DIFF
--- a/docs/src/content/docs/commands/JSON.DEL.md
+++ b/docs/src/content/docs/commands/JSON.DEL.md
@@ -5,14 +5,24 @@ description: Documentation for the DiceDB command JSON.DEL
 
 The `JSON.DEL` command is part of the DiceDBJSON module, which allows you to manipulate JSON data stored in DiceDB. This command is used to delete a specified path from a JSON document stored at a given key. If the path is not specified, the entire JSON document will be deleted.
 
-## Parameters
+## Syntax
 
-- `key`: (String) The key under which the JSON document is stored.
-- `path`: (String, optional) The JSONPath expression specifying the part of the JSON document to delete. If omitted, the entire JSON document will be deleted.
+```
+JSON.DEL key [path]
+```
+
+## Parameters
+| Parameter | Description                                                                            | Type    | Required |
+|-----------|----------------------------------------------------------------------------------------|---------|----------|
+| `key`     | The key under which the JSON document is stored.                                       | String  | Yes      |
+| `path`    | The JSONPath expression specifying the part of the JSON document to delete. If omitted, the entire JSON document will be deleted. | String  | No       |
 
 ## Return Value
 
-- `Integer`: The number of paths that were deleted. If the specified key does not exist, the command returns `0`.
+| Condition                                  | Return Value                             |
+|--------------------------------------------|------------------------------------------|
+| At least one path is successfully deleted  | The number of paths deleted (Integer)    |
+| The specified key does not exist           | `0`                                      |
 
 ## Behaviour
 
@@ -21,21 +31,25 @@ When the `JSON.DEL` command is executed, it performs the following actions:
 1. `Key Existence Check`: The command first checks if the specified key exists in the DiceDB database.
 2. `Path Evaluation`: If a path is provided, the command evaluates the JSONPath expression to locate the part of the JSON document to delete.
 3. `Deletion`: The specified path or the entire JSON document is deleted.
-4. `Return`: The command returns the number of paths that were successfully deleted.
+4. `Return`: 
+        - The command returns the number of paths that were successfully deleted.
+        - If the specified path does not exist `0` is returned, indicating that no operation was performed. 
 
 ## Error Handling
 
 The `JSON.DEL` command can raise the following errors:
+<!-- Error displayed in dicedb is different -->
+<!-- - `(error) WRONGTYPE Operation against a key holding the wrong kind of value`: This error is raised if the specified key exists but does not hold a JSON document. -->
+- `(error) ERROR Existing key has wrong Dice type`
 
-- `(error) WRONGTYPE Operation against a key holding the wrong kind of value`: This error is raised if the specified key exists but does not hold a JSON document.
-- `(error) ERR Path does not exist`: This error is raised if the specified path does not exist within the JSON document.
+<!-- - `(error) ERR Path does not exist`: This error is raised if the specified path does not exist within the JSON document. -->
 
 ## Example Usage
 
 ### Deleting an Entire JSON Document
 
 ```shell
-127.0.0.1:6379> JSON.SET myjson . '{"name": "John", "age": 30, "city": "New York"}'
+127.0.0.1:6379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
 127.0.0.1:6379> JSON.DEL myjson
 (integer) 1
@@ -46,9 +60,9 @@ OK
 ### Deleting a Specific Path
 
 ```shell
-127.0.0.1:6379> JSON.SET myjson . '{"name": "John", "age": 30, "city": "New York"}'
+127.0.0.1:6379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
-127.0.0.1:6379> JSON.DEL myjson .age
+127.0.0.1:6379> JSON.DEL myjson $.age
 (integer) 1
 127.0.0.1:6379> JSON.GET myjson
 "{\"name\":\"John\",\"city\":\"New York\"}"
@@ -57,9 +71,9 @@ OK
 ### Deleting a Non-Existent Path
 
 ```shell
-127.0.0.1:6379> JSON.SET myjson . '{"name": "John", "age": 30, "city": "New York"}'
+127.0.0.1:6379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
-127.0.0.1:6379> JSON.DEL myjson .address
+127.0.0.1:6379> JSON.DEL myjson $.address
 (integer) 0
 ```
 
@@ -69,7 +83,7 @@ OK
 127.0.0.1:6379> SET mystring "Hello, World!"
 OK
 127.0.0.1:6379> JSON.DEL mystring
-(error) WRONGTYPE Operation against a key holding the wrong kind of value
+(error) ERROR Existing key has wrong Dice type
 ```
 
 ## Notes


### PR DESCRIPTION
- Added missing syntax section for `JSON.DEL` in documentation.
- Updated formatting by referring [SET Command docs](https://dicedb.io/commands/set/)
- Updated examples to use `$` for path demonstration instead of `.` to align with Redis behavior (dicedb works fine with `.` but redis throws error `the legacy path syntax is not supported. JSONPath must start with $`).
- Improved error message documentation for wrong types during `JSON.DEL`. DiceDB shows `ERROR Existing key has wrong Dice type`, while Redis shows `WRONGTYPE Operation against a key holding the wrong kind of value`. (this should be consistent)
(for redis instance upstash was used)

Fixes #842