### PR TITLE
ADDED Support for ZPOPMAX

### DIFF
--- a/docs/src/content/docs/commands/ZPOPMAX.md
+++ b/docs/src/content/docs/commands/ZPOPMAX.md
@@ -1,0 +1,148 @@
+---
+title: ZPOPMAX  
+description: The `ZPOPMAX` command in DiceDB is used to remove and return the members with the highest scores from the sorted set data structure at the specified key. The second argument count is optional which specifies the number of elements that needs to be popped from the sorted set.
+---
+
+The `ZPOPMAX` command in DiceDB is used to remove and return the members with the highest scores from the sorted set data structure at the specified key. The second argument count is optional which specifies the number of elements that needs to be popped from the sorted set.
+
+## Syntax
+
+```
+ZPOPMAX key [count]
+```
+
+## Parameters
+
+| Parameter  | Description                                                                                  | Type    | Required |
+|------------|----------------------------------------------------------------------------------------------|---------|----------|
+| `key`      | The name of the sorted set data structure. If it does not exist, an empty array is returned. | String  | Yes      |
+| `count`    | The count argument specifies the maximum number of members to return from highest to lowest. | Integer | No       |
+
+## Return values
+
+| Condition                                                | Return Value                             |
+|----------------------------------------------------------|------------------------------------------|
+| If the key is of valid type and records are present      | List of members including their scores   |
+| If the key does not exist or if the sorted set is empty | `(empty list or set)`                     |
+
+## Behaviour
+
+- The command first checks if the specified key exists.
+- If the key does not exist, an empty array is returned.
+- If the key exists but is not a sorted set, an error is returned.
+- If the `count` argument is specified, up to that number of members with the highest scores are returned and removed.
+- The returned array contains the members and their corresponding scores in the order of highest to lowest.
+
+## Errors
+1. `Wrong type error`:
+    - Error Message: `(error) WRONGTYPE Operation against a key holding the wrong kind of value`
+    - Occurs when trying to use the command on a key that is not a sorted set.
+
+2. `Syntax error`:
+    - Error Message: `(error) ERROR wrong number of arguments for 'zpopMAX' command`
+    - Occurs when the command syntax is incorrect or missing required parameters.
+
+3. `Invalid argument type error`:
+    - Error Message : `(error) ERR value is not an integer or out of range`
+    - Occurs when the count argument passed to the command is not an integer.
+
+## Examples
+
+### Non-Existing Key (without count argument)
+
+Attempting to pop the member with the highest score from a non-existent sorted set:
+
+```bash
+127.0.0.1:7379> ZPOPMAX NON_EXISTENT_KEY
+(empty array)
+```
+
+### Existing Key (without count argument)
+
+Popping the member with the highest score from an existing sorted set:
+
+```bash
+127.0.0.1:7379> ZADD myzset 1 member1 2 member2 3 member3
+(integer) 3
+127.0.0.1:7379> ZPOPMAX myzset
+1) 1 "member1"
+```
+
+### With Count Argument
+
+Popping multiple members with the highest scores using the count argument:
+
+```bash
+127.0.0.1:7379> ZADD myzset 1 member1 2 member2 3 member3
+(integer) 3
+127.0.0.1:7379> ZPOPMAX myzset 2
+1) 1 "member1"
+2) 2 "member2"
+```
+
+### Count Argument but Multiple Members Have the Same Score
+
+Popping members when multiple members share the same score:
+
+```bash
+127.0.0.1:7379> ZADD myzset 1 member1 1 member2 1 member3
+(integer) 3
+127.0.0.1:7379> ZPOPMAX myzset 2
+1) 1 "member1"
+2) 1 "member2"
+```
+
+### Negative Count Argument
+
+Attempting to pop members using a negative count argument:
+
+```bash
+127.0.0.1:7379> ZADD myzset 1 member1 2 member2 3 member3
+(integer) 3
+127.0.0.1:7379> ZPOPMAX myzset -1
+(empty array)
+```
+
+### Floating-Point Scores
+
+Popping members with floating-point scores:
+
+```bash
+127.0.0.1:7379> ZADD myzset 1.5 member1 2.7 member2 3.8 member3
+(integer) 3
+127.0.0.1:7379> ZPOPMAX myzset
+1) 1.5 "member1"
+```
+
+### Wrong number of arguments
+
+Attempting to pop from a key that is not a sorted set:
+
+```bash
+127.0.0.1:7379> SET stringkey "string_value"
+OK
+127.0.0.1:7379> ZPOPMAX stringkey
+(error) WRONGTYPE Operation against a key holding the wrong kind of value
+```
+
+### Invalid Count Argument
+
+Using an invalid (non-integer) count argument:
+
+```bash
+127.0.0.1:7379> ZADD myzset 1 member1
+(integer) 1
+127.0.0.1:7379> ZPOPMAX myzset INCORRECT_COUNT_ARGUMENT
+(error) ERR value is not an integer or out of range
+```
+
+### Wrong Type of Key (without count argument)
+
+Attempting to pop from a key that is not a sorted set:
+
+```bash
+127.0.0.1:7379> SET stringkey "string_value"
+OK
+127.0.0.1:7379> ZPOPMAX stringkey
+(error) WRONGTYPE Operation against a key holding the wrong kind of value
+```

