### PR TITLE
Fix: removed extra prints in unit test

### DIFF
--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -3209,8 +3209,6 @@ func runEvalTests(t *testing.T, tests map[string]evalTestCase, evalFunc func([]s
 			if tc.validator != nil {
 				tc.validator(output)
 			} else {
-				fmt.Println(tc.output)
-				fmt.Println(output)
 				assert.Equal(t, string(tc.output), string(output))
 			}
 		})


### PR DESCRIPTION
Hi team,

These print statement floods the log when unit tests fail and thus make the logs difficult to understand.

Thanks
Apoorv