### PR TITLE
#1113 Add cURL Examples to HTTP Docs

### DIFF
--- a/docs/src/content/docs/protocols/http.mdx
+++ b/docs/src/content/docs/protocols/http.mdx
@@ -130,7 +130,7 @@ Our HTTP API supports all DiceDB commands. Please refer to our comprehensive com
 <Tabs syncKey="http-request-format">
   <TabItem label="HTTP Request">
   ```http
-POST http://localhost:8082/hset HTTP/1.1
+POST /HSET HTTP/1.1
 Content-Type: application/json
 
 {
@@ -168,7 +168,7 @@ Content-Type: application/json
 <Tabs syncKey="http-request-format">
   <TabItem label="HTTP Request">
 ```http
-POST http://localhost:8082/hget HTTP/1.1
+POST /HGET HTTP/1.1
 Content-Type: application/json
 
 {

--- a/docs/src/content/docs/protocols/http.mdx
+++ b/docs/src/content/docs/protocols/http.mdx
@@ -131,6 +131,7 @@ Our HTTP API supports all DiceDB commands. Please refer to our comprehensive com
   <TabItem label="HTTP Request">
   ```http
 POST /HSET HTTP/1.1
+Host: your-server-address
 Content-Type: application/json
 
 {
@@ -169,6 +170,7 @@ Content-Type: application/json
   <TabItem label="HTTP Request">
 ```http
 POST /HGET HTTP/1.1
+Host: your-server-address
 Content-Type: application/json
 
 {

--- a/docs/src/content/docs/protocols/http.mdx
+++ b/docs/src/content/docs/protocols/http.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 1
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 ## Table of Contents
 
 1. [Introduction](#introduction)
@@ -53,26 +55,31 @@ Our HTTP API supports all DiceDB commands. Please refer to our comprehensive com
 ### Setting a Key-Value Pair
 
 **Request:**
-```http
-POST /SET HTTP/1.1
-Host: your-server-address
-Content-Type: application/json
+<Tabs>
+  <TabItem label="HTTP Request">
+  ```http
+  POST /SET HTTP/1.1
+  Host: your-server-address
+  Content-Type: application/json
 
-{
-  "key": "mykey",
-  "value": "Hello, World!"
-}
-```
+  {
+    "key": "mykey",
+    "value": "Hello, World!"
+  }
+  ```
+</TabItem>
+  <TabItem label="cURL">
+  ```bash
+  curl --location 'http://your-server-address:PORT/SET' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "key": "mykey",
+    "value": "Hello, World!"
+  }'
+  ```
+  </TabItem>
+</Tabs>
 
-**cURL:**
-```bash
-curl --location 'http://your-server-address:PORT/SET' \
---header 'Content-Type: application/json' \
---data '{
-  "key": "mykey",
-  "value": "Hello, World!"
-}'
-```
 
 **Response:**
 ```json
@@ -85,24 +92,29 @@ curl --location 'http://your-server-address:PORT/SET' \
 ### Getting a Value
 
 **Request:**
-```http
-POST /GET HTTP/1.1
-Host: your-server-address
-Content-Type: application/json
+<Tabs>
+  <TabItem label="HTTP Request">
+  ```http
+  POST /GET HTTP/1.1
+  Host: your-server-address
+  Content-Type: application/json
 
-{
-  "key": "mykey"
-}
-```
+  {
+    "key": "mykey"
+  }
+  ```
+</TabItem>
+  <TabItem label="cURL">
+  ```bash
+  curl --location 'http://your-server-address:PORT/GET' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "key": "mykey"
+  }'
+  ```
+  </TabItem>
+</Tabs>
 
-**cURL:**
-```bash
-curl --location 'http://your-server-address:PORT/GET' \
---header 'Content-Type: application/json' \
---data '{
-  "key": "mykey"
-}'
-```
 
 **Response:**
 ```json
@@ -115,7 +127,9 @@ curl --location 'http://your-server-address:PORT/GET' \
 ### Setting a field in Hash
 
 **Request:**
-```http
+<Tabs>
+  <TabItem label="HTTP Request">
+  ```http
 POST http://localhost:8082/hset HTTP/1.1
 Content-Type: application/json
 
@@ -125,17 +139,20 @@ Content-Type: application/json
 	"value": "test"
 }
 ```
+</TabItem>
+  <TabItem label="cURL">
+  ```bash
+  curl --location 'http://your-server-address:PORT/HSET' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "key": "test",
+    "field": "test",
+    "value": "test"
+  }'
+  ```
+  </TabItem>
+</Tabs>
 
-**cURL:**
-```bash
-curl --location 'http://your-server-address:PORT/HSET' \
---header 'Content-Type: application/json' \
---data '{
-  "key": "test",
-  "field": "test",
-  "value": "test"
-}'
-```
 
 **Response:**
 ```json
