### PR TITLE
server: add unix socket capability

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ const (
 
 	DefaultHost           string = "0.0.0.0"
 	DefaultPort           int    = 7379
+	DefaultHost           string = "0.0.0.0"
 	DefaultConfigName     string = "dice.toml"
 	DefaultConfigFilePath string = "./"
 

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ const (
 
 	DefaultHost           string = "0.0.0.0"
 	DefaultPort           int    = 7379
-	DefaultHost           string = "0.0.0.0"
+	DefaultAddress        string = "unix:///tmp/dice.sock"
 	DefaultConfigName     string = "dice.toml"
 	DefaultConfigFilePath string = "./"
 
@@ -34,6 +34,8 @@ const (
 var (
 	Host = DefaultHost
 	Port = DefaultPort
+
+	Address = DefaultAddress
 
 	EnableMultiThreading = false
 	EnableHTTP           = true

--- a/internal/errors/migrated_errors.go
+++ b/internal/errors/migrated_errors.go
@@ -31,6 +31,7 @@ var (
 	ErrAborted                    = errors.New("server received ABORT command")
 	ErrEmptyCommand               = errors.New("empty command")
 	ErrInvalidIPAddress           = errors.New("invalid IP address")
+	ErrInvalidAddress             = errors.New("invalid address")
 
 	// Error generation functions for specific error messages with dynamic parameters.
 	ErrWrongArgumentCount = func(command string) error {

--- a/internal/querymanager/query_manager.go
+++ b/internal/querymanager/query_manager.go
@@ -317,7 +317,8 @@ func (m *Manager) addWatcher(query *sql.DSQLQuery, clientIdentifier ClientIdenti
 	qwatchClientChan chan comm.QwatchResponse, cacheChan chan *[]struct {
 		Key   string
 		Value *object.Obj
-	}) {
+	},
+) {
 	queryString := query.String()
 
 	clients, _ := m.WatchList.LoadOrStore(queryString, &sync.Map{})
@@ -344,7 +345,8 @@ func (m *Manager) addWatcher(query *sql.DSQLQuery, clientIdentifier ClientIdenti
 
 // removeWatcher removes a client from the watchlist for a query.
 func (m *Manager) removeWatcher(query *sql.DSQLQuery, clientIdentifier ClientIdentifier,
-	qwatchClientChan chan comm.QwatchResponse) {
+	qwatchClientChan chan comm.QwatchResponse,
+) {
 	queryString := query.String()
 	if clients, ok := m.WatchList.Load(queryString); ok {
 		if qwatchClientChan != nil {

--- a/internal/server/address.go
+++ b/internal/server/address.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Address struct {
+	Kind string // allowed values: unix, tcp, dice
+	Host string // e.g: "0.0.0.0", "::1"
+	Port int    // e.g., 6379
+	Path string // a valid unix socket path. eg: /tmp/dice.sock
+}
+
+func (a *Address) IsSocketAvail() bool {
+	_, err := os.Stat(a.Path)
+	return errors.Is(err, os.ErrNotExist)
+}
+
+func ParseAddress(address string) (*Address, error) {
+	// Prefer tcp sockets
+	if !strings.Contains(address, "://") {
+		address = "tcp://" + address
+	}
+	u, err := url.Parse(address)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "unix":
+		return &Address{
+			Kind: "unix",
+			Host: "",
+			Port: -1,
+			Path: u.Path,
+		}, nil
+	case "tcp", "dice":
+		host, portStr, err := net.SplitHostPort(u.Host)
+		if err != nil {
+			return nil, err
+		}
+		if host == "" {
+			host = "0.0.0.0"
+		}
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return nil, err
+		}
+		return &Address{
+			Kind: "dice",
+			Host: host,
+			Port: port,
+			Path: "",
+		}, nil
+	}
+	return nil, errors.New("invalid address supplied!")
+}

--- a/internal/server/address.go
+++ b/internal/server/address.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+const (
+	UnixScheme = "unix"
+	TCPScheme  = "tcp"
+	DiceScheme = "dice"
+)
+
 type Address struct {
 	Kind string // allowed values: unix, tcp, dice
 	Host string // e.g: "0.0.0.0", "::1"
@@ -32,14 +38,14 @@ func ParseAddress(address string) (*Address, error) {
 	}
 
 	switch u.Scheme {
-	case "unix":
+	case UnixScheme:
 		return &Address{
 			Kind: "unix",
 			Host: "",
 			Port: -1,
 			Path: u.Path,
 		}, nil
-	case "tcp", "dice":
+	case TCPScheme, DiceScheme:
 		host, portStr, err := net.SplitHostPort(u.Host)
 		if err != nil {
 			return nil, err
@@ -58,5 +64,5 @@ func ParseAddress(address string) (*Address, error) {
 			Path: "",
 		}, nil
 	}
-	return nil, errors.New("invalid address supplied!")
+	return nil, errors.New("invalid address supplied")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -122,7 +122,7 @@ func (s *AsyncServer) BindToTcp(addr *Address) (socketErr error) {
 	defer func() {
 		if socketErr != nil {
 			if err := syscall.Close(serverFD); err != nil {
-				log.Warn("failed to close server socket", "error", err)
+				slog.Warn("failed to close server socket", "error", err)
 			}
 		}
 	}()
@@ -139,10 +139,10 @@ func (s *AsyncServer) BindToTcp(addr *Address) (socketErr error) {
 
 	ip4 := net.ParseIP(addr.Host)
 	if ip4 == nil {
-		return ErrInvalidIPAddress
+		return diceerrors.ErrInvalidIPAddress
 	}
 
-	log.Infof("DiceDB running on port %d", addr.Port)
+	slog.Info("DiceDB running on port", "port", addr.Port)
 	return syscall.Bind(serverFD, &syscall.SockaddrInet4{
 		Port: addr.Port,
 		Addr: [4]byte{ip4[0], ip4[1], ip4[2], ip4[3]},
@@ -160,7 +160,7 @@ func (s *AsyncServer) BindToSocket(addr *Address) (socketErr error) {
 	defer func() {
 		if socketErr != nil {
 			if err := syscall.Close(serverFD); err != nil {
-				log.Warn("failed to close server socket", "error", err)
+				slog.Warn("failed to close server socket", "error", err)
 			}
 		}
 	}()
@@ -176,7 +176,7 @@ func (s *AsyncServer) BindToSocket(addr *Address) (socketErr error) {
 	}
 
 	if addr.IsSocketAvail() {
-		log.Infof("DiceDB running on socket: %s", addr.Path)
+		slog.Info("DiceDB running on socket", "path", addr.Path)
 		sockAddr := &syscall.SockaddrUnix{Name: addr.Path}
 		return syscall.Bind(serverFD, sockAddr)
 	} else {
@@ -195,7 +195,7 @@ func (s *AsyncServer) Bind() (socketErr error) {
 	case "tcp", "dice":
 		return s.BindToTcp(addr)
 	default:
-		return ErrInvalidAddress
+		return diceerrors.ErrInvalidAddress
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/charmbracelet/log"
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dice/internal/auth"
 	"github.com/dicedb/dice/internal/clientio"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -111,7 +111,7 @@ func (s *AsyncServer) FindPortAndBind() (socketErr error) {
 	return nil
 }
 
-func (s *AsyncServer) BindToTcp(addr *Address) (socketErr error) {
+func (s *AsyncServer) BindToTCP(addr *Address) (socketErr error) {
 	serverFD, socketErr := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
 
 	if socketErr != nil {
@@ -179,9 +179,8 @@ func (s *AsyncServer) BindToSocket(addr *Address) (socketErr error) {
 		slog.Info("DiceDB running on socket", "path", addr.Path)
 		sockAddr := &syscall.SockaddrUnix{Name: addr.Path}
 		return syscall.Bind(serverFD, sockAddr)
-	} else {
-		return errors.New("socket already in use")
 	}
+	return errors.New("socket already in use")
 }
 
 func (s *AsyncServer) Bind() (socketErr error) {
@@ -193,7 +192,7 @@ func (s *AsyncServer) Bind() (socketErr error) {
 	case "unix":
 		return s.BindToSocket(addr)
 	case "tcp", "dice":
-		return s.BindToTcp(addr)
+		return s.BindToTCP(addr)
 	default:
 		return diceerrors.ErrInvalidAddress
 	}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 func init() {
 	flag.StringVar(&config.Host, "host", "0.0.0.0", "host for the dicedb server")
 	flag.IntVar(&config.Port, "port", 7379, "port for the dicedb server")
+	flag.StringVar(&config.Address, "address", "0.0.0.0:7379", "address for the dice server")
 	flag.BoolVar(&config.EnableHTTP, "enable-http", true, "run server in HTTP mode as well")
 	flag.BoolVar(&config.EnableMultiThreading, "enable-multithreading", false, "run server in multithreading mode")
 	flag.IntVar(&config.HTTPPort, "http-port", 8082, "HTTP port for the dicedb server")

--- a/main.go
+++ b/main.go
@@ -100,7 +100,8 @@ func main() {
 	// Find a port and bind it
 	if !config.EnableMultiThreading {
 		asyncServer := server.NewAsyncServer(shardManager, queryWatchChan, logr)
-		if err := asyncServer.FindPortAndBind(); err != nil {
+		// if err := asyncServer.FindPortAndBind(); err != nil {
+		if err := asyncServer.Bind(); err != nil {
 			cancel()
 			logr.Error("Error finding and binding port", slog.Any("error", err))
 			os.Exit(1)


### PR DESCRIPTION
DiceDB now supports tcp://, dice:// and unix:// variant addresses

This supersedes https://github.com/DiceDB/dice/pull/540

__NOTE__: The implementation contains bug that the unix socket file isn't deleted after server is closed. Will be fixing soon

cc @lucifercr07 