### PR TITLE
Adds support for ZRANGE.WATCH

### DIFF
--- a/integration_tests/commands/resp/getwatch_test.go
+++ b/integration_tests/commands/resp/getwatch_test.go
@@ -36,7 +36,6 @@ func TestGETWATCH(t *testing.T) {
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
 	FireCommand(publisher, fmt.Sprintf("DEL %s", getWatchKey))
-	defer FireCommand(publisher, fmt.Sprintf("DEL %s", getWatchKey))
 
 	defer func() {
 		if err := publisher.Close(); err != nil {
@@ -95,7 +94,6 @@ func TestGETWATCHWithSDK(t *testing.T) {
 	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 
 	publisher.Del(context.Background(), getWatchKey)
-	defer publisher.Del(context.Background(), getWatchKey)
 
 	channels := make([]<-chan *redis.WMessage, len(subscribers))
 	for i, subscriber := range subscribers {

--- a/integration_tests/commands/resp/getwatch_test.go
+++ b/integration_tests/commands/resp/getwatch_test.go
@@ -35,6 +35,9 @@ func TestGETWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
+	FireCommand(publisher, "FLUSHDB")
+	defer FireCommand(publisher, "FLUSHDB")
+
 	defer func() {
 		if err := publisher.Close(); err != nil {
 			t.Errorf("Error closing publisher connection: %v", err)
@@ -90,6 +93,9 @@ func TestGETWATCH(t *testing.T) {
 func TestGETWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
 	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+
+	publisher.FlushDB(context.Background())
+	defer publisher.FlushDB(context.Background())
 
 	channels := make([]<-chan *redis.WMessage, len(subscribers))
 	for i, subscriber := range subscribers {

--- a/integration_tests/commands/resp/getwatch_test.go
+++ b/integration_tests/commands/resp/getwatch_test.go
@@ -35,8 +35,8 @@ func TestGETWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
-	FireCommand(publisher, "FLUSHDB")
-	defer FireCommand(publisher, "FLUSHDB")
+	FireCommand(publisher, fmt.Sprintf("DEL %s", getWatchKey))
+	defer FireCommand(publisher, fmt.Sprintf("DEL %s", getWatchKey))
 
 	defer func() {
 		if err := publisher.Close(); err != nil {
@@ -94,8 +94,8 @@ func TestGETWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
 	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 
-	publisher.FlushDB(context.Background())
-	defer publisher.FlushDB(context.Background())
+	publisher.Del(context.Background(), getWatchKey)
+	defer publisher.Del(context.Background(), getWatchKey)
 
 	channels := make([]<-chan *redis.WMessage, len(subscribers))
 	for i, subscriber := range subscribers {

--- a/integration_tests/commands/resp/zrangewatch_test.go
+++ b/integration_tests/commands/resp/zrangewatch_test.go
@@ -1,0 +1,113 @@
+package resp
+
+import (
+	"context"
+	"fmt"
+	"github.com/dicedb/dice/internal/clientio"
+	redis "github.com/dicedb/go-dice"
+	"gotest.tools/v3/assert"
+	"net"
+	"testing"
+	"time"
+)
+
+type zrangeWatchTestCase struct {
+	key    string
+	score  float64
+	val    string
+	result []any
+}
+
+const (
+	zrangeWatchKey   = "zrangewatchkey"
+	zrangeWatchQuery = "ZRANGE.WATCH %s 0 -1 REV WITHSCORES"
+)
+
+var zrangeWatchTestCases = []zrangeWatchTestCase{
+	{zrangeWatchKey, 1.0, "member1", []any{"member1", "1"}},
+	{zrangeWatchKey, 2.0, "member2", []any{"member2", "2", "member1", "1"}},
+	{zrangeWatchKey, 3.0, "member3", []any{"member3", "3", "member2", "2", "member1", "1"}},
+	{zrangeWatchKey, 4.0, "member4", []any{"member4", "4", "member3", "3", "member2", "2", "member1", "1"}},
+}
+
+func TestZRANGEWATCH(t *testing.T) {
+	publisher := getLocalConnection()
+	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
+
+	defer func() {
+		if err := publisher.Close(); err != nil {
+			t.Errorf("Error closing publisher connection: %v", err)
+		}
+		for _, sub := range subscribers {
+			time.Sleep(100 * time.Millisecond)
+			if err := sub.Close(); err != nil {
+				t.Errorf("Error closing subscriber connection: %v", err)
+			}
+		}
+	}()
+
+	respParsers := make([]*clientio.RESPParser, len(subscribers))
+	for i, subscriber := range subscribers {
+		rp := fireCommandAndGetRESPParser(subscriber, fmt.Sprintf(zrangeWatchQuery, zrangeWatchKey))
+		assert.Assert(t, rp != nil)
+		respParsers[i] = rp
+
+		v, err := rp.DecodeOne()
+		assert.NilError(t, err)
+		castedValue, ok := v.([]interface{})
+		if !ok {
+			t.Errorf("Type assertion to []interface{} failed for value: %v", v)
+		}
+		assert.Equal(t, 3, len(castedValue))
+	}
+
+	// Fire updates to the sorted set and check if the subscribers receive the updates in the push-response form
+	for _, tc := range zrangeWatchTestCases {
+		FireCommand(publisher, fmt.Sprintf("ZADD %s %f %s", tc.key, tc.score, tc.val))
+
+		for _, rp := range respParsers {
+			v, err := rp.DecodeOne()
+			assert.NilError(t, err)
+			castedValue, ok := v.([]interface{})
+			if !ok {
+				t.Errorf("Type assertion to []interface{} failed for value: %v", v)
+			}
+			assert.Equal(t, 3, len(castedValue))
+			assert.Equal(t, "ZRANGE", castedValue[0])
+			assert.Equal(t, "2491069200", castedValue[1])
+			assert.DeepEqual(t, tc.result, castedValue[2])
+		}
+	}
+}
+
+func TestZRANGEWATCHWithSDK(t *testing.T) {
+	publisher := getLocalSdk()
+	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+
+	channels := make([]<-chan *redis.WMessage, len(subscribers))
+	for i, subscriber := range subscribers {
+		watch := subscriber.client.WatchCommand(context.Background())
+		subscribers[i].watch = watch
+		assert.Assert(t, watch != nil)
+		err := watch.Watch(context.Background(), "ZRANGE", zrangeWatchKey, "0", "-1", "REV", "WITHSCORES")
+		assert.NilError(t, err)
+		channels[i] = watch.Channel()
+		<-channels[i] // Get the first message
+	}
+
+	for _, tc := range zrangeWatchTestCases {
+		err := publisher.ZAdd(context.Background(), tc.key, redis.Z{
+			Score:  tc.score,
+			Member: tc.val,
+		}).Err()
+		assert.NilError(t, err)
+
+		for _, channel := range channels {
+			v := <-channel
+
+			assert.Equal(t, "ZRANGE", v.Command)   // command
+			assert.Equal(t, "2491069200", v.Name)  // Fingerprint
+			assert.DeepEqual(t, tc.result, v.Data) // data
+		}
+	}
+}

--- a/integration_tests/commands/resp/zrangewatch_test.go
+++ b/integration_tests/commands/resp/zrangewatch_test.go
@@ -34,8 +34,8 @@ func TestZRANGEWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
-	FireCommand(publisher, "FLUSHDB")
-	defer FireCommand(publisher, "FLUSHDB")
+	FireCommand(publisher, fmt.Sprintf("DEL %s", zrangeWatchKey))
+	defer FireCommand(publisher, fmt.Sprintf("DEL %s", zrangeWatchKey))
 
 	defer func() {
 		if err := publisher.Close(); err != nil {
@@ -87,8 +87,8 @@ func TestZRANGEWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
 	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 
-	publisher.FlushDB(context.Background())
-	defer publisher.FlushDB(context.Background())
+	publisher.Del(context.Background(), zrangeWatchKey)
+	defer publisher.Del(context.Background(), zrangeWatchKey)
 
 	channels := make([]<-chan *redis.WMessage, len(subscribers))
 	for i, subscriber := range subscribers {

--- a/integration_tests/commands/resp/zrangewatch_test.go
+++ b/integration_tests/commands/resp/zrangewatch_test.go
@@ -35,7 +35,6 @@ func TestZRANGEWATCH(t *testing.T) {
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
 	FireCommand(publisher, fmt.Sprintf("DEL %s", zrangeWatchKey))
-	defer FireCommand(publisher, fmt.Sprintf("DEL %s", zrangeWatchKey))
 
 	defer func() {
 		if err := publisher.Close(); err != nil {
@@ -88,7 +87,6 @@ func TestZRANGEWATCHWithSDK(t *testing.T) {
 	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 
 	publisher.Del(context.Background(), zrangeWatchKey)
-	defer publisher.Del(context.Background(), zrangeWatchKey)
 
 	channels := make([]<-chan *redis.WMessage, len(subscribers))
 	for i, subscriber := range subscribers {

--- a/integration_tests/commands/resp/zrangewatch_test.go
+++ b/integration_tests/commands/resp/zrangewatch_test.go
@@ -34,6 +34,9 @@ func TestZRANGEWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
+	FireCommand(publisher, "FLUSHDB")
+	defer FireCommand(publisher, "FLUSHDB")
+
 	defer func() {
 		if err := publisher.Close(); err != nil {
 			t.Errorf("Error closing publisher connection: %v", err)
@@ -83,6 +86,9 @@ func TestZRANGEWATCH(t *testing.T) {
 func TestZRANGEWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
 	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+
+	publisher.FlushDB(context.Background())
+	defer publisher.FlushDB(context.Background())
 
 	channels := make([]<-chan *redis.WMessage, len(subscribers))
 	for i, subscriber := range subscribers {

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -4761,7 +4761,7 @@ func evalZADD(args []string, store *dstore.Store) []byte {
 	}
 
 	obj = store.NewObj(ss, -1, object.ObjTypeSortedSet, object.ObjEncodingBTree)
-	store.Put(key, obj)
+	store.Put(key, obj, dstore.WithPutCmd(dstore.ZAdd))
 
 	return clientio.Encode(added, false)
 }

--- a/internal/store/constants.go
+++ b/internal/store/constants.go
@@ -5,4 +5,6 @@ const (
 	Del    string = "DEL"
 	Get    string = "GET"
 	Rename string = "RENAME"
+	ZAdd   string = "ZADD"
+	ZRange string = "ZRANGE"
 )

--- a/internal/watchmanager/watch_manager.go
+++ b/internal/watchmanager/watch_manager.go
@@ -31,6 +31,7 @@ var (
 		dstore.Set:    {dstore.Get: struct{}{}},
 		dstore.Del:    {dstore.Get: struct{}{}},
 		dstore.Rename: {dstore.Get: struct{}{}},
+		dstore.ZAdd:   {dstore.ZRange: struct{}{}},
 	}
 )
 

--- a/internal/worker/cmd_meta.go
+++ b/internal/worker/cmd_meta.go
@@ -41,10 +41,11 @@ const (
 
 // Single-shard commands.
 const (
-	CmdSet      = "SET"
-	CmdGet      = "GET"
-	CmdGetSet   = "GETSET"
-	CmdGetWatch = "GET.WATCH"
+	CmdSet         = "SET"
+	CmdGet         = "GET"
+	CmdGetSet      = "GETSET"
+	CmdGetWatch    = "GET.WATCH"
+	CmdZRangeWatch = "ZRANGE.WATCH"
 )
 
 type CmdMeta struct {
@@ -90,6 +91,9 @@ var CommandsMeta = map[string]CmdMeta{
 
 	// Watch commands
 	CmdGetWatch: {
+		CmdType: Watch,
+	},
+	CmdZRangeWatch: {
 		CmdType: Watch,
 	},
 }


### PR DESCRIPTION
# Add ZRANGE.WATCH command and related functionality

This PR adds support for the ZRANGE.WATCH command, allowing clients to watch for changes to sorted sets. The main changes include:

1. New integration test for ZRANGE.WATCH command
2. Added ZAdd and ZRange constants in store/constants.go
3. Updated watchmanager to support ZRANGE.WATCH
4. Added ZRANGE.WATCH command metadata
5. Modified ZADD command to use the WithPutCmd option to properly track the changes.

Both raw RESP protocol and SDK-based tests are included to ensure compatibility.