### PR TITLE
Command Migration: ('JSON.RESP', 'JSON.DEBUG', 'JSON.INGEST')

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -30,6 +30,8 @@ const (
 	OverflowTypeErr        = "-ERR Invalid OVERFLOW type specified"
 	WrongKeyTypeErr        = "-ERR Existing key has wrong Dice type"
 	NoKeyExistsErr         = "-ERR Could not perform this operation on a key that doesn't exist"
+	UnknownSubcommandErr   = "-ERR Unknown subcommand '%s' - try `JSON.DEBUG HELP`"
+	InvalidJsonPathErr     = "-ERR invalid JSON path"
 )
 
 type DiceError struct {
@@ -77,4 +79,8 @@ func NewErrArity(cmdName string) []byte {
 
 func NewErrExpireTime(cmdName string) []byte {
 	return NewErrWithFormattedMessage(ExpiryErr, strings.ToLower(cmdName))
+}
+
+func NewErrUnknownSubcommand(cmdName string) error {
+	return fmt.Errorf(UnknownSubcommandErr, strings.ToLower(cmdName))
 }

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -244,9 +244,10 @@ var (
 		JSON.DEBUG MEMORY returns memory usage by key in bytes
 		JSON.DEBUG HELP displays help message
 		`,
-		Eval:     evalJSONDebug,
-		Arity:    2,
-		KeySpecs: KeySpecs{BeginIndex: 1},
+		Arity:      2,
+		KeySpecs:   KeySpecs{BeginIndex: 1},
+		IsMigrated: true,
+		NewEval:    evalJSONDEBUG,
 	}
 	jsonobjkeysCmdMeta = DiceCmdMeta{
 		Name: "JSON.OBJKEYS",
@@ -275,9 +276,10 @@ var (
 		the generated key is then used to store the provided JSON value at specified path.
 		Returns unique identifier if successful.
 		Returns encoded error message if the number of arguments is incorrect or the JSON string is invalid.`,
-		Eval:     evalJSONINGEST,
-		Arity:    -3,
-		KeySpecs: KeySpecs{BeginIndex: 1},
+		Arity:      -3,
+		KeySpecs:   KeySpecs{BeginIndex: 1},
+		IsMigrated: true,
+		NewEval:    evalJSONINGEST,
 	}
 	jsonarrinsertCmdMeta = DiceCmdMeta{
 		Name: "JSON.ARRINSERT",
@@ -294,9 +296,10 @@ var (
 		Name: "JSON.RESP",
 		Info: `JSON.RESP key [path]
 		Return the JSON in key in Redis serialization protocol specification form`,
-		Eval:     evalJSONRESP,
-		Arity:    -2,
-		KeySpecs: KeySpecs{BeginIndex: 1},
+		Arity:      -2,
+		KeySpecs:   KeySpecs{BeginIndex: 1},
+		IsMigrated: true,
+		NewEval:    evalJSONRESP,
 	}
 	jsonarrtrimCmdMeta = DiceCmdMeta{
 		Name: "JSON.ARRTRIM",

--- a/internal/server/cmd_meta.go
+++ b/internal/server/cmd_meta.go
@@ -98,6 +98,21 @@ var (
 		CmdType: SingleShard,
 	}
 
+	jsonrespCmdMeta = CmdsMeta{
+		Cmd:     "JSON.RESP",
+		CmdType: SingleShard,
+	}
+
+	jsondebugCmdMeta = CmdsMeta{
+		Cmd:     "JSON.DEBUG",
+		CmdType: SingleShard,
+	}
+
+	jsoningestCmdMeta = CmdsMeta{
+		Cmd:     "JSON.INGEST",
+		CmdType: SingleShard,
+	}
+
 	// Metadata for multishard commands would go here.
 	// These commands require both breakup and gather logic.
 
@@ -117,6 +132,9 @@ func init() {
 	WorkerCmdsMeta["JSON.CLEAR"] = jsonclearCmdMeta
 	WorkerCmdsMeta["JSON.STRLEN"] = jsonstrlenCmdMeta
 	WorkerCmdsMeta["JSON.OBJLEN"] = jsonobjlenCmdMeta
+	WorkerCmdsMeta["JSON.RESP"] = jsonrespCmdMeta
+	WorkerCmdsMeta["JSON.DEBUG"] = jsondebugCmdMeta
+	WorkerCmdsMeta["JSON.INGEST"] = jsoningestCmdMeta
 	WorkerCmdsMeta["ZADD"] = zaddCmdMeta
 	WorkerCmdsMeta["ZRANGE"] = zrangeCmdMeta
 	WorkerCmdsMeta["PFADD"] = pfaddCmdMeta

--- a/internal/worker/cmd_meta.go
+++ b/internal/worker/cmd_meta.go
@@ -54,6 +54,9 @@ const (
 	CmdPFAdd       = "PFADD"
 	CmdPFCount     = "PFCOUNT"
 	CmdPFMerge     = "PFMERGE"
+	CmdJSONResp    = "JSON.RESP"
+	CmdJSONDebug   = "JSON.DEBUG"
+	CmdJSONIngest  = "JSON.INGEST"
 )
 
 type CmdMeta struct {
@@ -104,6 +107,15 @@ var CommandsMeta = map[string]CmdMeta{
 		CmdType: SingleShard,
 	},
 	CmdPFMerge: {
+		CmdType: SingleShard,
+	},
+	CmdJSONResp: {
+		CmdType: SingleShard,
+	},
+	CmdJSONDebug: {
+		CmdType: SingleShard,
+	},
+	CmdJSONIngest: {
 		CmdType: SingleShard,
 	},
 


### PR DESCRIPTION
This PR migrates JSON.RESP, JSON.DEBUG and JSON.INGEST to make it protocol agnostic. Closes https://github.com/DiceDB/dice/issues/1030

Migration Checklist

- [x] Migrated the evalXXX function with the latest definition
- [ ] Update or add unit tests for the new implementation.
- [ ] All unit tests pass successfully.
- [ ] Ensure all integration tests pass successfully.
- [ ] Ensure integration tests are added for the migrated command on multi-threaded resp server.
- [ ] Add http, websocket tests for the commands
- [ ] Move Integration tests for the respective commands under the RESP integration tests directory from Async directory
- [ ] Please validate that the documentation for the respective commands is up to date. If not then consider adding them.