### PR TITLE
#1036 Preserve TTL after APPEND command

### DIFF
--- a/integration_tests/commands/http/append_test.go
+++ b/integration_tests/commands/http/append_test.go
@@ -70,13 +70,17 @@ func TestAPPEND(t *testing.T) {
 			},
 		},
 		{
-			name: "APPEND value with leading zeros",
+			name: "APPEND with leading zeros",
 			commands: []HTTPCommand{
-				{Command: "APPEND", Body: map[string]interface{}{"key": "z", "value": "0043"}},
+				{Command: "DEL", Body: map[string]interface{}{"key": "key"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "0043"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "0034"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},
 			},
-			expected: []interface{}{float64(4)},
+			expected: []interface{}{float64(0), float64(4), "0043", float64(8), "00430034"},
 			cleanup: []HTTPCommand{
-				{Command: "del", Body: map[string]interface{}{"key": "z"}},
+				{Command: "del", Body: map[string]interface{}{"key": "key"}},
 			},
 		},
 		{
@@ -118,7 +122,70 @@ func TestAPPEND(t *testing.T) {
 				{Command: "del", Body: map[string]interface{}{"key": "bitkey"}},
 			},
 		},
+		{
+			name: "APPEND After SET and DEL",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "key", "value": "value"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "value"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "100"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},
+				{Command: "DEL", Body: map[string]interface{}{"key": "key"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "value"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},
+			},
+			expected: []interface{}{"OK", float64(10), "valuevalue", float64(13), "valuevalue100", float64(1), float64(5), "value"},
+			cleanup: []HTTPCommand{
+				{Command: "del", Body: map[string]interface{}{"key": "key"}},
+			},
+		},
+		{
+			name: "APPEND to Integer Values",
+			commands: []HTTPCommand{
+				{Command: "DEL", Body: map[string]interface{}{"key": "key"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "1"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "2"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},
+				{Command: "SET", Body: map[string]interface{}{"key": "key", "value": "1"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "2"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},
+			},
+			expected: []interface{}{float64(0), float64(1), float64(2), "12", "OK", float64(2), "12"},
+			cleanup: []HTTPCommand{
+				{Command: "del", Body: map[string]interface{}{"key": "key"}},
+			},
+		},
+		{
+			name: "APPEND with Various Data Types",
+			commands: []HTTPCommand{
+				{Command: "LPUSH", Body: map[string]interface{}{"key": "listKey", "value": "lValue"}},
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "bitKey", "offset": 0, "value": 1}},
+				{Command: "HSET", Body: map[string]interface{}{"key": "hashKey", "field": "hKey", "value": "hValue"}},
+				{Command: "SADD", Body: map[string]interface{}{"key": "setKey", "value": "sValue"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "listKey", "value": "value"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "bitKey", "value": "value"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "hashKey", "value": "value"}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "setKey", "value": "value"}},
+			},
+			expected: []interface{}{
+				float64(1),
+				float64(0),
+				float64(1),
+				float64(1),
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+				float64(6),
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+			},
+			cleanup: []HTTPCommand{
+				{Command: "del", Body: map[string]interface{}{"key": "listKey"}},
+				{Command: "del", Body: map[string]interface{}{"key": "bitKey"}},
+				{Command: "del", Body: map[string]interface{}{"key": "hashKey"}},
+				{Command: "del", Body: map[string]interface{}{"key": "setKey"}},
+			},
+		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
@@ -127,6 +194,73 @@ func TestAPPEND(t *testing.T) {
 				assert.Equal(t, tc.expected[i], result)
 			}
 			exec.FireCommand(tc.cleanup[0])
