### PR TITLE
#955: fix: JSON.GET should return error when JSON path does not exist in JSON data

### DIFF
--- a/docs/src/content/docs/commands/JSON.GET.md
+++ b/docs/src/content/docs/commands/JSON.GET.md
@@ -26,7 +26,7 @@ JSON.GET <key> [path]
 | The specified key does not exists                                            | `nil`                                                |
 | The specified key exists and path argument is not specified                  | `String`: The entire JSON data for the key                |
 | The specified key exists and the specified path exists in the JSON data      | `String`: The data for the key at the specified path |
-| The specified key exists and specified path does not exists in the JSON data | `nil`                                                |
+| The specified key exists and specified path does not exists in the JSON data | `error`                                                |
 | Syntax or specified constraints are invalid                                  | error                                                |
 
 ## Behaviour
@@ -44,6 +44,8 @@ When the `JSON.GET` command is executed:
     - Error Message: `(error) ERR wrong number of arguments for 'json.get' command`
 2. `Invalid JSONPath expression`
     - Error Message: `(error) ERR invalid JSONPath`
+3. `Non-Existent JSONPath in the JSON data stored against a key`
+    - Error Message: `(error) ERR Path '$.<path>' does not exist`
 
 ## Example Usage
 
@@ -87,7 +89,7 @@ OK
 127.0.0.1:7379> JSON.SET user:1001 $ '{"name": "John Doe", "age": 30, "email": "john.doe@example.com"}'
 OK
 127.0.0.1:7379> JSON.GET user:1001 $.nonexistent
-(nil)
+(error) ERR Path '$.nonexistent' does not exist
 ```
 
 ## Notes

--- a/integration_tests/commands/async/json_test.go
+++ b/integration_tests/commands/async/json_test.go
@@ -144,6 +144,12 @@ func TestJSONOperations(t *testing.T) {
 			getCmd:   `JSON.GET inventory $.inventory.mountain_bikes[0].price`,
 			expected: `2000`,
 		},
+		{
+			name:     "Get JSON with non-existent path",
+			setCmd:   `JSON.SET user $ ` + simpleJSON,
+			getCmd:   `JSON.GET user $.nonExistent`,
+			expected: `ERR Path '$.nonExistent' does not exist`,
+		},
 	}
 
 	// Multiple test cases will address JSON operations where the order of elements can vary, but all orders are "valid" and to be accepted

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1130,7 +1130,7 @@ func jsonGETHelper(store *dstore.Store, path, key string) (result interface{}, e
 	// Execute the JSONPath query
 	results := expr.Get(jsonData)
 	if len(results) == 0 {
-		return result, nil
+		return result, diceerrors.NewErrWithMessage(fmt.Sprintf("Path '%s' does not exist", path))
 	}
 
 	// Serialize the result


### PR DESCRIPTION
## Changes
1. Return error when JSON path does not exists in the JSON data stored against a key (making it consistent with Redis)
2. Error format : `(error) ERR Path '$.<path>' does not exist`

## Screeshot
![Screenshot from 2024-10-05 21-02-25](https://github.com/user-attachments/assets/6e68886b-3cff-473f-acdc-e164b4b64e9a)

Closes https://github.com/DiceDB/dice/issues/955