### PR TITLE
Change port for RESP server integration tests

### DIFF
--- a/integration_tests/commands/resp/main_test.go
+++ b/integration_tests/commands/resp/main_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	// checks for available port and then forks a goroutine
 	// to start the server
 	opts := TestServerOptions{
-		Port:   8739,
+		Port:   9739,
 		Logger: logger,
 	}
 	RunTestServer(&wg, opts)

--- a/integration_tests/commands/resp/setup.go
+++ b/integration_tests/commands/resp/setup.go
@@ -119,7 +119,7 @@ func RunTestServer(wg *sync.WaitGroup, opt TestServerOptions) {
 	if opt.Port != 0 {
 		config.DiceConfig.Server.Port = opt.Port
 	} else {
-		config.DiceConfig.Server.Port = 8739
+		config.DiceConfig.Server.Port = 9739
 	}
 
 	watchChan := make(chan dstore.QueryWatchEvent, config.DiceConfig.Server.KeysLimit)


### PR DESCRIPTION
Seeing some flakiness in test server startup.

Starting the test server on port 8739
{"level":"error","error":"address already in use","time":"2024-10-02T23:20:35+05:30","message":"Error occurred"}
{"level":"error","error":"failed to bind socket: address already in use","time":"2024-10-02T23:20:35+05:30","message":"failed to bind server"}
{"level":"error","error":"failed to bind socket: address already in use","message":"Test server encountered an error"}
FAIL    github.com/dicedb/dice/integration_tests/commands/resp  2.416s

Changed RESP test server port to 9739 to avoid port conflicts with ASYNC server.