+		})
+	}
+
+	ttlTestCases := []struct {
+		name     string
+		commands []HTTPCommand
+		expected []interface{}
+		cleanup  []HTTPCommand
+	}{
+		{
+			name: "APPEND with TTL Set",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "key", "value": "Hello", "ex": 10}}, // Set a key with a 10-second TTL
+				{Command: "TTL", Body: map[string]interface{}{"key": "key"}},                             // Check initial TTL
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "World"}},        // Append a value
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},                             // Get the final value
+				{Command: "SLEEP", Body: map[string]interface{}{"seconds": 2}},                           // Sleep for 2 seconds
+				{Command: "TTL", Body: map[string]interface{}{"key": "key"}},                             // Check TTL after append
+			},
+			expected: []interface{}{"OK", float64(10), float64(10), "HelloWorld", "OK", float64(8)},
+			cleanup: []HTTPCommand{
+				{Command: "DEL", Body: map[string]interface{}{"key": "key"}},
+			},
+		},
+		{
+			name: "APPEND before near TTL Expiry",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "key", "value": "Hello", "ex": 3}}, // Set a key with a 3-second TTL
+				{Command: "TTL", Body: map[string]interface{}{"key": "key"}},                            // Check initial TTL
+				{Command: "APPEND", Body: map[string]interface{}{"key": "key", "value": "World"}},       // Append a value
+				{Command: "SLEEP", Body: map[string]interface{}{"seconds": 3}},                          // Sleep for 3 seconds
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},                            // Get the final value which should be nil
+			},
+			expected: []interface{}{"OK", float64(3), float64(10), "OK", (nil)},
+			cleanup: []HTTPCommand{
+				{Command: "DEL", Body: map[string]interface{}{"key": "key"}},
+			},
+		},
+	}
+
+	for _, tc := range ttlTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := NewHTTPCommandExecutor()
+
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+
+				// Apply TTL tolerance checks if the command is "TTL"
+				if cmd.Command == "TTL" {
+					expectedTTL := tc.expected[i].(float64)
+					actualTTL := result.(float64)
+
+					if actualTTL == -2 { // Key does not exist or has expired
+						assert.Equal(t, tc.expected[i], result)
+					} else {
+						assert.Condition(t, func() bool {
+							return actualTTL >= expectedTTL-2 && actualTTL <= expectedTTL+2
+						}, "TTL %f not within expected range [%f, %f]", actualTTL, expectedTTL-2, expectedTTL+2)
+					}
+				} else {
+					assert.Equal(t, tc.expected[i], result)
+				}
+			}
+
+			for _, cleanupCmd := range tc.cleanup {
+				exec.FireCommand(cleanupCmd)
+			}
 		})
 	}
 }

