### PR TITLE
Fix http Write Response functionality

### DIFF
--- a/internal/server/httpServer.go
+++ b/internal/server/httpServer.go
@@ -376,8 +376,20 @@ func (s *HTTPServer) writeResponse(writer http.ResponseWriter, result *ops.Store
 		"*0",     // Represents an empty RESP Array.
 	}
 
-	if val, ok := responseValue.(clientio.RespType); ok {
+	switch val := responseValue.(type) {
+	case clientio.RespType:
 		responseValue = respArr[val]
+	case []interface{}:
+		migrated := false
+		for idx := range val {
+			if v, ok := val[idx].(clientio.RespType); ok {
+				migrated = true
+				val[idx] = respArr[v]
+			}
+		}
+		if migrated {
+			responseValue = val
+		}
 	}
 
 	if responseValue == stringNil {


### PR DESCRIPTION
Issue: 
If migrated eval responses are embedded in an array of interface then HTTP Response writer is unable to typecase it to the respective RespType. 


Commands to reproduce:
```
go run main.go 
2024/10/19 00:50:20 INFO configurations loaded successfully.
12:50AM DBG The DiceDB server has started in single-threaded mode.
12:50AM INF DiceDB server is running in a single-threaded mode port=7379 version=0.0.4
12:50AM WRN DiceDB is running without authentication. Consider setting a password.
12:50AM INF HTTP Server running addr=:8082
12:50AM INF Websocket Server running port=8379
```

```
127.0.0.1:7379> json.set k $ '{"a":3}'
OK
127.0.0.1:7379> 
```

```
curl --request GET \
  --url http://localhost:8082/JSON.ARRPOP \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/8.4.5' \
  --data '{
	"key": "k",
	"path": "$.a",
	"value": 1
}'
```

Before fix:
<img width="1299" alt="Screenshot 2024-10-19 at 12 50 36 AM" src="https://github.com/user-attachments/assets/d32e49ca-937d-423c-b4bf-fdb16068ca53">

After fix: 
<img width="1300" alt="Screenshot 2024-10-19 at 12 42 00 AM" src="https://github.com/user-attachments/assets/1cb94f2a-d00a-47ae-a3e6-483ece492527">