### PR TITLE
#1165: Fix ZRANK command to return score as string with WITHSCORE

### DIFF
--- a/integration_tests/commands/http/zrank_test.go
+++ b/integration_tests/commands/http/zrank_test.go
@@ -71,7 +71,7 @@ func TestZRANK(t *testing.T) {
 					},
 				},
 			},
-			expected: []interface{}{[]interface{}{float64(2), float64(3)}},
+			expected: []interface{}{[]interface{}{float64(2), "3"}},
 		},
 		{
 			name: "ZRANK with WITHSCORE option for non-existing member",

--- a/integration_tests/commands/resp/zrank_test.go
+++ b/integration_tests/commands/resp/zrank_test.go
@@ -30,7 +30,7 @@ func TestZRANK(t *testing.T) {
 		{
 			name:     "ZRANK with WITHSCORE option for existing member",
 			commands: []string{"ZRANK key member3 WITHSCORE"},
-			expected: []interface{}{[]interface{}{int64(2), int64(3)}},
+			expected: []interface{}{[]interface{}{int64(2), "3"}},
 		},
 		{
 			name:     "ZRANK with WITHSCORE option for non-existing member",

--- a/integration_tests/commands/websocket/zrank_test.go
+++ b/integration_tests/commands/websocket/zrank_test.go
@@ -36,7 +36,7 @@ func TestZRANK(t *testing.T) {
 		{
 			name:     "ZRANK with WITHSCORE option for existing member",
 			commands: []string{"ZRANK myset member3 WITHSCORE"},
-			expected: []interface{}{[]interface{}{float64(2), float64(3)}},
+			expected: []interface{}{[]interface{}{float64(2), "3"}},
 		},
 		{
 			name:     "ZRANK with WITHSCORE option for non-existing member",

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -5969,7 +5969,7 @@ func testEvalZRANK(t *testing.T, store *dstore.Store) {
 			},
 			input: []string{"myzset", "member2", "WITHSCORE"},
 			migratedOutput: EvalResponse{
-				Result: []interface{}{int64(1), float64(2)},
+				Result: []interface{}{int64(1), "2"},
 				Error:  nil,
 			},
 		},

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -504,8 +504,9 @@ func evalZRANK(args []string, store *dstore.Store) *EvalResponse {
 	}
 
 	if withScore {
+		scoreStr := strconv.FormatFloat(score, 'f', -1, 64) 
 		return &EvalResponse{
-			Result: []interface{}{rank, score},
+			Result: []interface{}{rank, scoreStr},
 			Error:  nil,
 		}
 	}


### PR DESCRIPTION
fixes #1165 
ZRANK when used with WITHSCORE now return score as string