### PR TITLE
Add support for get in set command 207

### DIFF
--- a/integration_tests/commands/resp/set_test.go
+++ b/integration_tests/commands/resp/set_test.go
@@ -71,8 +71,8 @@ func TestSetWithGetOption(t *testing.T) {
 		},
 		{
 			name:     "Bitwise Set and Retrieve with GET",
-			commands: []string{"SETBIT k 1 1", "GET k","SET k val GET"},
-			expected: []interface{}{int64(0), "@","@"},
+			commands: []string{"SETBIT k 1 1", "GET k", "SET k val GET"},
+			expected: []interface{}{int64(0), "@", "@"},
 		},
 		{
 			name:     "Set with GET and NX on Existing Key",
@@ -128,12 +128,12 @@ func TestSetWithGetOption(t *testing.T) {
 		{
 			name:     "Set with GET and XX on a Non-Existent Key",
 			commands: []string{"DEL k", "SET k new_value XX GET", "GET k"},
-			expected: []interface{}{int64(0),"(nil)", "(nil)"},
+			expected: []interface{}{int64(0), "(nil)", "(nil)"},
 		},
 		{
 			name:     "Set with GET and NX followed by XX",
 			commands: []string{"SET k first_value NX GET", "SET k second_value XX GET", "GET k"},
-			expected: []interface{}{"(nil)", "first_value","second_value"},
+			expected: []interface{}{"(nil)", "first_value", "second_value"},
 		},
 	}
 

--- a/integration_tests/commands/resp/set_test.go
+++ b/integration_tests/commands/resp/set_test.go
@@ -70,6 +70,11 @@ func TestSetWithGetOption(t *testing.T) {
 			expected: []interface{}{int64(0), "(nil)", "new_value"},
 		},
 		{
+			name:     "Bitwise Set and Retrieve with GET",
+			commands: []string{"SETBIT k 1 1", "GET k","SET k val GET"},
+			expected: []interface{}{int64(0), "@","@"},
+		},
+		{
 			name:     "Set with GET and NX on Existing Key",
 			commands: []string{"SET k old_value", "SET k new_value NX GET", "GET k"},
 			expected: []interface{}{"OK", "(nil)", "old_value"},

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -44,6 +44,8 @@ func evalSET(args []string, store *dstore.Store) *EvalResponse {
 	var exDurationMs int64 = -1
 	var state exDurationState = Uninitialized
 	var keepttl bool = false
+	var isGetCmdPresent bool = false
+	var getResp *EvalResponse;
 
 	key, value = args[0], args[1]
 	oType, oEnc := deduceTypeEncoding(value)
@@ -149,6 +151,9 @@ func evalSET(args []string, store *dstore.Store) *EvalResponse {
 			}
 		case KeepTTL:
 			keepttl = true
+		case GET:
+			isGetCmdPresent = true
+			getResp = evalGET([]string{key}, store)
 		default:
 			return &EvalResponse{
 				Result: nil,
@@ -170,10 +175,13 @@ func evalSET(args []string, store *dstore.Store) *EvalResponse {
 			Error:  diceerrors.ErrUnsupportedEncoding(int(oEnc)),
 		}
 	}
-
+	
 	// putting the k and value in a Hash Table
 	store.Put(key, store.NewObj(storedValue, exDurationMs, oType, oEnc), dstore.WithKeepTTL(keepttl))
-
+	
+	if(isGetCmdPresent){
+		return getResp;
+	}
 	return &EvalResponse{
 		Result: clientio.OK,
 		Error:  nil,

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -154,8 +154,8 @@ func evalSET(args []string, store *dstore.Store) *EvalResponse {
 		case GET:
 			isGetCmdPresent = true
 			getResp = evalGET([]string{key}, store)
-			//Abort SET operation if it has error
-			if getResp.Error != nil{
+			// Abort SET operation if it has error
+			if getResp.Error != nil {
 				return getResp
 			}
 		default:


### PR DESCRIPTION
This draft PR introduces support for the GET option in the SET command. When using SET with the GET option, the command now returns the previous value of the key if it exists before updating it with the new value. If the key does not exist, nil is returned, and the new value is stored. Additionally, TTL handling (e.g., EX, PX, KEEPTTL) remains functional with this update. This PR is still a work in progress, and I'm actively learning throughout the process. Apologies for the slow progress, and feedback is greatly appreciated!