### PR TITLE
Issue 798 - Auditing PFMERGE command docs

### DIFF
--- a/docs/src/content/docs/commands/PFMERGE.md
+++ b/docs/src/content/docs/commands/PFMERGE.md
@@ -19,13 +19,13 @@ PFMERGE destkey sourcekey [sourcekey ...]
 | `destkey`  | The key where the merged HyperLogLog will be stored. If this key already exists, it will be overwritten. | String       | Yes      |
 | `sourcekey`| One or more keys of the HyperLogLogs that you want to merge. These keys must already exist and contain HyperLogLog data. | List[String] | Yes      |
 
-## Return Value
+## Return Values
 
 
 | Condition                                      | Return Value                                      |
 |------------------------------------------------|---------------------------------------------------|
 | Command is successful                          | `OK`                                              |
-| Syntax or specified constraints are invalid    | error                                             |
+| Syntax or specified constraints are invalid    | `(error)`                                             |
 
 
 ## Behaviour

--- a/docs/src/content/docs/commands/PFMERGE.md
+++ b/docs/src/content/docs/commands/PFMERGE.md
@@ -30,20 +30,19 @@ PFMERGE destkey sourcekey [sourcekey ...]
 
 ## Behaviour
 
-When the `PFMERGE` command is executed, DiceDB will:
+- If the `destkey` already exists, the `PFMERGE` command will overwrite the existing value with the new merged HyperLogLog.
+- The command retrieves the HyperLogLog data structures from the specified `sourcekey` keys.
+- These `sourcekey` keys are merged into a single HyperLogLog and stored in the `destkey`.
+- If the `sourcekey` keys are not valid HyperLogLogs, an error is returned.
+  
 
-1. Retrieve the HyperLogLog data structures from the specified `sourcekey` keys.
-2. Merge these HyperLogLogs into a single HyperLogLog.
-3. Store the resulting HyperLogLog in the `destkey`.
-4. If the `destkey` already exists, its previous value will be overwritten with the new merged HyperLogLog.
-
-## Error Handling
+## Errors
 
 The `PFMERGE` command can raise errors in the following scenarios:
 
 1. `Wrong Type Error`: If any of the `sourcekey` keys or the `destkey` key contains a value that is not a HyperLogLog, DiceDB will return an error.
 
-   - `Error Message`: `WRONGTYPE Operation against a key holding the wrong kind of value`
+   - `(error)`: `WRONGTYPE Operation against a key holding the wrong kind of value`
 
 2. `Non-Existent Key Error`: If any of the `sourcekey` keys do not exist, DiceDB will treat them as empty HyperLogLogs and proceed with the merge operation without raising an error.
 

--- a/docs/src/content/docs/commands/PFMERGE.md
+++ b/docs/src/content/docs/commands/PFMERGE.md
@@ -13,12 +13,20 @@ PFMERGE destkey sourcekey [sourcekey ...]
 
 ## Parameters
 
-- `destkey`: The key where the merged HyperLogLog will be stored. If this key already exists, it will be overwritten.
-- `sourcekey`: One or more keys of the HyperLogLogs that you want to merge. These keys must already exist and contain HyperLogLog data structures.
+
+| Parameter  | Description                                                                     | Type         | Required |
+|------------|---------------------------------------------------------------------------------|--------------|----------|
+| `destkey`  | The key where the merged HyperLogLog will be stored. If this key already exists, it will be overwritten. | String       | Yes      |
+| `sourcekey`| One or more keys of the HyperLogLogs that you want to merge. These keys must already exist and contain HyperLogLog data. | List[String] | Yes      |
 
 ## Return Value
 
-- `Simple String Reply`: Returns `OK` if the merge operation is successful.
+
+| Condition                                      | Return Value                                      |
+|------------------------------------------------|---------------------------------------------------|
+| Command is successful                          | `OK`                                              |
+| Syntax or specified constraints are invalid    | error                                             |
+
 
 ## Behaviour
 
