### PR TITLE
#1070: Fixes Async Server when incorrect command leads to inconsistent output

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -320,6 +320,7 @@ func (s *AsyncServer) executeCommandToBuffer(diceDBCmd *cmd.DiceDBCmd, buf *byte
 		// Handle error case independently
 		if resp.EvalResponse.Error != nil {
 			handleMigratedResp(resp.EvalResponse.Error, buf)
+			return
 		}
 		handleMigratedResp(resp.EvalResponse.Result, buf)
 		return


### PR DESCRIPTION
Fixes #1070 
All test pass.
