### PR TITLE
docs: Made the documentation for sleep command consistent #832

### DIFF
--- a/docs/src/content/docs/commands/SLEEP.md
+++ b/docs/src/content/docs/commands/SLEEP.md
@@ -5,21 +5,26 @@ description: The `SLEEP` command in DiceDB is used to pause the execution of the
 
 The `SLEEP` command in DiceDB is used to pause the execution of the current client connection for a specified number of seconds. This command is primarily useful for testing purposes, such as simulating network latency or delaying operations to observe the behavior of other commands in a controlled environment.
 
-## Parameters
-
-### Syntax
+## Syntax
 
 ```
 SLEEP seconds
 ```
 
-### Parameters
+## Parameters
 
-- `seconds`: (Required) A floating-point number representing the number of seconds to sleep. This value can be an integer or a decimal, allowing for sub-second precision.
+| Parameter | Description                                                               | Type   | Required |
+|-----------|---------------------------------------------------------------------------|--------|----------|
+| `seconds` | An integer representing the number of seconds to sleep. Only integers values are allowed.      | Integer  | Yes      |
 
-## Return Value
 
-The `SLEEP` command returns a simple string reply of "OK" after the specified sleep duration has elapsed.
+## Return values
+
+| Condition                               | Return Value                                    |
+|-----------------------------------------|-------------------------------------------------|
+| Command is successful                   | `OK` after specified sleep duration has elapsed |
+| Syntax or specified datatype is invalid | error                                           |
+
 
 ## Behaviour
 
@@ -30,21 +35,19 @@ When the `SLEEP` command is executed, the following behavior is observed:
 3. Other clients connected to the DiceDB server will not be affected and can continue to execute commands normally.
 4. After the sleep duration has elapsed, the client will receive an "OK" response and can resume normal operations.
 
-## Error Handling
+## Errors
 
 The `SLEEP` command can raise errors under the following conditions:
 
 1. `Invalid Number of Arguments`:
-
-   - `Error Message`: `ERR wrong number of arguments for 'sleep' command`
-   - `Condition`: This error occurs if the `SLEEP` command is called without the required `seconds` parameter or with more than one parameter.
+   - Error Message: `ERR wrong number of arguments for 'sleep' command`
+   - Occurs if the `SLEEP` command is called without the required `seconds` parameter or with more than one parameter.
 
 2. `Invalid Parameter Type`:
+   - Error Message: `ERR value is not an integer or out of range`
+   - Occurs if the `seconds` parameter is not a valid integer.
 
-   - `Error Message`: `ERR value is not a valid float`
-   - `Condition`: This error occurs if the `seconds` parameter is not a valid floating-point number.
-
-## Example Usage
+## Examples
 
 ### Example 1: Basic Usage
 
@@ -53,18 +56,10 @@ Pause the client for 5 seconds.
 ```shell
 127.0.0.1:7379> SLEEP 5
 OK
+(5.01s)
 ```
 
-### Example 2: Sub-second Precision
-
-Pause the client for 1.5 seconds.
-
-```shell
-127.0.0.1:7379> SLEEP 1.5
-OK
-```
-
-### Example 3: Error Handling - Missing Parameter
+### Example 2: Error Handling - Missing Parameter
 
 Attempt to call `SLEEP` without specifying the `seconds` parameter.
 
@@ -73,13 +68,13 @@ Attempt to call `SLEEP` without specifying the `seconds` parameter.
 (error) ERR wrong number of arguments for 'sleep' command
 ```
 
-### Example 4: Error Handling - Invalid Parameter Type
+### Example 3: Error Handling - Invalid Parameter Type
 
-Attempt to call `SLEEP` with a non-numeric parameter.
+Attempt to call `SLEEP` with a non-integer parameter.
 
 ```shell
 127.0.0.1:7379> SLEEP abc
-(error) ERR value is not a valid float
+(error) ERR value is not an integer or out of range
 ```
 
 ## Notes


### PR DESCRIPTION
Fixes #832
Audit and make documentation for command SLEEP consistent

Changes include:

1. Fixed the structure to match the format of other commands (e.g. SET)
2. As discussed this on the discord, removed all the references of floating point being supported, changed them to integers.
3. Updated the Parameters and Return values sections to use markdown tables.
4. Revised the Errors section and Examples to align them with the overall changes.




