### PR TITLE
fix: issue #1115 handling integer parsing in SETBIT in certain situation

### DIFF
--- a/integration_tests/commands/http/append_test.go
+++ b/integration_tests/commands/http/append_test.go
@@ -123,6 +123,19 @@ func TestAPPEND(t *testing.T) {
 			},
 		},
 		{
+			name: "SET and SETBIT commands followed by GET",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "key", "value": "10"}},
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "key", "values": []string{"1", "1"}}},
+				{Command: "GET", Body: map[string]interface{}{"key": "key"}},
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "key", "values": []string{"0", "1"}}},
+			},
+			expected: []interface{}{"OK", float64(0), "q0", float64(0)},
+			cleanup: []HTTPCommand{
+				{Command: "del", Body: map[string]interface{}{"key": "key"}},
+			},
+		},
+		{
 			name: "APPEND After SET and DEL",
 			commands: []HTTPCommand{
 				{Command: "SET", Body: map[string]interface{}{"key": "key", "value": "value"}},

--- a/internal/eval/bytearray.go
+++ b/internal/eval/bytearray.go
@@ -98,7 +98,7 @@ func ByteSliceToObj(store *dstore.Store, oldObj *object.Obj, b []byte, objType, 
 func ByteSliceToIntObj(store *dstore.Store, oldObj *object.Obj, b []byte) (*object.Obj, error) {
 	intVal, err := strconv.ParseInt(string(b), 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse byte slice to int: %v", err)
+		return store.NewObj(string(b), -1, object.ObjTypeString, object.ObjEncodingEmbStr), nil
 	}
 	return store.NewObj(intVal, -1, object.ObjTypeInt, object.ObjEncodingInt), nil
 }


### PR DESCRIPTION
This PR closes issue #1115:
### Description:

- Updated `ByteSliceToObj` function to handle integer parsing more robustly. If the modified byte array can't be parsed as an integer, it now defaults to a string format(similar to how redis handles it).
- added corresponding unit test with expected output.