### PR TITLE
fix null value in removing array element and add test for this scenario

### DIFF
--- a/integration_tests/commands/async/json_test.go
+++ b/integration_tests/commands/async/json_test.go
@@ -504,6 +504,14 @@ func TestJSONDelOperations(t *testing.T) {
 				"JSON.GET user $"},
 			expected: []interface{}{"OK", int64(1), `{"name":"sugar"}`},
 		},
+		{
+			name: "delete key with []",
+			commands: []string{
+				`JSON.SET data $ {"key[0]":"value","array":["a","b"]}`,
+				`JSON.DEL data ["key[0]"]`,
+				"JSON.GET data $"},
+			expected: []interface{}{"OK", int64(1), `{"array": ["a","b"]}`},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/integration_tests/commands/async/json_test.go
+++ b/integration_tests/commands/async/json_test.go
@@ -592,6 +592,13 @@ func TestJSONForgetOperations(t *testing.T) {
 				"JSON.GET user $"},
 			expected: []interface{}{"OK", int64(1), `{"name":"sugar"}`},
 		},
+		{
+			name: "forget array element",
+			commands: []string{`JSON.SET user $ {"names":["Rahul","Tom"],"bosses":{"names":["Jerry","Rocky"],"hobby":"swim"}}`,
+				"JSON.FORGET user $.names[0]",
+				"JSON.GET user $"},
+			expected: []interface{}{"OK", int64(1), `{"names":["Tom"],"bosses":{"names":["Jerry","Rocky"],"hobby":"swim"}}`},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -862,8 +869,8 @@ func TestJsonNummultby(t *testing.T) {
 	invalidArgMessage := "ERR wrong number of arguments for 'json.nummultby' command"
 
 	testCases := []struct {
-		name        string
-		commands    []string
+		name       string
+		commands   []string
 		expected   []interface{}
 		assertType []string
 	}{
@@ -1021,9 +1028,9 @@ func TestJSONNumIncrBy(t *testing.T) {
 	defer conn.Close()
 	invalidArgMessage := "ERR wrong number of arguments for 'json.numincrby' command"
 	testCases := []struct {
-		name        string
-		setupData   string
-		commands    []string
+		name       string
+		setupData  string
+		commands   []string
 		expected   []interface{}
 		assertType []string
 		cleanUp    []string

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2,7 +2,6 @@ package eval
 
 import (
 	"bytes"
-
 	"crypto/rand"
 
 	"errors"
@@ -915,7 +914,15 @@ func evalJSONDEL(args []string, store *dstore.Store) []byte {
 		return diceerrors.NewErrWithMessage("invalid JSONPath")
 	}
 	results := expr.Get(jsonData)
-	err = expr.Del(jsonData)
+
+	hasBrackets := strings.Contains(path, "[") && strings.Contains(path, "]")
+
+	if hasBrackets {
+		_, err = expr.Remove(jsonData)
+	} else {
+		err = expr.Del(jsonData)
+	}
+
 	if err != nil {
 		return diceerrors.NewErrWithMessage(err.Error())
 	}
@@ -3174,7 +3181,7 @@ func evalHGET(args []string, store *dstore.Store) []byte {
 // evalHMGET returns an array of values associated with the given fields,
 // in the same order as they are requested.
 // If a field does not exist, returns a corresponding nil value in the array.
-// If the key does not exist, returns an array of nil values. 
+// If the key does not exist, returns an array of nil values.
 func evalHMGET(args []string, store *dstore.Store) []byte {
 	if len(args) < 2 {
 		return diceerrors.NewErrArity("HMGET")

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -917,6 +917,7 @@ func evalJSONDEL(args []string, store *dstore.Store) []byte {
 
 	hasBrackets := strings.Contains(path, "[") && strings.Contains(path, "]")
 
+	//If the command has square brackets then we have to delete an element inside an array
 	if hasBrackets {
 		_, err = expr.Remove(jsonData)
 	} else {


### PR DESCRIPTION
This will fix the issue where, instead of completely removing an element from the array and reindexing, we get `null` when we try to forget the element.

Fixes #910 