### PR TITLE
Fix return value in evalPersist function(when key exists but no expiration is set on it)

### DIFF
--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2818,10 +2818,10 @@ func evalPersist(args []string, store *dstore.Store) []byte {
 		return clientio.RespZero
 	}
 
-	// If the object exists but no expiration is set on it, return -1
+	// If the object exists but no expiration is set on it, return 0
 	_, isExpirySet := dstore.GetExpiry(obj, store)
 	if !isExpirySet {
-		return clientio.RespMinusOne
+		return clientio.RespZero
 	}
 
 	// If the object exists, remove the expiration time

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1988,7 +1988,7 @@ func testEvalPersist(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				evalSET([]string{"existent_no_expiry", "value"}, store)
 			},
-			output: clientio.RespMinusOne,
+			output: clientio.RespZero,
 		},
 		"key exists and expiration removed": {
 			input: []string{"existent_with_expiry"},


### PR DESCRIPTION
Fixes #995 
Now the return is correctly configured to 0 when key exists but no expiration is set on it.