--- a/integration_tests/commands/http/zpopmax_test.go
+++ b/integration_tests/commands/http/zpopmax_test.go
@@ -1,0 +1,97 @@
+package http
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestZPOPMAX(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+	testCases := []TestCase{
+		{
+			name: "ZPOPMAX on non-existing key with/without count argument",
+			commands: []HTTPCommand{
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "invalidTest"}},
+			},
+			expected: []interface{}{[]interface{}{}},
+		},
+		{
+			name: "ZPOPMAX with wrong type of key with/without count argument",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "sortedSet", "value": "testString"}},
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "sortedSet"}},
+			},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+		},
+		{
+			name: "ZPOPMAX on existing key (without count argument)",
+			commands: []HTTPCommand{
+				{Command: "ZADD", Body: map[string]interface{}{"key": "sortedSet", "values": [...]string{"1", "member1", "2", "member2", "3", "member3"}}},
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "sortedSet"}},
+			},
+			expected: []interface{}{float64(3), []interface{}{"member3", "3"}},
+		},
+		{
+			name: "ZPOPMAX with normal count argument",
+			commands: []HTTPCommand{
+				{Command: "ZADD", Body: map[string]interface{}{"key": "sortedSet", "values": [...]string{"1", "member1", "2", "member2", "3", "member3"}}},
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "sortedSet", "value": int64(2)}},
+			},
+			expected: []interface{}{float64(3), []interface{}{"member3", "3", "member2", "2"}},
+		},
+		{
+			name: "ZPOPMAX with count argument but multiple members have the same score",
+			commands: []HTTPCommand{
+				{Command: "ZADD", Body: map[string]interface{}{"key": "sortedSet", "values": [...]string{"1", "member1", "1", "member2", "1", "member3"}}},
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "sortedSet", "value": int64(2)}},
+			},
+			expected: []interface{}{float64(3), []interface{}{"member3", "1", "member2", "1"}},
+		},
+		{
+			name: "ZPOPMAX with negative count argument",
+			commands: []HTTPCommand{
+				{Command: "ZADD", Body: map[string]interface{}{"key": "sortedSet", "values": [...]string{"1", "member1", "2", "member2", "3", "member3"}}},
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "sortedSet", "value": int64(-1)}},
+			},
+			expected: []interface{}{float64(3), []interface{}{}},
+		},
+		{
+			name: "ZPOPMAX with invalid count argument",
+			commands: []HTTPCommand{
+				{Command: "ZADD", Body: map[string]interface{}{"key": "sortedSet", "values": [...]string{"1", "member1"}}},
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "sortedSet", "value": "INCORRECT_COUNT_ARGUMENT"}},
+			},
+			expected: []interface{}{float64(1), "ERR value is not an integer or out of range"},
+		},
+		{
+			name: "ZPOPMAX with count argument greater than length of sorted set",
+			commands: []HTTPCommand{
+				{Command: "ZADD", Body: map[string]interface{}{"key": "sortedSet", "values": [...]string{"1", "member1", "2", "member2", "3", "member3"}}},
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "sortedSet", "value": int64(10)}},
+			},
+			expected: []interface{}{float64(3), []interface{}{"member3", "3", "member2", "2", "member1", "1"}},
+		},
+		{
+			name: "ZPOPMAX with floating-point scores",
+			commands: []HTTPCommand{
+				{Command: "ZADD", Body: map[string]interface{}{"key": "sortedSet", "values": [...]string{"1.5", "member1", "2.7", "member2", "3.8", "member3"}}},
+				{Command: "ZPOPMAX", Body: map[string]interface{}{"key": "sortedSet"}},
+			},
+			expected: []interface{}{float64(3), []interface{}{"member3", "3.8"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exec.FireCommand(HTTPCommand{
+				Command: "DEL",
+				Body:    map[string]interface{}{"key": "sortedSet"},
+			})
+			for i, cmd := range tc.commands {
+				result, _ := exec.FireCommand(cmd)
+				assert.DeepEqual(t, tc.expected[i], result)
+			}
+		})
+	}
+}