--- a/integration_tests/commands/resp/append_test.go
+++ b/integration_tests/commands/resp/append_test.go
@@ -21,49 +21,85 @@ func TestAPPEND(t *testing.T) {
 			name:     "APPEND and GET a new Val",
 			commands: []string{"APPEND k newVal", "GET k"},
 			expected: []interface{}{int64(6), "newVal"},
-			cleanup:  []string{"del k"},
+			cleanup:  []string{"DEL k"},
 		},
 		{
 			name:     "APPEND to an existing key and GET",
 			commands: []string{"SET k Bhima", "APPEND k Shankar", "GET k"},
 			expected: []interface{}{"OK", int64(12), "BhimaShankar"},
-			cleanup:  []string{"del k"},
+			cleanup:  []string{"DEL k"},
 		},
 		{
 			name:     "APPEND without input value",
 			commands: []string{"APPEND k"},
 			expected: []interface{}{"ERR wrong number of arguments for 'append' command"},
-			cleanup:  []string{"del k"},
+			cleanup:  []string{"DEL k"},
 		},
 		{
 			name:     "APPEND empty string to an existing key with empty string",
 			commands: []string{"SET k \"\"", "APPEND k \"\""},
 			expected: []interface{}{"OK", int64(0)},
-			cleanup:  []string{"del k"},
+			cleanup:  []string{"DEL k"},
 		},
 		{
 			name:     "APPEND to key created using LPUSH",
 			commands: []string{"LPUSH m bhima", "APPEND m shankar"},
 			expected: []interface{}{int64(1), "WRONGTYPE Operation against a key holding the wrong kind of value"},
-			cleanup:  []string{"del m"},
+			cleanup:  []string{"DEL m"},
 		},
 		{
-			name:     "APPEND value with leading zeros",
-			commands: []string{"APPEND z 0043"},
-			expected: []interface{}{int64(4)},
-			cleanup:  []string{"del z"},
+			name:     "APPEND with leading zeros",
+			commands: []string{"DEL key", "APPEND key 0043", "GET key", "APPEND key 0034", "GET key"},
+			expected: []interface{}{int64(0), int64(4), "0043", int64(8), "00430034"},
+			cleanup:  []string{"DEL key"},
 		},
 		{
 			name:     "APPEND to key created using SADD",
 			commands: []string{"SADD key apple", "APPEND key banana"},
 			expected: []interface{}{int64(1), "WRONGTYPE Operation against a key holding the wrong kind of value"},
-			cleanup:  []string{"del key"},
+			cleanup:  []string{"DEL key"},
 		},
 		{
 			name:     "APPEND to key created using ZADD",
 			commands: []string{"ZADD key 1 one", "APPEND key two"},
 			expected: []interface{}{int64(1), "WRONGTYPE Operation against a key holding the wrong kind of value"},
-			cleanup:  []string{"del key"},
+			cleanup:  []string{"DEL key"},
+		},
+		{
+			name:     "APPEND After SET and DEL",
+			commands: []string{"SET key value", "APPEND key value", "GET key", "APPEND key 100", "GET key", "DEL key", "APPEND key value", "GET key"},
+			expected: []interface{}{"OK", int64(10), "valuevalue", int64(13), "valuevalue100", int64(1), int64(5), "value"},
+			cleanup:  []string{"DEL key"},
+		},
+		{
+			name:     "APPEND to Integer Values",
+			commands: []string{"DEL key", "APPEND key 1", "APPEND key 2", "GET key", "SET key 1", "APPEND key 2", "GET key"},
+			expected: []interface{}{int64(0), int64(1), int64(2), "12", "OK", int64(2), "12"},
+			cleanup:  []string{"DEL key"},
+		},
+		{
+			name: "APPEND with Various Data Types",
+			commands: []string{
+				"LPUSH listKey lValue",
+				"SETBIT bitKey 0 1",
+				"HSET hashKey hKey hValue",
+				"SADD setKey sValue",
+				"APPEND listKey value",
+				"APPEND bitKey value",
+				"APPEND hashKey value",
+				"APPEND setKey value",
+			},
+			expected: []interface{}{
+				int64(1),
+				int64(0),
+				int64(1),
+				int64(1),
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+				int64(6),
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+			},
+			cleanup: []string{"DEL listKey", "DEL bitKey", "DEL hashKey", "DEL setKey"},
 		},
 		{
 			name:     "APPEND to key created using SETBIT",
@@ -79,6 +115,70 @@ func TestAPPEND(t *testing.T) {
 				result := FireCommand(conn, tc.commands[i])
 				expected := tc.expected[i]
 				assert.Equal(t, expected, result)
+			}
+
+			for _, cmd := range tc.cleanup {
+				FireCommand(conn, cmd)
+			}
+		})
+	}
+
+	setErrorMsg := "WRONGTYPE Operation against a key holding the wrong kind of value"
+	ttlTolerance := int64(2) // Set tolerance in seconds for the TTL checks
+	ttlTestCases := []struct {
+		name     string
+		commands []string
+		expected []interface{}
+		cleanup  []string
+	}{
+		{
+			name: "APPEND with TTL Set",
+			commands: []string{
+				"SET key Hello EX 10", // Set a key with a 10-second TTL
+				"TTL key",             // Check initial TTL
+				"APPEND key World",    // Append a value
+				"GET key",             // Get the final value
+				"SLEEP 2",             // Sleep for 2 seconds
+				"TTL key",             // Check TTL after append.
+			},
+			expected: []interface{}{"OK", int64(10), int64(10), "HelloWorld", "OK", int64(8), setErrorMsg, setErrorMsg, setErrorMsg, setErrorMsg},
+			cleanup:  []string{"DEL key"},
+		},
+		{
+			name: "APPEND before near TTL Expiry",
+			commands: []string{
+				"SET key Hello EX 3", // Set a key with a 10-second TTL
+				"TTL key",            // Check initial TTL
+				"APPEND key World",   // Append a value
+				"SLEEP 3",            // Sleep for 5 seconds
+				"GET key",            // Get the final value which should be (nil)
+			},
+			expected: []interface{}{"OK", int64(3), int64(10), "OK", "(nil)", int64(-2), setErrorMsg, setErrorMsg, setErrorMsg, setErrorMsg},
+			cleanup:  []string{"DEL key"},
+		},
+	}
+
+	for _, tc := range ttlTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			FireCommand(conn, "DEL key")
+
+			for i, cmd := range tc.commands {
+				result := FireCommand(conn, cmd)
+				// If checking TTL, apply a tolerance to account for system performance variability
+				if cmd == "TTL key" { // Check if TTL command is executed
+					expectedTTL := tc.expected[i].(int64)
+					actualTTL := result.(int64)
+
+					if actualTTL == -2 { // Key does not exist or is expired
+						assert.Equal(t, tc.expected[i], result)
+					} else {
+						assert.Condition(t, func() bool {
+							return actualTTL >= expectedTTL-ttlTolerance && actualTTL <= expectedTTL+ttlTolerance
+						}, "TTL %d not within expected range [%d, %d]", actualTTL, expectedTTL-ttlTolerance, expectedTTL+ttlTolerance)
+					}
+				} else {
+					assert.Equal(t, tc.expected[i], result)
+				}
 			}
 
 			for _, cmd := range tc.cleanup {

--- a/integration_tests/commands/websocket/append_test.go
+++ b/integration_tests/commands/websocket/append_test.go
@@ -40,10 +40,10 @@ func TestAppend(t *testing.T) {
 			cleanupKey: "z",
 		},
 		{
-			name:       "APPEND value with leading zeros",
-			commands:   []string{"APPEND key1 0043"},
-			expected:   []interface{}{float64(4)},
-			cleanupKey: "key1",
+			name:       "APPEND with leading zeros",
+			commands:   []string{"DEL key", "APPEND key 0043", "GET key", "APPEND key 0034", "GET key"},
+			expected:   []interface{}{float64(0), float64(4), "0043", float64(8), "00430034"},
+			cleanupKey: "key",
 		},
 		{
 			name:       "APPEND to key created using ZADD",
@@ -57,6 +57,42 @@ func TestAppend(t *testing.T) {
 			expected:   []interface{}{float64(0), float64(0), float64(0), float64(0), float64(0), float64(0), float64(3), "421"},
 			cleanupKey: "bitkey",
 		},
+		{
+			name:       "APPEND After SET and DEL",
+			commands:   []string{"SET key value", "APPEND key value", "GET key", "APPEND key 100", "GET key", "DEL key", "APPEND key value", "GET key"},
+			expected:   []interface{}{"OK", float64(10), "valuevalue", float64(13), "valuevalue100", float64(1), float64(5), "value"},
+			cleanupKey: "key",
+		},
+		{
+			name:       "APPEND to Integer Values",
+			commands:   []string{"DEL key", "APPEND key 1", "APPEND key 2", "GET key", "SET key 1", "APPEND key 2", "GET key"},
+			expected:   []interface{}{float64(0), float64(1), float64(2), "12", "OK", float64(2), "12"},
+			cleanupKey: "key",
+		},
+		{
+			name: "APPEND with Various Data Types",
+			commands: []string{
+				"LPUSH listKey lValue",
+				"SETBIT bitKey 0 1",
+				"HSET hashKey hKey hValue",
+				"SADD setKey sValue",
+				"APPEND listKey value",
+				"APPEND bitKey value",
+				"APPEND hashKey value",
+				"APPEND setKey value",
+			},
+			expected: []interface{}{
+				float64(1),
+				float64(0),
+				float64(1),
+				float64(1),
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+				float64(6),
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+			},
+			cleanupKey: "listKey",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -67,6 +103,56 @@ func TestAppend(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, tc.expected[i], result)
 			}
+			DeleteKey(t, conn, exec, tc.cleanupKey)
+		})
+	}
+
+	ttlTolerance := float64(2) // Set tolerance in seconds for the TTL checks
+	ttlTestCases := []struct {
+		name       string
+		commands   []string
+		expected   []interface{}
+		cleanupKey string
+	}{
+		{
+			name:       "APPEND with TTL Set",
+			commands:   []string{"SET key Hello EX 10", "TTL key", "APPEND key World", "GET key", "SLEEP 2", "TTL key"},
+			expected:   []interface{}{"OK", float64(10), float64(10), "HelloWorld", "OK", float64(8)},
+			cleanupKey: "key",
+		},
+		{
+			name:       "APPEND before near TTL Expiry",
+			commands:   []string{"SET key Hello EX 3", "TTL key", "APPEND key World", "SLEEP 3", "GET key"},
+			expected:   []interface{}{"OK", float64(3), float64(10), "OK", (nil)},
+			cleanupKey: "key",
+		},
+	}
+
+	for _, tc := range ttlTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := exec.ConnectToServer()
+
+			for i, cmd := range tc.commands {
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
+
+				// TTL tolerance handling
+				if cmd == "TTL key" {
+					expectedTTL := tc.expected[i].(float64)
+					actualTTL := result.(float64)
+					if actualTTL == -2 {
+						assert.Equal(t, tc.expected[i], result)
+					} else {
+						assert.Condition(t, func() bool {
+							return actualTTL >= expectedTTL-ttlTolerance && actualTTL <= expectedTTL+ttlTolerance
+						}, "TTL %f not within range [%f, %f]", actualTTL, expectedTTL-ttlTolerance, expectedTTL+ttlTolerance)
+					}
+				} else {
+					assert.Equal(t, tc.expected[i], result)
+				}
+			}
+
+			// Cleanup
 			DeleteKey(t, conn, exec, tc.cleanupKey)
 		})
 	}

