### PR TITLE
#188: Added Integration Tests for QWATCH Where Clause

### DIFF
--- a/integration_tests/commands/async/qunwatch_test.go
+++ b/integration_tests/commands/async/qunwatch_test.go
@@ -45,7 +45,7 @@ func TestQWatchUnwatch(t *testing.T) {
 	}
 
 	// Make updates to the store
-	runQWatchScenarios(t, publisher, respParsers)
+	runQWatchScenarios(t, publisher, respParsers, qWatchQuery, qWatchTestCases)
 
 	// Unwatch the query on two of the subscribers
 	for _, sub := range subscribers[0:2] {

--- a/integration_tests/commands/http/set_data_cmd_test.go
+++ b/integration_tests/commands/http/set_data_cmd_test.go
@@ -270,7 +270,7 @@ func TestSetDataCmd(t *testing.T) {
 				{Command: "SADD", Body: map[string]interface{}{"key": "foo", "value": "baz"}},
 				{Command: "SINTER", Body: map[string]interface{}{"values": []interface{}{"foo"}}},
 			},
-			assert_type: []string{"equal", "equal", "unordered_equal"},
+			assert_type: []string{"equal", "equal", "array"},
 			expected:    []interface{}{float64(1), float64(1), []any{string("bar"), string("baz")}},
 		},
 	}


### PR DESCRIPTION
Closes #188 

This PR

1. adds integration tests for QWATCH Where clause
2. adds tests for both JSON and Regular keys
3. refactors existing code to reuse helper functions
4. fixes a flaky test case in `TestSetDataCmd`