### PR TITLE
#1101: Refactor evalAPPEND to handle leading zeros in value

### DIFF
--- a/integration_tests/commands/async/append_test.go
+++ b/integration_tests/commands/async/append_test.go
@@ -55,7 +55,7 @@ func TestAPPEND(t *testing.T) {
 				"APPEND key 0034",
 				"GET key",
 			},
-			expected: []interface{}{int64(4), "0043", int64(8), "00430034"},
+			expected: []interface{}{int64(0), int64(4), "0043", int64(8), "00430034"},
 		},
 		{
 			name: "APPEND with Various Data Types",

--- a/integration_tests/commands/async/append_test.go
+++ b/integration_tests/commands/async/append_test.go
@@ -47,6 +47,17 @@ func TestAPPEND(t *testing.T) {
 			expected: []interface{}{int64(0), int64(1), int64(2), "12", "OK", int64(2), "12"},
 		},
 		{
+			name: "APPEND with leading zeros",
+			commands: []string{
+				"DEL key",
+				"APPEND key 0043",
+				"GET key",
+				"APPEND key 0034",
+				"GET key",
+			},
+			expected: []interface{}{int64(4), "0043", int64(8), "00430034"},
+		},
+		{
 			name: "APPEND with Various Data Types",
 			commands: []string{
 				"LPUSH listKey lValue",     // Add element to a list

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -4692,6 +4692,15 @@ func evalAPPEND(args []string, store *dstore.Store) []byte {
 
 	if obj == nil {
 		// Key does not exist path
+
+		// check if the value starts with '0' and has more than 1 character to handle leading zeros
+		if len(value) > 1 && value[0] == '0' {
+			// treat as string if has leading zeros
+			store.Put(key, store.NewObj(value, -1, object.ObjTypeString, object.ObjEncodingRaw))
+			return clientio.Encode(len(value), false)
+		}
+
+		// Deduce type and encoding based on the value if no leading zeros
 		oType, oEnc := deduceTypeEncoding(value)
 
 		var storedValue interface{}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -5171,6 +5171,23 @@ func testEvalAPPEND(t *testing.T, store *dstore.Store) {
 			input:  []string{"bitKey", "val"},
 			output: diceerrors.NewErrWithFormattedMessage(diceerrors.WrongTypeErr),
 		},
+		"append value with leading zeros":{
+			setup: func() {
+				store.Del("key_with_leading_zeros")
+			},
+			input: []string{"key_with_leading_zeros", "0043"},
+			output: clientio.Encode(4, false), // The length of "0043" is 4
+			validator: func(output []byte){
+				obj := store.Get("key_with_leading_zeros")
+				_, enc := object.ExtractTypeEncoding(obj)
+				if enc != object.ObjEncodingRaw {
+					t.Errorf("expected encoding to be Raw for string with leading zeros")
+				} 
+				if obj.Value.(string) != "0043" {
+					t.Errorf("expected value to be '0043', got %v", obj.Value)
+				}
+			},
+		},
 	}
 
 	runEvalTests(t, tests, evalAPPEND, store)


### PR DESCRIPTION
Fixes #1101 
evalAPPEND function wasn't configured to handle the case with leading zeros and it is treating value "0043" as "43"
I have added that case to handle it properly and producing desired result as of redis

![image](https://github.com/user-attachments/assets/69355844-44b6-46cf-96fd-a55446f8e48f)
