### PR TITLE
fix: handling multiple failure/error scenarios during socket writes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,8 +69,10 @@ type Config struct {
 	} `mapstructure:"http"`
 
 	WebSocket struct {
-		Enabled bool `mapstructure:"enabled"`
-		Port    int  `mapstructure:"port"`
+		Enabled                 bool          `mapstructure:"enabled"`
+		Port                    int           `mapstructure:"port"`
+		MaxWriteResponseRetries int           `mapstructure:"maxwriteresponseretries"`
+		WriteResponseTimeout    time.Duration `mapstructure:"writeresponsetimeout"`
 	} `mapstructure:"websocket"`
 
 	Performance struct {
@@ -137,11 +139,15 @@ var baseConfig = Config{
 		Port:    HTTPPort,
 	},
 	WebSocket: struct {
-		Enabled bool `mapstructure:"enabled"`
-		Port    int  `mapstructure:"port"`
+		Enabled                 bool          `mapstructure:"enabled"`
+		Port                    int           `mapstructure:"port"`
+		MaxWriteResponseRetries int           `mapstructure:"maxwriteresponseretries"`
+		WriteResponseTimeout    time.Duration `mapstructure:"writeresponsetimeout"`
 	}{
-		Enabled: EnableWebsocket,
-		Port:    WebsocketPort,
+		Enabled:                 EnableWebsocket,
+		Port:                    WebsocketPort,
+		MaxWriteResponseRetries: 3,
+		WriteResponseTimeout:    10 * time.Second,
 	},
 	Performance: struct {
 		WatchChanBufSize       int           `mapstructure:"watchchanbufsize"`

--- a/integration_tests/commands/websocket/setup.go
+++ b/integration_tests/commands/websocket/setup.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-const url = "ws://localhost:8380"
+const URL = "ws://localhost:8380"
 
 type TestServerOptions struct {
 	Port   int
@@ -38,7 +38,7 @@ type WebsocketCommandExecutor struct {
 
 func NewWebsocketCommandExecutor() *WebsocketCommandExecutor {
 	return &WebsocketCommandExecutor{
-		baseURL: url,
+		baseURL: URL,
 		websocketClient: &http.Client{
 			Timeout: time.Second * 100,
 		},
@@ -50,7 +50,7 @@ func NewWebsocketCommandExecutor() *WebsocketCommandExecutor {
 
 func (e *WebsocketCommandExecutor) ConnectToServer() *websocket.Conn {
 	// connect with Websocket Server
-	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	conn, resp, err := websocket.DefaultDialer.Dial(URL, nil)
 	if err != nil {
 		return nil
 	}

--- a/integration_tests/commands/websocket/websocket_write_retries_test.go
+++ b/integration_tests/commands/websocket/websocket_write_retries_test.go
@@ -1,0 +1,108 @@
+package websocket
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dicedb/dice/internal/server"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+)
+
+var serverAddr = "localhost:12345"
+var once sync.Once
+
+func TestWriteResponseWithRetries_Success(t *testing.T) {
+	conn := createWebSocketConn(t)
+	defer conn.Close()
+
+	// Complete a write without any errors
+	err := server.WriteResponseWithRetries(conn, []byte("hello"), 3)
+	assert.NoError(t, err)
+}
+
+func TestWriteResponseWithRetries_NetworkError(t *testing.T) {
+	conn := createWebSocketConn(t)
+	defer conn.Close()
+
+	// Simulate a network error by closing the connection beforehand
+	conn.Close()
+
+	err := server.WriteResponseWithRetries(conn, []byte("hello"), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "network operation error")
+}
+
+func TestWriteResponseWithRetries_BrokenPipe(t *testing.T) {
+	conn := createWebSocketConn(t)
+	defer conn.Close()
+
+	// Simulate a broken pipe error by manually triggering it.
+	conn.UnderlyingConn().(*net.TCPConn).CloseWrite()
+
+	err := server.WriteResponseWithRetries(conn, []byte("hello"), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "broken pipe")
+}
+
+func TestWriteResponseWithRetries_EAGAINRetry(t *testing.T) {
+	conn := createWebSocketConn(t)
+	defer conn.Close()
+
+	// No direct way to trigger EAGAIN, but this simulates retries working.
+	// Forcing the first two attempts to fail by closing and reopening the socket.
+	retries := 0
+	conn.SetWriteDeadline(time.Now().Add(1 * time.Millisecond))
+
+	for retries < 2 {
+		err := server.WriteResponseWithRetries(conn, []byte("hello"), 3)
+		if err != nil {
+			// Retry and reset deadline after a failed attempt.
+			conn.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
+			retries++
+		}
+	}
+	assert.Equal(t, 2, retries)
+}
+
+func newSyscallError(syscall string, err error) *os.SyscallError {
+	return &os.SyscallError{Syscall: syscall, Err: err}
+}
+
+func startWebSocketServer() {
+	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Upgrade(w, r, nil, 1024, 1024)
+		if err != nil {
+			http.Error(w, "Failed to upgrade", http.StatusInternalServerError)
+			return
+		}
+		defer conn.Close()
+
+		for {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			conn.WriteMessage(websocket.TextMessage, msg)
+		}
+	})
+
+	go http.ListenAndServe(serverAddr, nil)
+}
+
+// Helper to create a WebSocket connection for testing
+func createWebSocketConn(t *testing.T) *websocket.Conn {
+	once.Do(startWebSocketServer)
+
+	u := url.URL{Scheme: "ws", Host: serverAddr, Path: "/ws"}
+	conn, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		t.Fatalf("Failed to connect to WebSocket server: %v", err)
+	}
+	return conn
+}

--- a/internal/server/websocketServer.go
+++ b/internal/server/websocketServer.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"os"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/dicedb/dice/config"
@@ -20,6 +23,7 @@ import (
 	"github.com/dicedb/dice/internal/shard"
 	dstore "github.com/dicedb/dice/internal/store"
 	"github.com/gorilla/websocket"
+	"golang.org/x/exp/rand"
 )
 
 const Qwatch = "QWATCH"
@@ -215,11 +219,78 @@ func (s *WebsocketServer) WebsocketHandler(w http.ResponseWriter, r *http.Reques
 			continue
 		}
 
-		// Write response
-		writeResponse(conn, respBytes)
+		// Write response with retries for transient errors
+		if err := WriteResponseWithRetries(conn, respBytes, config.DiceConfig.WebSocket.MaxWriteResponseRetries); err != nil {
+			s.logger.Error(fmt.Sprintf("Error reading message: %v", err))
+			break // Exit the loop on write error
+		}
 	}
 }
 
+func WriteResponseWithRetries(conn *websocket.Conn, text []byte, maxRetries int) error {
+	for attempts := 0; attempts < maxRetries; attempts++ {
+		// Set a write deadline
+		if err := conn.SetWriteDeadline(time.Now().Add(config.DiceConfig.WebSocket.WriteResponseTimeout)); err != nil {
+			slog.Error(fmt.Sprintf("Error setting write deadline: %v", err))
+			return err
+		}
+
+		// Attempt to write message
+		err := conn.WriteMessage(websocket.TextMessage, text)
+		if err == nil {
+			break // Exit loop if write succeeds
+		}
+
+		// Handle network errors
+		var netErr *net.OpError
+		if !errors.As(err, &netErr) {
+			return fmt.Errorf("error writing message: %w", err)
+		}
+
+		opErr, ok := netErr.Err.(*os.SyscallError)
+		if !ok {
+			return fmt.Errorf("network operation error: %w", err)
+		}
+
+		if opErr.Syscall != "write" {
+			return fmt.Errorf("unexpected syscall error: %w", err)
+		}
+
+		switch opErr.Err {
+		case syscall.EPIPE:
+			return fmt.Errorf("broken pipe: %w", err)
+		case syscall.ECONNRESET:
+			return fmt.Errorf("connection reset by peer: %w", err)
+		case syscall.ENOBUFS:
+			return fmt.Errorf("no buffer space available: %w", err)
+		case syscall.EAGAIN:
+			// Exponential backoff with jitter
+			backoffDuration := time.Duration(attempts+1)*100*time.Millisecond + time.Duration(rand.Intn(50))*time.Millisecond 
+
+			slog.Warn(fmt.Sprintf(
+				"Temporary issue (EAGAIN) on attempt %d. Retrying in %v...", 
+				attempts+1, backoffDuration,
+			))
+
+			time.Sleep(backoffDuration)
+			continue
+		default:
+			return fmt.Errorf("write error: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func writeResponse(conn *websocket.Conn, text []byte) {
-	_ = conn.WriteMessage(websocket.TextMessage, text)
+	// Set a write deadline to prevent hanging
+	if err := conn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		slog.Error(fmt.Sprintf("Error setting write deadline: %v", err))
+		return
+	}
+
+	err := conn.WriteMessage(websocket.TextMessage, text)
+	if err != nil {
+		slog.Error(fmt.Sprintf("Error writing response: %v", err))
+	}
 }


### PR DESCRIPTION
Fixes: #717 

the following failure scenarios have been added

Timeout: Check if net.Error and checking if it's a timeout.
Retries: Exponential backoffs and retries in writes
Connection reset: Detect by checking for syscall.ECONNRESET
Broken Pipe: Detect broken pipe by using syscall.EPIPE

