### PR TITLE
fix: switch logging mode to dev by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /app
 COPY --from=builder /dicedb/dicedb ./
 EXPOSE  7379
+ENV DICE_ENV=prod
 CMD ["/app/dicedb"]

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To run the live DiceDB server for local development:
 ```sh
 $ git clone https://github.com/dicedb/dice
 $ cd dice
-$ DICE_ENV=dev air
+$ air
 ```
 
 > The `DICE_ENV` environment variable is used set the environment, by default it is treated as production. `dev` is used to get pretty printed logs and lower log level.

--- a/config/config.go
+++ b/config/config.go
@@ -127,8 +127,8 @@ var baseConfig = Config{
 		AOFFile:                "./dice-master.aof",
 		WriteAOFOnCleanup:      false,
 		LFULogFactor:           10,
-		LogLevel:               "info",
-		PrettyPrintLogs:        false,
+		LogLevel:               "debug",
+		PrettyPrintLogs:        true,
 		EnableMultiThreading:   false,
 		StoreMapInitSize:       1024000,
 		WatchChanBufSize:       20000,
@@ -156,9 +156,9 @@ func init() {
 	config := baseConfig
 	env := os.Getenv("DICE_ENV")
 	switch env {
-	case "dev":
-		config.Server.LogLevel = "debug"
-		config.Server.PrettyPrintLogs = true
+	case "prod":
+		config.Server.LogLevel = "info"
+		config.Server.PrettyPrintLogs = false
 	default:
 	}
 	logLevel := os.Getenv("DICE_LOG_LEVEL")


### PR DESCRIPTION
This PR makes dev mode logging the default.

This PR also makes sure that the dockerifle is built with prod mode logging