### PR TITLE
A Better CI

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -fsSL https://raw.githubusercontent.com/aquasecurity/trivy/master/scripts/install.sh | sh -s -- -b /usr/local/bin
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.56.2
 
       - name: Run Trivy scan
         run: |

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -18,4 +18,4 @@ jobs:
 
       - name: Run Trivy scan
         run: |
-          trivy --scanners vulnerability --format json --output trivy-report.json .
+          trivy fs --security-checks vuln .

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -18,4 +18,4 @@ jobs:
 
       - name: Run Trivy scan
         run: |
-          trivy --security-checks vuln --ignore-unfixed --exit-code 1 --output-template template:table --quiet .
+          trivy --scanners vulnerability --format json --output trivy-report.json .

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -1,0 +1,21 @@
+name: Weekly Trivy Scan
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Run every Monday at midnight
+  workflow_dispatch:
+
+jobs:
+  trivy_scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Trivy
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/aquasecurity/trivy/master/scripts/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Run Trivy scan
+        run: |
+          trivy --security-checks vuln --ignore-unfixed --exit-code 1 --output-template template:table --quiet .

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
@@ -29,16 +32,18 @@ jobs:
         with:
           images: dicedb/dicedb
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (with cache)
         id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
+          cache-from: type=gha # This tells Buildx to attempt to use the GitHub Actions cache
+          cache-to: type=gha,mode=max # This stores the generated cache in the GitHub Actions cache
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -33,8 +33,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23.x"
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with: # Cache the Go modules
+          path: |
+            vendor/
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Install dependencies
-        run: go get .
+        run: go get -v . # Check if there is any version changes from the cache
       - name: Build
         run: make build
       - name: Run Unit tests

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,3 +28,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60.1
+          

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,9 +1,15 @@
-name: linter
+name: Linter
+
 on:
   push:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - '*.go'
+
   pull_request:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - '*.go'
 
 permissions:
   contents: read

--- a/main.go
+++ b/main.go
@@ -321,3 +321,5 @@ func startProfiling(logr *slog.Logger) (func(), error) {
 		traceFile.Close()
 	}, nil
 }
+
+// Adding this comment to trigger the CI Jobs once

--- a/main.go
+++ b/main.go
@@ -321,5 +321,3 @@ func startProfiling(logr *slog.Logger) (func(), error) {
 		traceFile.Close()
 	}, nil
 }
-
-// Adding this comment to trigger the CI Jobs once


### PR DESCRIPTION
Hi @JyotinderSingh 
I have made some changes as per the disccusion on issue:
- https://github.com/DiceDB/dice/issues/620

Changes:

1. The **dockerhub.yml** is going to cache layers to resuse. I have some questions around this one.
Since I see this CI will only trigger on release it means frequency will be less. I have added the changes, but couldn't test it. Please go through it once, then we can talk more on it.

2. The **full-test-suite.yml** is going to cache the go dependencies from last build. Only pull new if required. Now I see Suryavir has very well defined to ignore the files **when not to run** the CI. We can make it **run only on** changes to go files or go.mod. Because with time, my understanding is that new folders and types of files may be included.

3. The **linter.yml** now will only run when a change is done to a .go file.

4. The **cve-scan.yml** I am using [Trivy](https://github.com/aquasecurity/trivy) to find the CVEs in the codebase. I have kept it to run once a week and on demand. I need to understand the requirement on this one from you as well

----

Other Discussions:

1. An Image scan can be done on Github actions with Trivy or anyone other options on Github marketplace. Also Docker has scout which does it for you on DockerHub as well. You let me know which is preferred by the team.

2. I understand caching the go dependencies on full-test-suite is a lil overkill. Since pulling Go pkgs is free. I think it can just decrease the build time a lil. But it's your call to keep or remove


---

Sorry for the delay on this one. My personal laptop was broken and I was on a little vaccation. 
cc: @arpitbbhayani 
