### PR TITLE
#951 Design for Hash with expiry, Open for Review

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -1083,6 +1083,23 @@ var (
 		Eval:     evalGEODIST,
 		KeySpecs: KeySpecs{BeginIndex: 1},
 	}
+	hexpireCmdMeta = DiceCmdMeta{
+		Name: "HEXPIRE",
+		Info: `Set an expiration (TTL or time to live) on one or more fields of a given hash key. 
+		You must specify at least one field. Field(s) will automatically be deleted from the hash 
+		key when their TTLs expire.`,
+		Arity: -5,
+		Eval:  evalHEXPIRE,
+	}
+	httlCmdMeta = DiceCmdMeta{
+		Name: "HTTL",
+		Info: `Returns the remaining TTL (time to live) of a hash key's field(s) that have a set 
+		expiration. This introspection capability allows you to check how many seconds a given 
+		hash field will continue to be part of the hash key.`,
+		Arity:    -4,
+		Eval:     evalHTTL,
+		KeySpecs: KeySpecs{BeginIndex: 4, Step: 1},
+	}
 )
 
 func init() {
@@ -1203,6 +1220,8 @@ func init() {
 	DiceCmds["HEXISTS"] = hexistsCmdMeta
 	DiceCmds["GEOADD"] = geoAddCmdMeta
 	DiceCmds["GEODIST"] = geoDistCmdMeta
+	DiceCmds["HEXPIRE"] = hexpireCmdMeta
+	DiceCmds["HTTL"] = httlCmdMeta
 }
 
 // Function to convert DiceCmdMeta to []interface{}

--- a/internal/eval/constants.go
+++ b/internal/eval/constants.go
@@ -40,4 +40,7 @@ const (
 	SIGNED     string = "SIGNED"
 	UNSIGNED   string = "UNSIGNED"
 	FIELDS     string = "FIELDS"
+	NOT_FOUND  int64  = -2
+	PAST       int64  = -1
+	EXPIRY_SET int64  = 1
 )

--- a/internal/eval/constants.go
+++ b/internal/eval/constants.go
@@ -39,4 +39,5 @@ const (
 	FAIL       string = "FAIL"
 	SIGNED     string = "SIGNED"
 	UNSIGNED   string = "UNSIGNED"
+	FIELDS     string = "FIELDS"
 )

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -2919,7 +2919,7 @@ func testEvalHSET(t *testing.T, store *dstore.Store) {
 				res, ok := hashMap.Get(field)
 
 				assert.Assert(t, ok == true)
-				assert.DeepEqual(t, res, mockValue)
+				assert.DeepEqual(t, *res, mockValue)
 			},
 			input: []string{
 				"KEY_MOCK",
@@ -3009,7 +3009,7 @@ func testEvalHMSET(t *testing.T, store *dstore.Store) {
 				res, ok := hashMap.Get(field)
 
 				assert.Assert(t, ok == true)
-				assert.DeepEqual(t, res, mockValue)
+				assert.DeepEqual(t, *res, mockValue)
 			},
 			input: []string{
 				"KEY_MOCK",

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -2131,8 +2131,8 @@ func testEvalHGET(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2149,8 +2149,8 @@ func testEvalHGET(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2189,8 +2189,8 @@ func testEvalHMGET(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2207,8 +2207,8 @@ func testEvalHMGET(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2224,10 +2224,11 @@ func testEvalHMGET(t *testing.T, store *dstore.Store) {
 		"some fields exist some do not": {
 			setup: func() {
 				key := "KEY_MOCK"
-				newMap := HashMap{
+				newMap := NewHashMap[string, string]()
+				newMap.SetAll(map[string]string{
 					"field1": "value1",
 					"field2": "value2",
-				}
+				})
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          newMap,
@@ -2260,8 +2261,8 @@ func testEvalHVALS(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2299,8 +2300,8 @@ func testEvalHSTRLEN(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2317,8 +2318,8 @@ func testEvalHSTRLEN(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "HelloWorld"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "HelloWorld")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2357,8 +2358,8 @@ func testEvalHEXISTS(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2375,8 +2376,8 @@ func testEvalHEXISTS(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "HelloWorld"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "HelloWorld")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2823,8 +2824,6 @@ func runEvalTests(t *testing.T, tests map[string]evalTestCase, evalFunc func([]s
 			if tc.validator != nil {
 				tc.validator(output)
 			} else {
-				fmt.Println(tc.output)
-				fmt.Println(output)
 				assert.Equal(t, string(tc.output), string(output))
 			}
 		})
@@ -2882,8 +2881,8 @@ func testEvalHSET(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2901,8 +2900,8 @@ func testEvalHSET(t *testing.T, store *dstore.Store) {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
 				mockValue := "mock_field_value"
-				newMap := make(HashMap)
-				newMap[field] = mockValue
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, mockValue)
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2913,10 +2912,14 @@ func testEvalHSET(t *testing.T, store *dstore.Store) {
 				store.Put(key, obj)
 
 				// Check if the map is saved correctly in the store
-				res, err := getValueFromHashMap(key, field, store)
+				obj = store.Get(key)
+				assert.Assert(t, obj != nil)
 
-				assert.Assert(t, err == nil)
-				assert.DeepEqual(t, res, clientio.Encode(mockValue, false))
+				hashMap := obj.Value.(StrStrHashMap)
+				res, ok := hashMap.Get(field)
+
+				assert.Assert(t, ok == true)
+				assert.DeepEqual(t, res, mockValue)
 			},
 			input: []string{
 				"KEY_MOCK",
@@ -2968,8 +2971,9 @@ func testEvalHMSET(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2987,8 +2991,8 @@ func testEvalHMSET(t *testing.T, store *dstore.Store) {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
 				mockValue := "mock_field_value"
-				newMap := make(HashMap)
-				newMap[field] = mockValue
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, mockValue)
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -2997,12 +3001,15 @@ func testEvalHMSET(t *testing.T, store *dstore.Store) {
 				}
 
 				store.Put(key, obj)
-
 				// Check if the map is saved correctly in the store
-				res, err := getValueFromHashMap(key, field, store)
+				obj = store.Get(key)
+				assert.Assert(t, obj != nil)
 
-				assert.Assert(t, err == nil)
-				assert.DeepEqual(t, res, clientio.Encode(mockValue, false))
+				hashMap := obj.Value.(StrStrHashMap)
+				res, ok := hashMap.Get(field)
+
+				assert.Assert(t, ok == true)
+				assert.DeepEqual(t, res, mockValue)
 			},
 			input: []string{
 				"KEY_MOCK",
@@ -3041,8 +3048,8 @@ func testEvalHKEYS(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field1 := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field1] = "HelloWorld"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field1, "HelloWorld")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -4088,8 +4095,8 @@ func testEvalHSETNX(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "KEY_MOCK"
 				field := "mock_field_name"
-				newMap := make(HashMap)
-				newMap[field] = "mock_field_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "mock_field_value")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -4155,8 +4162,8 @@ func testEvalHINCRBY(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = "10"
+				h := NewHashMap[string, string]()
+				h.Set(field, "10")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -4181,8 +4188,8 @@ func testEvalHINCRBY(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "new_key"
 				field := "new_field"
-				newMap := make(HashMap)
-				newMap[field] = "new_value"
+				newMap := NewHashMap[string, string]()
+				newMap.Set(field, "new_value")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          newMap,
@@ -4198,8 +4205,8 @@ func testEvalHINCRBY(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = " 10  "
+				h := NewHashMap[string, string]()
+				h.Set(field, " 10  ")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -4220,9 +4227,8 @@ func testEvalHINCRBY(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-
-				h[field] = "-10"
+				h := NewHashMap[string, string]()
+				h.Set(field, "-10")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -4237,9 +4243,8 @@ func testEvalHINCRBY(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-
-				h[field] = fmt.Sprintf("%v", math.MaxInt64)
+				h := NewHashMap[string, string]()
+				h.Set(field, fmt.Sprintf("%v", math.MaxInt64))
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -4254,9 +4259,8 @@ func testEvalHINCRBY(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-
-				h[field] = fmt.Sprintf("%v", math.MinInt64)
+				h := NewHashMap[string, string]()
+				h.Set(field, fmt.Sprintf("%v", math.MinInt64))
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -4701,9 +4705,9 @@ func testEvalHRANDFIELD(t *testing.T, store *dstore.Store) {
 		"key exists with fields and no count argument": {
 			setup: func() {
 				key := "KEY_MOCK"
-				newMap := make(HashMap)
-				newMap["field1"] = "Value1"
-				newMap["field2"] = "Value2"
+				newMap := NewHashMap[string, string]()
+				newMap.Set("field1", "Value1")
+				newMap.Set("field2", "Value2")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -4725,10 +4729,10 @@ func testEvalHRANDFIELD(t *testing.T, store *dstore.Store) {
 		"key exists with fields and count argument": {
 			setup: func() {
 				key := "KEY_MOCK"
-				newMap := make(HashMap)
-				newMap["field1"] = "value1"
-				newMap["field2"] = "value2"
-				newMap["field3"] = "value3"
+				newMap := NewHashMap[string, string]()
+				newMap.Set("field1", "value1")
+				newMap.Set("field2", "value2")
+				newMap.Set("field3", "value3")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -4758,10 +4762,10 @@ func testEvalHRANDFIELD(t *testing.T, store *dstore.Store) {
 		"key exists with count and WITHVALUES argument": {
 			setup: func() {
 				key := "KEY_MOCK"
-				newMap := make(HashMap)
-				newMap["field1"] = "value1"
-				newMap["field2"] = "value2"
-				newMap["field3"] = "value3"
+				newMap := NewHashMap[string, string]()
+				newMap.Set("field1", "value1")
+				newMap.Set("field2", "value2")
+				newMap.Set("field3", "value3")
 
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
@@ -4922,10 +4926,7 @@ func testEvalAPPEND(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "hashKey"
 				// Create a new hash map object
-				initialValues := HashMap{
-					"field1": "value1",
-					"field2": "value2",
-				}
+				initialValues := NewHashMap[string, string]()
 				obj := store.NewObj(initialValues, -1, object.ObjTypeHashMap, object.ObjEncodingHashMap)
 				store.Put(key, obj)
 			},
@@ -5291,7 +5292,7 @@ func testEvalHINCRBYFLOAT(t *testing.T, store *dstore.Store) {
 		"HINCRBYFLOAT on an existing key and non-existing field": {
 			setup: func() {
 				key := "key"
-				h := make(HashMap)
+				h := NewHashMap[string, string]()
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -5306,8 +5307,8 @@ func testEvalHINCRBYFLOAT(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = "2.1"
+				h := NewHashMap[string, string]()
+				h.Set(field, "2.1")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -5322,8 +5323,8 @@ func testEvalHINCRBYFLOAT(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = "2"
+				h := NewHashMap[string, string]()
+				h.Set(field, "2")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -5338,8 +5339,8 @@ func testEvalHINCRBYFLOAT(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = "2.0"
+				h := NewHashMap[string, string]()
+				h.Set(field, "2.0")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -5355,8 +5356,8 @@ func testEvalHINCRBYFLOAT(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = "2.0"
+				h := NewHashMap[string, string]()
+				h.Set(field, "2.0")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -5372,8 +5373,8 @@ func testEvalHINCRBYFLOAT(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = "non_numeric"
+				h := NewHashMap[string, string]()
+				h.Set(field, "non_numeric")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -5389,8 +5390,8 @@ func testEvalHINCRBYFLOAT(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = "1e308"
+				h := NewHashMap[string, string]()
+				h.Set(field, "1e308")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -5405,8 +5406,8 @@ func testEvalHINCRBYFLOAT(t *testing.T, store *dstore.Store) {
 			setup: func() {
 				key := "key"
 				field := "field"
-				h := make(HashMap)
-				h[field] = "1e2"
+				h := NewHashMap[string, string]()
+				h.Set(field, "1e2")
 				obj := &object.Obj{
 					TypeEncoding:   object.ObjTypeHashMap | object.ObjEncodingHashMap,
 					Value:          h,
@@ -5426,8 +5427,14 @@ func BenchmarkEvalHINCRBYFLOAT(b *testing.B) {
 	store := dstore.NewStore(nil, nil)
 
 	// Setting initial fields with some values
-	store.Put("key1", store.NewObj(HashMap{"field1": "1.0", "field2": "1.2"}, maxExDuration, object.ObjTypeHashMap, object.ObjEncodingHashMap))
-	store.Put("key2", store.NewObj(HashMap{"field1": "0.1"}, maxExDuration, object.ObjTypeHashMap, object.ObjEncodingHashMap))
+	h1 := NewHashMap[string, string]()
+	h1.SetAll(map[string]string{"field1": "1.0", "field2": "1.2"})
+
+	h2 := NewHashMap[string, string]()
+	h2.SetAll(map[string]string{"field1": "0.1"})
+
+	store.Put("key1", store.NewObj(h1, maxExDuration, object.ObjTypeHashMap, object.ObjEncodingHashMap))
+	store.Put("key2", store.NewObj(h2, maxExDuration, object.ObjTypeHashMap, object.ObjEncodingHashMap))
 
 	inputs := []struct {
 		key   string

--- a/internal/eval/hmap.go
+++ b/internal/eval/hmap.go
@@ -1,133 +1,196 @@
 package eval
 
 import (
-	"fmt"
-	"math"
-	"strconv"
-
-	"github.com/dicedb/dice/internal/clientio"
-	diceerrors "github.com/dicedb/dice/internal/errors"
-	dstore "github.com/dicedb/dice/internal/store"
+	"time"
 )
 
-type HashMap map[string]string
-
-func (h HashMap) Get(k string) (*string, bool) {
-	value, ok := h[k]
-	if !ok {
-		return nil, false
-	}
-	return &value, true
+// HashMap is a generic implementation of a hashmap with expiration support.
+// hmap stores the actual values
+// expires stores the expiry values
+type HashMap[K comparable, V any] struct {
+	hmap    map[K]V
+	expires map[K]uint64
 }
 
-func (h HashMap) Set(k, v string) (*string, bool) {
-	value, ok := h[k]
+// NewHashMap creates a new instance of HashMap.
+func NewHashMap[K comparable, V any]() *HashMap[K, V] {
+	return &HashMap[K, V]{
+		hmap:    make(map[K]V),
+		expires: make(map[K]uint64),
+	}
+}
+
+// Keys returns all valid keys in the map.
+// Any key which is past its ttl will be deleted
+func (h *HashMap[K, V]) Keys() []K {
+	keys := make([]K, 0, len(h.hmap))
+	for k := range h.hmap {
+		if _, ok := h.Get(k); ok {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// Values returns all valid values in the map.
+// Any key which is past its ttl will be deleted
+func (h *HashMap[K, V]) Values() []V {
+	values := make([]V, 0, len(h.hmap))
+	for k := range h.hmap {
+		if val, ok := h.Get(k); ok {
+			values = append(values, val)
+		}
+	}
+	return values
+}
+
+// Items returns all valid key-value pairs in the map.
+// Any key which is past its ttl will be deleted
+func (h *HashMap[K, V]) Items() [][]interface{} {
+	items := make([][]interface{}, 0, len(h.hmap))
+	for k, v := range h.hmap {
+		if _, ok := h.Get(k); ok {
+			items = append(items, []interface{}{k, v})
+		}
+	}
+	return items
+}
+
+// Clear removes all entries from the HashMap, resetting it to an empty state.
+func (h *HashMap[K, V]) Clear() {
+	h.hmap = make(map[K]V)
+	h.expires = make(map[K]uint64)
+}
+
+// ApproxLength returns the approximate length of the HashMap.
+// This counts all the entries in the map, including potentially expired ones.
+// This method can be used for creating slices using make()
+func (h *HashMap[K, V]) ApproxLength() int {
+	return len(h.hmap)
+}
+
+// ActualValidLength returns the actual number of valid entries in the HashMap.
+// It counts only those entries that have not expired.
+func (h *HashMap[K, V]) Len() int {
+	validKeys := h.Keys()
+	return len(validKeys)
+}
+
+// hasExpired checks if the key has expired.
+func (h *HashMap[K, V]) hasExpired(k K) bool {
+	exp, ok := h.expires[k]
+	if !ok {
+		return false
+	}
+	return exp <= uint64(time.Now().UnixMilli())
+}
+
+// GetExpiry returns the expiry time for a given key\
+// with an expiry set
+func (h *HashMap[K, V]) GetExpiry(k K) (uint64, bool) {
+	expiryMs, ok := h.expires[k]
+	return expiryMs, ok
+}
+
+// SetExpiry sets an expiry time for a given key.
+func (h *HashMap[K, V]) SetExpiry(k K, expiryMs uint64) {
+	h.expires[k] = expiryMs
+}
+
+// Get retrieves the value associated with a key, checking expiration.
+// Any key which is past its ttl will be deleted
+func (h *HashMap[K, V]) Get(k K) (V, bool) {
+	value, ok := h.hmap[k]
+	if ok && h.hasExpired(k) {
+		h.Delete(k)
+		return *new(V), false
+	}
+	return value, ok
+}
+
+// Delete removes a key and its expiration from the map.
+func (h *HashMap[K, V]) Delete(k K) bool {
+	_, ok := h.hmap[k]
 	if ok {
-		oldValue := value
-		h[k] = v
-		return &oldValue, true
+		delete(h.hmap, k)
+		delete(h.expires, k)
 	}
-
-	h[k] = v
-	return nil, false
+	return ok
 }
 
-func hashMapBuilder(keyValuePairs []string, currentHashMap HashMap) (HashMap, int64, error) {
-	var hmap HashMap
-	var numKeysNewlySet int64
-
-	if currentHashMap == nil {
-		hmap = make(HashMap)
-	} else {
-		hmap = currentHashMap
-	}
-
-	iter := 0
-	argLength := len(keyValuePairs)
-
-	for iter <= argLength-1 {
-		if iter >= argLength-1 || iter+1 > argLength-1 {
-			return hmap, -1, diceerrors.NewErr(fmt.Sprintf(diceerrors.ArityErr, "HSET"))
-		}
-
-		k := keyValuePairs[iter]
-		v := keyValuePairs[iter+1]
-
-		_, present := hmap.Set(k, v)
-		if !present {
-			numKeysNewlySet++
-		}
-		iter += 2
-	}
-
-	return hmap, numKeysNewlySet, nil
+// SetHelper sets a value in the map and removes expiration.
+func (h *HashMap[K, V]) SetHelper(k K, v V) (V, bool) {
+	oldVal, ok := h.hmap[k]
+	h.hmap[k] = v
+	delete(h.expires, k)
+	return oldVal, ok
 }
 
-func getValueFromHashMap(key, field string, store *dstore.Store) (val, err []byte) {
-	var value string
-
-	obj := store.Get(key)
-
-	if obj == nil {
-		return clientio.RespNIL, nil
-	}
-
-	switch currentVal := obj.Value.(type) {
-	case HashMap:
-		val, present := currentVal.Get(field)
-		if !present {
-			return clientio.RespNIL, nil
-		}
-		value = *val
-	default:
-		return nil, diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr)
-	}
-
-	return clientio.Encode(value, false), nil
+// Set adds or updates a value in the map.
+func (h *HashMap[K, V]) Set(k K, v V) (V, bool) {
+	return h.SetHelper(k, v)
 }
 
-func (h HashMap) incrementValue(field string, increment int64) (int64, error) {
-	val, ok := h[field]
+// SetAll adds or updates multiple values in the map.
+func (h *HashMap[K, V]) SetAll(data map[K]V) int64 {
+	var cnt int64
+	for k, v := range data {
+		_, ok := h.hmap[k]
+		if !ok {
+			cnt++
+		}
+		h.hmap[k] = v
+	}
+	return cnt
+}
+
+// ModifyOrCreate modifies the value associated with the given key using the provided modifier function.
+// If the key does not exist, a new value will be created based on the modifier's logic.
+// The modifier function takes the current value of type V and returns a modified value and an optional error.
+//
+// Example 1: Incrementing an Integer Value
+//
+//	hMap := NewHashMap[string, int]()
+//	modifier := func(currentValue int) (int, error) {
+//	    return currentValue + 1, nil // Increment the current value by 1
+//	}
+//	err := hMap.ModifyOrCreate("counter", modifier)
+//	if err != nil {
+//	    fmt.Println("Error modifying value:", err)
+//	}
+//
+// Example 2: Updating a Field in a Struct
+//
+//	type User struct {
+//	    Name  string
+//	    Age   int
+//	    Email string
+//	}
+//
+//	hMap := NewHashMap[string, User]()
+//	modifier := func(currentValue User) (User, error) {
+//	    currentValue.Age += 1 // Increment the user's age by 1
+//	    return currentValue, nil
+//	}
+//	err := hMap.ModifyOrCreate("john_doe", modifier)
+//	if err != nil {
+//	    fmt.Println("Error modifying value:", err)
+//	}
+//
+// In this example, if the key "john_doe" exists, the "Age" field of the User struct is incremented by 1.
+// If the key does not exist, the modifier will use the zero value for the User struct, where all fields are initialized
+// to their zero values (empty string for Name and Email, 0 for Age), and increment the Age to 1.
+//
+// The ModifyOrCreate method allows for flexible modifications of complex data types based on the provided logic.
+func (h *HashMap[K, V]) CreateOrModify(k K, modifier func(V) (V, error)) (V, error) {
+	val, ok := h.hmap[k]
 	if !ok {
-		h[field] = fmt.Sprintf("%v", increment)
-		return increment, nil
+		val = *new(V)
 	}
-
-	i, err := strconv.ParseInt(val, 10, 64)
+	newVal, err := modifier(val)
 	if err != nil {
-		return -1, diceerrors.NewErr(diceerrors.HashValueNotIntegerErr)
+		return val, err
 	}
-
-	if (i > 0 && increment > 0 && i > math.MaxInt64-increment) || (i < 0 && increment < 0 && i < math.MinInt64-increment) {
-		return -1, diceerrors.NewErr(diceerrors.IncrDecrOverflowErr)
-	}
-
-	total := i + increment
-	h[field] = fmt.Sprintf("%v", total)
-
-	return total, nil
-}
-
-func (h HashMap) incrementFloatValue(field string, incr float64) (string, error) {
-	val, ok := h[field]
-	if !ok {
-		h[field] = fmt.Sprintf("%v", incr)
-		strValue := formatFloat(incr, false)
-		return strValue, nil
-	}
-
-	i, err := strconv.ParseFloat(val, 64)
-	if err != nil {
-		return "-1", diceerrors.NewErr(diceerrors.IntOrFloatErr)
-	}
-
-	if math.IsInf(i+incr, 1) || math.IsInf(i+incr, -1) {
-		return "-1", diceerrors.NewErr(diceerrors.IncrDecrOverflowErr)
-	}
-
-	total := i + incr
-	strValue := formatFloat(total, false)
-	h[field] = fmt.Sprintf("%v", total)
-
-	return strValue, nil
+	h.hmap[k] = newVal
+	return newVal, nil
 }

--- a/internal/eval/hmap_test.go
+++ b/internal/eval/hmap_test.go
@@ -19,7 +19,7 @@ func TestSetAndGet(t *testing.T) {
 
 	val, ok := hmap.Get("key1")
 	assert.True(t, ok, "Expected key1 to exist")
-	assert.Equal(t, "value1", val, "Expected value1 to be returned")
+	assert.Equal(t, "value1", *val, "Expected value1 to be returned")
 
 	// Test non-existent key
 	val, ok = hmap.Get("key2")
@@ -81,20 +81,6 @@ func TestValues(t *testing.T) {
 	assert.NotContains(t, values, "value2", "Expected value2 to be expired and not in valid values")
 }
 
-// func TestItems(t *testing.T) {
-// 	hmap := NewHashMap[string, string]()
-// 	hmap.Set("key1", "value1")
-// 	hmap.Set("key2", "value2")
-
-// 	// Set expiry for key2
-// 	hmap.SetExpiry("key2", uint64(time.Now().UnixMilli()-1000)) // key2 expired
-
-// 	items := hmap.Items()
-// 	assert.Equal(t, 1, len(items), "Expected only 1 valid item")
-// 	assert.Equal(t, "value1", items["key1"][1].(string), "Expected key1 to map to value1")
-// 	assert.NotContains(t, items, "key2", "Expected key2 to be expired and not in items")
-// }
-
 func TestClear(t *testing.T) {
 	hmap := NewHashMap[string, string]()
 	hmap.Set("key1", "value1")
@@ -111,7 +97,7 @@ func TestApproxLength(t *testing.T) {
 	assert.Equal(t, 2, hmap.ApproxLength(), "Expected approximate length to be 2")
 }
 
-func TestActualValidLength(t *testing.T) {
+func TestLen(t *testing.T) {
 	hmap := NewHashMap[string, string]()
 	hmap.Set("key1", "value1")
 	hmap.Set("key2", "value2")
@@ -135,7 +121,7 @@ func TestDelete(t *testing.T) {
 	// Ensure key2 still exists
 	val, ok := hmap.Get("key2")
 	assert.True(t, ok, "Expected key2 to still exist")
-	assert.Equal(t, "value2", val, "Expected value2 for key2")
+	assert.Equal(t, "value2", *val, "Expected value2 for key2")
 }
 
 func TestCreateOrModify(t *testing.T) {
@@ -152,7 +138,7 @@ func TestCreateOrModify(t *testing.T) {
 
 	val, ok := hmap.Get("counter")
 	assert.True(t, ok, "Expected counter to exist")
-	assert.Equal(t, 1, val, "Expected counter to be initialized to 1")
+	assert.Equal(t, 1, *val, "Expected counter to be initialized to 1")
 
 	// Increment again
 	_, err = hmap.CreateOrModify("counter", modifier)
@@ -160,5 +146,5 @@ func TestCreateOrModify(t *testing.T) {
 
 	val, ok = hmap.Get("counter")
 	assert.True(t, ok, "Expected counter to exist")
-	assert.Equal(t, 2, val, "Expected counter to be incremented to 2")
+	assert.Equal(t, 2, *val, "Expected counter to be incremented to 2")
 }

--- a/internal/server/utils/modifiers.go
+++ b/internal/server/utils/modifiers.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"math"
+
+	diceerrors "github.com/dicedb/dice/internal/errors"
+)
+
+// util function for incrementing a value with a int64 increment
+// parses the value to int64 internally and returns
+// error if any
+func IncrementInt(val int64, incr int64) (int64, error) {
+	if (incr < 0 && val < 0 && incr < (math.MinInt64-val)) ||
+		(incr > 0 && val > 0 && incr > (math.MaxInt64-val)) {
+		return -1, diceerrors.NewErr(diceerrors.IncrDecrOverflowErr)
+	}
+	return val + incr, nil
+}
+
+func IncrementFloat(val float64, incr float64) (float64, error) {
+	if math.IsInf(val+incr, 1) || math.IsInf(val+incr, -1) {
+		return -1, diceerrors.NewErr(diceerrors.IncrDecrOverflowErr)
+	}
+	return val + incr, nil
+}


### PR DESCRIPTION
Fixes: #951 
Hi everyone, 

I am looking for reviews on this PR and implementation of HASHMAP data with expiry support. This is the basic implementation of what Redis does (they have built it from scratch) which I think is something we can plan for the future. Currently, the design is similar to what we have for store but uses Go's built-in maps. I am looking for reviews concerning design, code quality, documentation, and optimizations. I will be creating benchmark tests + writing unit & integration tests for two new commands: HEXPIRE & HTTL. 

Currently, we are migrating Hash-related commands and therefore, this PR either has to be merged before any of them is merged or I can wait for them to be merged and then rebase + refactor once again. 

Post this merge, we can create issues for other expiry commands for Hashmap. 

Thanks,
Apoorv