@@ -148,6 +165,8 @@ curl --location 'http://your-server-address:PORT/HSET' \
 ### Getting a field in a HashSet
 
 **Request:**
+<Tabs>
+  <TabItem label="HTTP Request">
 ```http
 POST http://localhost:8082/hget HTTP/1.1
 Content-Type: application/json
@@ -157,9 +176,9 @@ Content-Type: application/json
   "field": "test"
 }
 ```
-
-**cURL:**
-```bash
+</TabItem>
+  <TabItem label="cURL">
+ ```bash
 curl --location 'http://your-server-address:PORT/HGET' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -167,6 +186,8 @@ curl --location 'http://your-server-address:PORT/HGET' \
   "field": "test"
 }'
 ```
+  </TabItem>
+</Tabs>
 
 **Response:**
 ```json
@@ -181,6 +202,8 @@ curl --location 'http://your-server-address:PORT/HGET' \
 **NOTE**: The `QWATCH` command is asynchronous and requires the use of Server-Sent Events (SSE) to receive updates. The following example demonstrates how to use `QWATCH` with SSE.
 
 **Request:**
+<Tabs>
+  <TabItem label="HTTP Request">
 ```http
 POST /QWATCH HTTP/1.1
 Host: your-server-address
@@ -191,7 +214,8 @@ Content-Type: application/json
 }
 ```
 
-**cURL:**
+</TabItem>
+  <TabItem label="cURL">
 ```bash
 curl --location 'http://your-server-address:PORT/QWATCH' \
 --header 'Content-Type: application/json' \
@@ -199,4 +223,8 @@ curl --location 'http://your-server-address:PORT/QWATCH' \
   "query": "SELECT $key, $value WHERE $key like '\''match:100:*'\'' AND $value > 10 ORDER BY $value DESC LIMIT 3"
 }'
 ```
+  </TabItem>
+</Tabs>
+
+
 

--- a/docs/src/content/docs/protocols/http.mdx
+++ b/docs/src/content/docs/protocols/http.mdx
@@ -55,7 +55,7 @@ Our HTTP API supports all DiceDB commands. Please refer to our comprehensive com
 ### Setting a Key-Value Pair
 
 **Request:**
-<Tabs>
+<Tabs syncKey="http-request-format">
   <TabItem label="HTTP Request">
   ```http
   POST /SET HTTP/1.1
@@ -92,7 +92,7 @@ Our HTTP API supports all DiceDB commands. Please refer to our comprehensive com
 ### Getting a Value
 
 **Request:**
-<Tabs>
+<Tabs syncKey="http-request-format">
   <TabItem label="HTTP Request">
   ```http
   POST /GET HTTP/1.1
@@ -127,7 +127,7 @@ Our HTTP API supports all DiceDB commands. Please refer to our comprehensive com
 ### Setting a field in Hash
 
 **Request:**
-<Tabs>
+<Tabs syncKey="http-request-format">
   <TabItem label="HTTP Request">
   ```http
 POST http://localhost:8082/hset HTTP/1.1
@@ -165,7 +165,7 @@ Content-Type: application/json
 ### Getting a field in a HashSet
 
 **Request:**
-<Tabs>
+<Tabs syncKey="http-request-format">
   <TabItem label="HTTP Request">
 ```http
 POST http://localhost:8082/hget HTTP/1.1
@@ -202,7 +202,7 @@ curl --location 'http://your-server-address:PORT/HGET' \
 **NOTE**: The `QWATCH` command is asynchronous and requires the use of Server-Sent Events (SSE) to receive updates. The following example demonstrates how to use `QWATCH` with SSE.
 
 **Request:**