--- a/integration_tests/commands/resp/zpopmax_test.go
+++ b/integration_tests/commands/resp/zpopmax_test.go
@@ -1,0 +1,75 @@
+package resp
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestZPOPMax(t *testing.T) {
+	conn := getLocalConnection()
+	defer conn.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "ZPOPMAX on non-existing key with/without count argument",
+			commands: []string{"ZPOPMAX NON_EXISTENT_KEY"},
+			expected: []interface{}{[]interface{}{}},
+		},
+		{
+			name:     "ZPOPMAX with wrong type of key with/without count argument",
+			commands: []string{"SET stringkey string_value", "ZPOPMAX stringkey"},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+		},
+		{
+			name:     "ZPOPMAX on existing key (without count argument)",
+			commands: []string{"ZADD sortedSet 1 member1 2 member2 3 member3", "ZPOPMAX sortedSet"},
+			expected: []interface{}{int64(3), []interface{}{"member3", "3"}},
+		},
+		{
+			name:     "ZPOPMAX with normal count argument",
+			commands: []string{"ZADD sortedSet 1 member1 2 member2 3 member3", "ZPOPMAX sortedSet 2"},
+			expected: []interface{}{int64(3), []interface{}{"member3", "3", "member2", "2"}},
+		},
+		{
+			name:     "ZPOPMAX with count argument but multiple members have the same score",
+			commands: []string{"ZADD sortedSet 1 member1 1 member2 1 member3", "ZPOPMAX sortedSet 2"},
+			expected: []interface{}{int64(3), []interface{}{"member3", "1", "member2", "1"}},
+		},
+		{
+			name:     "ZPOPMAX with negative count argument",
+			commands: []string{"ZADD sortedSet 1 member1 2 member2 3 member3", "ZPOPMAX sortedSet -1"},
+			expected: []interface{}{int64(3), []interface{}{}},
+		},
+		{
+			name:     "ZPOPMAX with invalid count argument",
+			commands: []string{"ZADD sortedSet 1 member1", "ZPOPMAX sortedSet INCORRECT_COUNT_ARGUMENT"},
+			expected: []interface{}{int64(1), "ERR value is not an integer or out of range"},
+		},
+		{
+			name:     "ZPOPMAX with count argument greater than length of sorted set",
+			commands: []string{"ZADD sortedSet 1 member1 2 member2 3 member3", "ZPOPMAX sortedSet 10"},
+			expected: []interface{}{int64(3), []interface{}{"member3", "3", "member2", "2", "member1", "1"}},
+		},
+		{
+			name:     "ZPOPMAX on empty sorted set",
+			commands: []string{"ZADD sortedSet 1 member1", "ZPOPMAX sortedSet 1", "ZPOPMAX sortedSet"},
+			expected: []interface{}{int64(1), []interface{}{"member1", "1"}, []interface{}{}},
+		},
+		{
+			name:     "ZPOPMAX with floating-point scores",
+			commands: []string{"ZADD sortedSet 1.5 member1 2.7 member2 3.8 member3", "ZPOPMAX sortedSet"},
+			expected: []interface{}{int64(3), []interface{}{"member3", "3.8"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			FireCommand(conn, "DEL sortedSet")
+			for i, cmd := range tc.commands {
+				result := FireCommand(conn, cmd)
+				assert.DeepEqual(t, tc.expected[i], result)
+			}
+		})
+	}
+}

