### PR TITLE
Fixed bugs in Websocket Integration Tests

### DIFF
--- a/integration_tests/commands/websocket/get_test.go
+++ b/integration_tests/commands/websocket/get_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGet(t *testing.T) {
@@ -19,9 +19,9 @@ func TestGet(t *testing.T) {
 	}{
 		{
 			name:   "Get with expiration",
-			cmds:   []string{"SET k v EX 4", "GET k", "GET k"},
+			cmds:   []string{"SET k v EX 1", "GET k", "GET k"},
 			expect: []interface{}{"OK", "v", "(nil)"},
-			delays: []time.Duration{0, 0, 5 * time.Second},
+			delays: []time.Duration{0, 0, 2 * time.Second},
 		},
 	}
 
@@ -31,7 +31,8 @@ func TestGet(t *testing.T) {
 				if tc.delays[i] > 0 {
 					time.Sleep(tc.delays[i])
 				}
-				result := exec.FireCommand(conn, cmd)
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
 				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
 			}
 		})

--- a/integration_tests/commands/websocket/helper.go
+++ b/integration_tests/commands/websocket/helper.go
@@ -1,0 +1,17 @@
+package websocket
+
+import (
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+)
+
+func DeleteKey(t *testing.T, conn *websocket.Conn, exec *WebsocketCommandExecutor, key string) {
+	cmd := "DEL " + key
+	resp, err := exec.FireCommandAndReadResponse(conn, cmd)
+	assert.Nil(t, err)
+	respFloat, ok := resp.(float64)
+	assert.True(t, ok, "error converting response to float64")
+	assert.True(t, respFloat == 1 || respFloat == 0, "unexpected response in %v: %v", cmd, resp)
+}

--- a/integration_tests/commands/websocket/hyperloglog_test.go
+++ b/integration_tests/commands/websocket/hyperloglog_test.go
@@ -3,7 +3,7 @@ package websocket
 import (
 	"testing"
 
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHyperLogLogCommands(t *testing.T) {
@@ -82,11 +82,12 @@ func TestHyperLogLogCommands(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			conn := exec.ConnectToServer()
-			exec.FireCommand(conn, "del k")
+			DeleteKey(t, conn, exec, "k")
 
 			for i, cmd := range tc.commands {
-				result := exec.FireCommand(conn, cmd)
-				assert.DeepEqual(t, tc.expected[i], result)
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expected[i], result)
 			}
 		})
 	}

--- a/integration_tests/commands/websocket/json_test.go
+++ b/integration_tests/commands/websocket/json_test.go
@@ -1,8 +1,9 @@
 package websocket
 
 import (
-	"gotest.tools/v3/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJSONClearOperations(t *testing.T) {
@@ -10,10 +11,11 @@ func TestJSONClearOperations(t *testing.T) {
 	conn := exec.ConnectToServer()
 	defer conn.Close()
 
-	exec.FireCommand(conn, "DEL user")
+	DeleteKey(t, conn, exec, "user")
 
 	defer func() {
-		resp := exec.FireCommand(conn, "DEL user")
+		resp, err := exec.FireCommandAndReadResponse(conn, "DEL user")
+		assert.Nil(t, err)
 		assert.Equal(t, float64(1), resp)
 	}()
 
@@ -86,7 +88,8 @@ func TestJSONClearOperations(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for i, cmd := range tc.commands {
-				result := exec.FireCommand(conn, cmd)
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
 				assert.Equal(t, tc.expected[i], result)
 			}
 		})
@@ -99,10 +102,11 @@ func TestJsonStrlen(t *testing.T) {
 
 	defer conn.Close()
 
-	exec.FireCommand(conn, "DEL doc")
+	DeleteKey(t, conn, exec, "doc")
 
 	defer func() {
-		resp := exec.FireCommand(conn, "DEL doc")
+		resp, err := exec.FireCommandAndReadResponse(conn, "DEL doc")
+		assert.Nil(t, err)
 		assert.Equal(t, float64(1), resp)
 	}()
 
@@ -172,12 +176,13 @@ func TestJsonStrlen(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for i, cmd := range tc.commands {
-				result := exec.FireCommand(conn, cmd)
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err, "error: %v", err)
 				stringResult, ok := result.(string)
 				if ok {
 					assert.Equal(t, tc.expected[i], stringResult)
 				} else {
-					assert.Assert(t, arraysArePermutations(tc.expected[i].([]interface{}), result.([]interface{})))
+					assert.True(t, arraysArePermutations(tc.expected[i].([]interface{}), result.([]interface{})))
 				}
 			}
 		})