-<Tabs>
+<Tabs syncKey="http-request-format">
   <TabItem label="HTTP Request">
 ```http
 POST /QWATCH HTTP/1.1

--- a/docs/src/content/docs/protocols/http.mdx
+++ b/docs/src/content/docs/protocols/http.mdx
@@ -64,9 +64,22 @@ Content-Type: application/json
 }
 ```
 
+**cURL:**
+```bash
+curl --location 'http://your-server-address:PORT/SET' \
+--header 'Content-Type: application/json' \
+--data '{
+  "key": "mykey",
+  "value": "Hello, World!"
+}'
+```
+
 **Response:**
 ```json
-"OK"
+{
+    "status": "success",
+    "data": "OK"
+}
 ```
 
 ### Getting a Value
@@ -82,13 +95,26 @@ Content-Type: application/json
 }
 ```
 
+**cURL:**
+```bash
+curl --location 'http://your-server-address:PORT/GET' \
+--header 'Content-Type: application/json' \
+--data '{
+  "key": "mykey"
+}'
+```
+
 **Response:**
 ```json
-"Hello, World!"
+{
+    "status": "success",
+    "data": "Hello, World!"
+}
 ```
 
 ### Setting a field in Hash
 
+**Request:**
 ```http
 POST http://localhost:8082/hset HTTP/1.1
 Content-Type: application/json
@@ -100,13 +126,28 @@ Content-Type: application/json
 }
 ```
 
+**cURL:**
+```bash
+curl --location 'http://your-server-address:PORT/HSET' \
+--header 'Content-Type: application/json' \
+--data '{
+  "key": "test",
+  "field": "test",
+  "value": "test"
+}'
+```
+
 **Response:**
 ```json
-1
+{
+    "status": "success",
+    "data": 1
+}
 ```
 
 ### Getting a field in a HashSet
 
+**Request:**
 ```http
 POST http://localhost:8082/hget HTTP/1.1
 Content-Type: application/json
@@ -117,9 +158,22 @@ Content-Type: application/json
 }
 ```
 
+**cURL:**
+```bash
+curl --location 'http://your-server-address:PORT/HGET' \
+--header 'Content-Type: application/json' \
+--data '{
+  "key": "test",
+  "field": "test"
+}'
+```
+
 **Response:**
 ```json
-"test"
+{
+    "status": "success",
+    "data": "test"
+}
 ```
 
 ### QWATCH Example
@@ -135,5 +189,14 @@ Content-Type: application/json
 {
   "query": "SELECT $key, $value WHERE $key like 'match:100:*' AND $value > 10 ORDER BY $value DESC LIMIT 3"
 }
+```
+
+**cURL:**
+```bash
+curl --location 'http://your-server-address:PORT/QWATCH' \
+--header 'Content-Type: application/json' \
+--data '{
+  "query": "SELECT $key, $value WHERE $key like '\''match:100:*'\'' AND $value > 10 ORDER BY $value DESC LIMIT 3"
+}'
 ```
 


### PR DESCRIPTION
#1113

1. Added Curl Examples to HTTP Docs. For Better DX.
2. Fixed Response which we actually get from the calls. 

Attaching screenshots for the same.
![Screenshot 2024-10-17 at 12 37 41 PM](https://github.com/user-attachments/assets/a5ded951-9df4-42fd-9750-c7a6446975b7)
![Screenshot 2024-10-17 at 12 38 02 PM](https://github.com/user-attachments/assets/979baed6-8f59-4d8a-9db5-f9df05072b4e)
![Screenshot 2024-10-17 at 12 38 14 PM](https://github.com/user-attachments/assets/10ff62ff-6410-4038-9756-edb525ea1b67)
![Screenshot 2024-10-17 at 12 38 33 PM](https://github.com/user-attachments/assets/afd23a4e-8125-4127-bbb9-fdc53fd046d3)
![Screenshot 2024-10-17 at 12 38 43 PM](https://github.com/user-attachments/assets/c3d5c82d-f8ae-4c08-872d-dc64c3862dfa)


Incase of any changes please let me know.

cc @JyotinderSingh 