--- a/integration_tests/commands/websocket/zpopmax_test.go
+++ b/integration_tests/commands/websocket/zpopmax_test.go
@@ -1,0 +1,75 @@
+package websocket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZPOPMAX(t *testing.T) {
+	exec := NewWebsocketCommandExecutor()
+	testCases := []TestCase{
+		{
+			name:     "ZPOPMAX on non-existing key with/without count argument",
+			commands: []string{"ZPOPMAX NON_EXISTENT_KEY"},
+			expected: []interface{}{[]interface{}{}},
+		},
+		{
+			name:     "ZPOPMAX with wrong type of key with/without count argument",
+			commands: []string{"SET stringkey string_value", "ZPOPMAX stringkey"},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+		},
+		{
+			name:     "ZPOPMAX on existing key (without count argument)",
+			commands: []string{"ZADD sortedSet 1 member1 2 member2 3 member3", "ZPOPMAX sortedSet"},
+			expected: []interface{}{float64(3), []interface{}{"member3", "3"}},
+		},
+		{
+			name:     "ZPOPMAX with normal count argument",
+			commands: []string{"ZADD sortedSet 1 member1 2 member2 3 member3", "ZPOPMAX sortedSet 2"},
+			expected: []interface{}{float64(3), []interface{}{"member3", "3", "member2", "2"}},
+		},
+		{
+			name:     "ZPOPMAX with count argument but multiple members have the same score",
+			commands: []string{"ZADD sortedSet 1 member1 1 member2 1 member3", "ZPOPMAX sortedSet 2"},
+			expected: []interface{}{float64(3), []interface{}{"member3", "1", "member2", "1"}},
+		},
+		{
+			name:     "ZPOPMAX with negative count argument",
+			commands: []string{"ZADD sortedSet 1 member1 2 member2 3 member3", "ZPOPMAX sortedSet -1"},
+			expected: []interface{}{float64(3), []interface{}{}},
+		},
+		{
+			name:     "ZPOPMAX with invalid count argument",
+			commands: []string{"ZADD sortedSet 1 member1", "ZPOPMAX sortedSet INCORRECT_COUNT_ARGUMENT"},
+			expected: []interface{}{float64(1), "ERR value is not an integer or out of range"},
+		},
+		{
+			name:     "ZPOPMAX with count argument greater than length of sorted set",
+			commands: []string{"ZADD sortedSet 1 member1 2 member2 3 member3", "ZPOPMAX sortedSet 10"},
+			expected: []interface{}{float64(3), []interface{}{"member3", "3", "member2", "2", "member1", "1"}},
+		},
+		{
+			name:     "ZPOPMAX on empty sorted set",
+			commands: []string{"ZADD sortedSet 1 member1", "ZPOPMAX sortedSet 1", "ZPOPMAX sortedSet"},
+			expected: []interface{}{float64(1), []interface{}{"member1", "1"}, []interface{}{}},
+		},
+		{
+			name:     "ZPOPMAX with floating-point scores",
+			commands: []string{"ZADD sortedSet 1.5 member1 2.7 member2 3.8 member3", "ZPOPMAX sortedSet"},
+			expected: []interface{}{float64(3), []interface{}{"member3", "3.8"}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := exec.ConnectToServer()
+			DeleteKey(t, conn, exec, "sortedSet")
+
+			for i, cmd := range tc.commands {
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expected[i], result)
+			}
+		})
+	}
+}

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -1041,6 +1041,16 @@ var (
 		IsMigrated: true,
 		NewEval:    evalZRANGE,
 	}
