### PR TITLE
Update: GitHub stars on docs

### DIFF
--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -29,7 +29,7 @@ import { Github } from "lucide-astro";
             title="DiceDB source code on GitHub"
           >
             <span class="icon"><Github /></span>
-            <span>GitHub (5k+)</span>
+            <span>GitHub (6k+)</span>
           </a>
         </p>
       </div>

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -34,7 +34,7 @@ import site from "../data/site.json";
             title="DiceDB source code on GitHub"
           >
             <span class="icon"><Github /></span>
-            <span>GitHub (5k+)</span>
+            <span>GitHub (6k+)</span>
           </a>
         </div>
         <p class="has-text-grey">


### PR DESCRIPTION
Hi team,

DiceDB has recently crossed 6000 stars (currently 6.2k+). This PR updates this stat on dicedb.io. 

Thanks,
Apoorv