@@ -46,15 +54,15 @@ The `PFMERGE` command can raise errors in the following scenarios:
 Suppose you have three HyperLogLogs stored at keys `hll1`, `hll2`, and `hll3`, and you want to merge them into a new HyperLogLog stored at key `hll_merged`.
 
 ```sh
-127.0.0.1:6379> PFADD hll1 "a" "b" "c"
+127.0.0.1:7379> PFADD hll1 "a" "b" "c"
 (integer) 1
-127.0.0.1:6379> PFADD hll2 "c" "d" "e"
+127.0.0.1:7379> PFADD hll2 "c" "d" "e"
 (integer) 1
-127.0.0.1:6379> PFADD hll3 "e" "f" "g"
+127.0.0.1:7379> PFADD hll3 "e" "f" "g"
 (integer) 1
-127.0.0.1:6379> PFMERGE hll_merged hll1 hll2 hll3
+127.0.0.1:7379> PFMERGE hll_merged hll1 hll2 hll3
 OK
-127.0.0.1:6379> PFCOUNT hll_merged
+127.0.0.1:7379> PFCOUNT hll_merged
 (integer) 7
 ```
 
@@ -63,11 +71,11 @@ OK
 If the `destkey` already exists, it will be overwritten by the merged HyperLogLog.
 
 ```sh
-127.0.0.1:6379> PFADD hll_merged "x" "y" "z"
+127.0.0.1:7379> PFADD hll_merged "x" "y" "z"
 (integer) 1
-127.0.0.1:6379> PFMERGE hll_merged hll1 hll2 hll3
+127.0.0.1:7379> PFMERGE hll_merged hll1 hll2 hll3
 OK
-127.0.0.1:6379> PFCOUNT hll_merged
+127.0.0.1:7379> PFCOUNT hll_merged
 (integer) 7
 ```
 
@@ -76,8 +84,8 @@ OK
 If a `sourcekey` does not exist, DiceDB will treat it as an empty HyperLogLog.
 
 ```sh
-127.0.0.1:6379> PFMERGE hll_merged hll1 hll2 non_existent_key
+127.0.0.1:7379> PFMERGE hll_merged hll1 hll2 non_existent_key
 OK
-127.0.0.1:6379> PFCOUNT hll_merged
+127.0.0.1:7379> PFCOUNT hll_merged
 (integer) 5
 ```

--- a/docs/src/content/docs/commands/PFMERGE.md
+++ b/docs/src/content/docs/commands/PFMERGE.md
@@ -48,7 +48,7 @@ The `PFMERGE` command can raise errors in the following scenarios:
 
 ## Example Usage
 
-### Example 1: Basic Usage
+### Basic Usage
 
 Suppose you have three HyperLogLogs stored at keys `hll1`, `hll2`, and `hll3`, and you want to merge them into a new HyperLogLog stored at key `hll_merged`.
 
@@ -65,7 +65,7 @@ OK
 (integer) 7
 ```
 
-### Example 2: Overwriting Existing Key
+### Overwriting Existing Key
 
 If the `destkey` already exists, it will be overwritten by the merged HyperLogLog.
 
@@ -78,7 +78,7 @@ OK
 (integer) 7
 ```
 
-### Example 3: Handling Non-Existent Source Keys
+### Handling Non-Existent Source Keys
 
 If a `sourcekey` does not exist, DiceDB will treat it as an empty HyperLogLog.
 
@@ -87,4 +87,14 @@ If a `sourcekey` does not exist, DiceDB will treat it as an empty HyperLogLog.
 OK
 127.0.0.1:7379> PFCOUNT hll_merged
 (integer) 5
+```
+
+### Invalid Usage
+
+if a `sourcekey` exists and is not of type HyperLogLog, the command will result in an error
+
+```sh
+127.0.0.1:7379> PFMERGE hll_merged not_hyperLogLog
+(error) WRONGTYPE Key is not a valid HyperLogLog string value.
+
 ```


### PR DESCRIPTION
This PR aims to find and fix inconsistencies in the documentation for the `PFMERGE` command as mentioned in the issue #798 

The objectives of this PR can be simplified in the points below

- [x] Run the command and its examples in a local instance of `DiceDB` and make sure they work as per requirements
- [x] Compare the command with Redis's counterpart and make sure that the results are the same
- [x] In the official documentation, format the headings with the correct title as specified in the issue
- [x] Remove the Conclusion heading if it exists
- [x] Appropriate use of headers
- [x] Convert Parameters and Return Value to a markdown table format to ensure consistency

end goal - documentation should match the format followed by [SET](https://dicedb.io/commands/set/) and be consistent with how the code works 

Fixes #798 