+	zpopmaxCmdMeta = DiceCmdMeta{
+		Name: "ZPOPMAX",
+		Info: `ZPOPMAX  key [count]
+		Pops count number of elements from the sorted set from highest to lowest and returns those score and member.
+		If count is not provided '1' is considered by default.`,
+		Arity:      2,
+		KeySpecs:   KeySpecs{BeginIndex: 1},
+		IsMigrated: true,
+		NewEval:    evalZPOPMAX,
+	}
 	bitfieldCmdMeta = DiceCmdMeta{
 		Name: "BITFIELD",
 		Info: `The command treats a string as an array of bits as well as bytearray data structure,
@@ -1230,6 +1240,7 @@ func init() {
 	DiceCmds["TYPE"] = typeCmdMeta
 	DiceCmds["ZADD"] = zaddCmdMeta
 	DiceCmds["ZRANGE"] = zrangeCmdMeta
+	DiceCmds["ZPOPMAX"] = zpopmaxCmdMeta
 	DiceCmds["JSON.STRAPPEND"] = jsonstrappendCmdMeta
 }
 

--- a/internal/eval/sortedset/sorted_set.go
+++ b/internal/eval/sortedset/sorted_set.go
@@ -146,3 +146,22 @@ func (ss *Set) Get(member string) (float64, bool) {
 	score, exists := ss.memberMap[member]
 	return score, exists
 }
+
+// This func is used to remove the maximum element from the sortedset.
+// It takes count as an argument which tells the number of elements to be removed from the sortedset.
+func (ss *Set) PopMax(count int) []string {
+	result := []string{}
+
+	for i := 0; i < count; i++ {
+		item := ss.tree.DeleteMax()
+		if item == nil {
+			break
+		}
+		ssi := item.(*Item)
+		result = append(result, ssi.Member)
+		result = append(result, strconv.FormatFloat(ssi.Score, 'g', -1, 64))
+
+		delete(ss.memberMap, ssi.Member)
+	}
+	return result
+}

--- a/internal/server/cmd_meta.go
+++ b/internal/server/cmd_meta.go
@@ -98,6 +98,10 @@ var (
 		CmdType: SingleShard,
 	}
 
+	zpopmaxCmdMeta = CmdsMeta{
+		Cmd:     "ZPOPMAX",
+		CmdType: SingleShard,
+	}
 	// Metadata for multishard commands would go here.
 	// These commands require both breakup and gather logic.
 
@@ -122,5 +126,6 @@ func init() {
 	WorkerCmdsMeta["PFADD"] = pfaddCmdMeta
 	WorkerCmdsMeta["PFCOUNT"] = pfcountCmdMeta
 	WorkerCmdsMeta["PFMERGE"] = pfmergeCmdMeta
+	WorkerCmdsMeta["ZPOPMAX"] = zpopmaxCmdMeta
 	// Additional commands (multishard, custom) can be added here as needed.
 }

--- a/internal/worker/cmd_meta.go
+++ b/internal/worker/cmd_meta.go
@@ -54,6 +54,7 @@ const (
 	CmdPFAdd       = "PFADD"
 	CmdPFCount     = "PFCOUNT"
 	CmdPFMerge     = "PFMERGE"
+	CmdZPopMax     = "ZPOPMAX"
 )
 
 type CmdMeta struct {
@@ -128,6 +129,9 @@ var CommandsMeta = map[string]CmdMeta{
 		CmdType: SingleShard,
 	},
 	CmdZRange: {
+		CmdType: SingleShard,
+	},
+	CmdZPopMax: {
 		CmdType: SingleShard,
 	},
 }


### PR DESCRIPTION
This PR closes #1127. 

- [ ] Add ZPOPMAX logic in store_eval.go  and also add support in dice db
- [ ] Add integration tests.
- [ ] Add Unit tests.
- [ ] Add Docs for ZPOPMAX