### PR TITLE
Issue-1103 - Fixing broken pipe errors

### DIFF
--- a/internal/server/websocketServer.go
+++ b/internal/server/websocketServer.go
@@ -122,7 +122,7 @@ func (s *WebsocketServer) WebsocketHandler(w http.ResponseWriter, r *http.Reques
 	defer func() {
 		closeErr := conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "close 1000 (normal)"))
 		if closeErr != nil {
-			slog.Warn("Error during closing handshake", slog.Any("error", closeErr))
+			slog.Debug("Error during closing handshake", slog.Any("error", closeErr))
 		}
 		conn.Close()
 	}()
@@ -130,20 +130,14 @@ func (s *WebsocketServer) WebsocketHandler(w http.ResponseWriter, r *http.Reques
 	maxRetries := config.DiceConfig.WebSocket.MaxWriteResponseRetries
 	for {
 		// read incoming message
-		messageType, msg, err := conn.ReadMessage()
+		_, msg, err := conn.ReadMessage()
 		if err != nil {
 			// acceptable close errors
 			errs := []int{websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure}
 			if websocket.IsCloseError(err, errs...) {
-				slog.Info("Gracefully Exited")
 				break
 			}
 			slog.Error("Error reading message", slog.Any("error", err))
-			break
-		}
-
-		if messageType == websocket.CloseMessage {
-			slog.Info("graceful shutdown...")
 			break
 		}
 

--- a/internal/server/websocketServer.go
+++ b/internal/server/websocketServer.go
@@ -137,11 +137,9 @@ func (s *WebsocketServer) WebsocketHandler(w http.ResponseWriter, r *http.Reques
 			if websocket.IsCloseError(err, errs...) {
 				slog.Info("Gracefully Exited")
 				break
-			} else {
-				slog.Error("Error reading message", slog.Any("error", err))
-				break
 			}
-
+			slog.Error("Error reading message", slog.Any("error", err))
+			break
 		}
 
 		if messageType == websocket.CloseMessage {
@@ -194,7 +192,6 @@ func (s *WebsocketServer) WebsocketHandler(w http.ResponseWriter, r *http.Reques
 		resp := <-s.ioChan
 		if err := s.processResponse(conn, diceDBCmd, resp); err != nil {
 			break
-
 		}
 	}
 }


### PR DESCRIPTION
The identification of broken pipe is only when there is an abrupt exit, so what I saw in the codebase was there are only a couple of places that deal with the closure of WebSocket connections, most of them were only handling the case where the user exited irrespective if it was gracefully or abruptly, so I modified and added some sections for the same

- in the `closing_handshake` , it wasn't checking if the closeValue had an error, indicating that there was an error while closing the connection, so I added a check for the same
- now when a message is being read, if there is an error that belongs to the `errs` category, it means that there is a graceful exit, otherwise, the exit was due to another error, so I have added the check for the same
- In the `WriteResponseWithRetries` you have a case where the function returns the `syscall.EPIPE` error, this function is utilized in WebSocketHandler function, so I have added the check for the same


Those were all the that i found were capable of returning broken pipe errors, i have provided the segregated messages for the same, please do let me know if any other changes or features are needed

Fixes #1103 

Thank you!