### PR TITLE
#933: fix: Fixes output of LPUSH command

### DIFF
--- a/integration_tests/commands/async/deque_test.go
+++ b/integration_tests/commands/async/deque_test.go
@@ -83,17 +83,17 @@ func TestLPush(t *testing.T) {
 		{
 			name:   "LPUSH",
 			cmds:   []string{"LPUSH k v", "LPUSH k v1 1 v2 2", "LPUSH k 3 3 3 v3 v3 v3"},
-			expect: []any{"OK", "OK", "OK"},
+			expect: []any{int64(1), int64(5), int64(11)},
 		},
 		{
 			name:   "LPUSH normal values",
 			cmds:   []string{"LPUSH k " + strings.Join(deqNormalValues, " ")},
-			expect: []any{"OK"},
+			expect: []any{int64(25)},
 		},
 		{
 			name:   "LPUSH edge values",
 			cmds:   []string{"LPUSH k " + strings.Join(deqEdgeValues, " ")},
-			expect: []any{"OK"},
+			expect: []any{int64(42)},
 		},
 	}
 
@@ -121,17 +121,17 @@ func TestRPush(t *testing.T) {
 	}{
 		{
 			name:   "RPUSH",
-			cmds:   []string{"LPUSH k v", "LPUSH k v1 1 v2 2", "LPUSH k 3 3 3 v3 v3 v3"},
+			cmds:   []string{"RPUSH k v", "RPUSH k v1 1 v2 2", "RPUSH k 3 3 3 v3 v3 v3"},
 			expect: []any{"OK", "OK", "OK"},
 		},
 		{
 			name:   "RPUSH normal values",
-			cmds:   []string{"LPUSH k " + strings.Join(deqNormalValues, " ")},
+			cmds:   []string{"RPUSH k " + strings.Join(deqNormalValues, " ")},
 			expect: []any{"OK"},
 		},
 		{
 			name:   "RPUSH edge values",
-			cmds:   []string{"LPUSH k " + strings.Join(deqEdgeValues, " ")},
+			cmds:   []string{"RPUSH k " + strings.Join(deqEdgeValues, " ")},
 			expect: []any{"OK"},
 		},
 	}
@@ -176,17 +176,17 @@ func TestLPushLPop(t *testing.T) {
 		{
 			name:   "LPUSH LPOP",
 			cmds:   []string{"LPUSH k v1 1", "LPOP k", "LPOP k", "LPOP k"},
-			expect: []any{"OK", "1", "v1", "(nil)"},
+			expect: []any{int64(2), "1", "v1", "(nil)"},
 		},
 		{
 			name:   "LPUSH LPOP normal values",
 			cmds:   append([]string{"LPUSH k " + strings.Join(deqNormalValues, " ")}, getPops(deqNormalValues)...),
-			expect: append(append([]any{"OK"}, getPopExpects(deqNormalValues)...), "(nil)"),
+			expect: append(append([]any{int64(14)}, getPopExpects(deqNormalValues)...), "(nil)"),
 		},
 		{
 			name:   "LPUSH LPOP edge values",
 			cmds:   append([]string{"LPUSH k " + strings.Join(deqEdgeValues, " ")}, getPops(deqEdgeValues)...),
-			expect: append(append([]any{"OK"}, getPopExpects(deqEdgeValues)...), "(nil)"),
+			expect: append(append([]any{int64(17)}, getPopExpects(deqEdgeValues)...), "(nil)"),
 		},
 	}
 
@@ -230,17 +230,17 @@ func TestLPushRPop(t *testing.T) {
 		{
 			name:   "LPUSH RPOP",
 			cmds:   []string{"LPUSH k v1 1", "RPOP k", "RPOP k", "RPOP k"},
-			expect: []any{"OK", "v1", "1", "(nil)"},
+			expect: []any{int64(2), "v1", "1", "(nil)"},
 		},
 		{
 			name:   "LPUSH RPOP normal values",
 			cmds:   append([]string{"LPUSH k " + strings.Join(deqNormalValues, " ")}, getPops(deqNormalValues)...),
-			expect: append(append([]any{"OK"}, getPopExpects(deqNormalValues)...), "(nil)"),
+			expect: append(append([]any{int64(14)}, getPopExpects(deqNormalValues)...), "(nil)"),
 		},
 		{
 			name:   "LPUSH RPOP edge values",
 			cmds:   append([]string{"LPUSH k " + strings.Join(deqEdgeValues, " ")}, getPops(deqEdgeValues)...),
-			expect: append(append([]any{"OK"}, getPopExpects(deqEdgeValues)...), "(nil)"),
+			expect: append(append([]any{int64(17)}, getPopExpects(deqEdgeValues)...), "(nil)"),
 		},
 	}
 
@@ -383,9 +383,9 @@ func TestLRPushLRPop(t *testing.T) {
 				"RPOP k", "LPOP k", "LPOP k", "RPOP k",
 			},
 			expect: []any{
-				"OK", "OK",
+				"OK", int64(4),
 				"1000", "v1000", "2000",
-				"OK",
+				int64(2),
 				"v2000", "v6", "(nil)", "(nil)",
 			},
 		},
@@ -422,9 +422,9 @@ func TestLLEN(t *testing.T) {
 				"RPOP k", "LLEN k", "LPOP k", "LPOP k", "RPOP k", "LLEN k",
 			},
 			expect: []any{
-				"OK", "OK", int64(4),
+				"OK", int64(4), int64(4),
 				"1000", int64(3), "v1000", "2000", int64(1),
-				"OK", int64(2),
+				int64(2), int64(2),
 				"v2000", int64(1), "v6", "(nil)", "(nil)", int64(0),
 			},
 		},

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -3403,7 +3403,7 @@ func evalLPUSH(args []string, store *dstore.Store) []byte {
 		obj.Value.(*Deque).LPush(args[i])
 	}
 
-	return clientio.RespOK
+	return clientio.Encode((obj.Value.(*Deque).Length), false)
 }
 
 func evalRPUSH(args []string, store *dstore.Store) []byte {


### PR DESCRIPTION
Fixes #933 by returning the length instead of OK.

Minor side change - Integration test for RPUSH used LPUSH command like below, which was fixed
https://github.com/DiceDB/dice/blob/887d693113e266c8525c75b103346ced5fbdf997/integration_tests/commands/async/deque_test.go#L124

Would also like to point out the existence of a duplicate issue #961