### PR TITLE
FIX: alternating `error` and `nil` responses in consecutive exection of commands with error

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -320,9 +320,9 @@ func (s *AsyncServer) executeCommandToBuffer(diceDBCmd *cmd.DiceDBCmd, buf *byte
 		// Handle error case independently
 		if resp.EvalResponse.Error != nil {
 			handleMigratedResp(resp.EvalResponse.Error, buf)
+			return
 		}
 		handleMigratedResp(resp.EvalResponse.Result, buf)
-		return
 	}
 }
 


### PR DESCRIPTION
Fixes #1006 

![Screenshot From 2024-10-08 17-38-22](https://github.com/user-attachments/assets/f11bdc0e-3dff-453c-b545-3aa4e8372f01)