@@ -189,7 +194,7 @@ func TestJsonObjLen(t *testing.T) {
 	conn := exec.ConnectToServer()
 	defer conn.Close()
 
-	exec.FireCommand(conn, "DEL obj")
+	DeleteKey(t, conn, exec, "obj")
 
 	a := `{"name":"jerry","partner":{"name":"tom","language":["rust"]}}`
 	b := `{"name":"jerry","partner":{"name":"tom","language":["rust"]},"partner2":{"name":"spike","language":["go","rust"]}}`
@@ -197,7 +202,8 @@ func TestJsonObjLen(t *testing.T) {
 	d := `["this","is","an","array"]`
 
 	defer func() {
-		resp := exec.FireCommand(conn, "DEL obj")
+		resp, err := exec.FireCommandAndReadResponse(conn, "DEL obj")
+		assert.Nil(t, err)
 		assert.Equal(t, float64(1), resp)
 	}()
 
@@ -259,13 +265,14 @@ func TestJsonObjLen(t *testing.T) {
 	}
 
 	for _, tcase := range testCases {
-		exec.FireCommand(conn, "DEL obj")
+		DeleteKey(t, conn, exec, "obj")
 		t.Run(tcase.name, func(t *testing.T) {
 			for i := 0; i < len(tcase.commands); i++ {
 				cmd := tcase.commands[i]
 				out := tcase.expected[i]
-				result := exec.FireCommand(conn, cmd)
-				assert.DeepEqual(t, out, result)
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
+				assert.Equal(t, out, result)
 			}
 		})
 	}

--- a/integration_tests/commands/websocket/main_test.go
+++ b/integration_tests/commands/websocket/main_test.go
@@ -21,10 +21,11 @@ func TestMain(m *testing.M) {
 	// checks for available port and then forks a goroutine
 	// to start the server
 	opts := TestServerOptions{
-		Port:   8380,
+		Port:   testPort1,
 		Logger: l,
 	}
-	RunWebsocketServer(context.Background(), &wg, opts)
+	ctx, cancel := context.WithCancel(context.Background())
+	RunWebsocketServer(ctx, &wg, opts)
 
 	// Wait for the server to start
 	time.Sleep(2 * time.Second)
@@ -37,8 +38,8 @@ func TestMain(m *testing.M) {
 	// abort
 	conn := executor.ConnectToServer()
 	executor.FireCommand(conn, "abort")
-	executor.DisconnectServer(conn)
 
+	cancel()
 	wg.Wait()
 	os.Exit(exitCode)
 }

--- a/integration_tests/commands/websocket/main_test.go
+++ b/integration_tests/commands/websocket/main_test.go
@@ -25,6 +25,7 @@ func TestMain(m *testing.M) {
 		Logger: l,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	RunWebsocketServer(ctx, &wg, opts)
 
 	// Wait for the server to start
@@ -39,7 +40,6 @@ func TestMain(m *testing.M) {
 	conn := executor.ConnectToServer()
 	executor.FireCommand(conn, "abort")
 
-	cancel()
 	wg.Wait()
 	os.Exit(exitCode)
 }

--- a/integration_tests/commands/websocket/writeretry_test.go
+++ b/integration_tests/commands/websocket/writeretry_test.go
@@ -1,10 +1,10 @@
 package websocket
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var serverAddr = "localhost:12345"
+var serverAddr = fmt.Sprintf("localhost:%v", testPort2)
 var once sync.Once
 
 func TestWriteResponseWithRetries_Success(t *testing.T) {
@@ -68,10 +68,6 @@ func TestWriteResponseWithRetries_EAGAINRetry(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 2, retries)
-}
-
-func newSyscallError(syscall string, err error) *os.SyscallError {
-	return &os.SyscallError{Syscall: syscall, Err: err}
 }
 
 func startWebSocketServer() {

--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func main() {
 		}()
 	}
 
-	websocketServer := server.NewWebSocketServer(shardManager, queryWatchChan, logr)
+	websocketServer := server.NewWebSocketServer(shardManager, queryWatchChan, config.WebsocketPort, logr)
 	serverWg.Add(1)
 	go func() {
 		defer serverWg.Done()


### PR DESCRIPTION
This PR fixes following issues:

1. Several `Error reading from client` errors were thrown while running Integration tests because client disconnection was not handled and server kept trying to read. Added error handling of `acceptable errors` and added a warning for other errors. Any kind of error received now returns the `WebsocketHandler` function.

2. Several `Error writing response` errors were thrown while running Integration tests because some of the test commands were not written to also read response from server. Created two different functions `FireCommand` and `FireCommandAndReadResponse`. Refactored existing tests to run correctly.

3. Migrates assert to testify/assert

4. A few other minor fixes