--- a/internal/eval/type_string.go
+++ b/internal/eval/type_string.go
@@ -5,7 +5,6 @@ import (
 
 	diceerrors "github.com/dicedb/dice/internal/errors"
 	"github.com/dicedb/dice/internal/object"
-	dstore "github.com/dicedb/dice/internal/object"
 )
 
 // Similar to
@@ -17,12 +16,12 @@ func deduceTypeEncoding(v string) (o, e uint8) {
 		return object.ObjTypeString, object.ObjEncodingRaw
 	}
 	if _, err := strconv.ParseInt(v, 10, 64); err == nil {
-		return dstore.ObjTypeInt, dstore.ObjEncodingInt
+		return object.ObjTypeInt, object.ObjEncodingInt
 	}
 	if len(v) <= 44 {
-		return dstore.ObjTypeString, dstore.ObjEncodingEmbStr
+		return object.ObjTypeString, object.ObjEncodingEmbStr
 	}
-	return dstore.ObjTypeString, dstore.ObjEncodingRaw
+	return object.ObjTypeString, object.ObjEncodingRaw
 }
 
 // Function to handle converting the value based on the encoding type

--- a/internal/eval/type_string.go
+++ b/internal/eval/type_string.go
@@ -3,12 +3,19 @@ package eval
 import (
 	"strconv"
 
+	diceerrors "github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/object"
 	dstore "github.com/dicedb/dice/internal/object"
 )
 
 // Similar to
 // tryObjectEncoding function in Redis
 func deduceTypeEncoding(v string) (o, e uint8) {
+	// Check if the value has leading zero
+	if len(v) > 1 && v[0] == '0' {
+		// If so, treat as string
+		return object.ObjTypeString, object.ObjEncodingRaw
+	}
 	if _, err := strconv.ParseInt(v, 10, 64); err == nil {
 		return dstore.ObjTypeInt, dstore.ObjEncodingInt
 	}
@@ -16,4 +23,54 @@ func deduceTypeEncoding(v string) (o, e uint8) {
 		return dstore.ObjTypeString, dstore.ObjEncodingEmbStr
 	}
 	return dstore.ObjTypeString, dstore.ObjEncodingRaw
+}
+
+// Function to handle converting the value based on the encoding type
+func storeValueWithEncoding(value string, oEnc uint8) (interface{}, error) {
+	var returnValue interface{}
+
+	// treat as string if value has leading zero
+	if len(value) > 1 && value[0] == '0' {
+		// If so, treat as string
+		return value, nil
+	}
+
+	switch oEnc {
+	case object.ObjEncodingInt:
+		intValue, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, diceerrors.ErrWrongTypeOperation
+		}
+		returnValue = intValue
+	case object.ObjEncodingEmbStr, object.ObjEncodingRaw:
+		returnValue = value
+	default:
+		return nil, diceerrors.ErrWrongTypeOperation
+	}
+
+	return returnValue, nil
+}
+
+// Function to convert the value to a string for concatenation or manipulation
+func convertValueToString(obj *object.Obj, oEnc uint8) (string, error) {
+	var currentValueStr string
+
+	switch oEnc {
+	case object.ObjEncodingInt:
+		// Convert int64 to string for concatenation
+		currentValueStr = strconv.FormatInt(obj.Value.(int64), 10)
+	case object.ObjEncodingEmbStr, object.ObjEncodingRaw:
+		// Use the string value directly
+		currentValueStr = obj.Value.(string)
+	case object.ObjEncodingByteArray:
+		val, ok := obj.Value.(*ByteArray)
+		if !ok {
+			return "", diceerrors.ErrWrongTypeOperation
+		}
+		currentValueStr = string(val.data)
+	default:
+		return "", diceerrors.ErrWrongTypeOperation
+	}
+
+	return currentValueStr, nil
 }


### PR DESCRIPTION
- Resolved an issue where the TTL was incorrectly reset to -1 after using the APPEND command on a key with an existing TTL.
- The TTL is now correctly preserved after appending to a key, matching expected behavior in Redis.
- Added relevant test cases to ensure that TTL is maintained across APPEND operations.
- Tests include scenarios for key expiration after APPEND and correct TTL decrement over time.

## Benchmark
![image](https://github.com/user-attachments/assets/ca691cb0-b1cb-4fd3-b647-a525c75ec0d6)


Closes #1036