### PR TITLE
Introducing DiceDB Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ DiceDB
 <a href="https://dicedb.io">![slatedb.io](https://img.shields.io/badge/site-dicedb.io-00A1FF?style=flat-square)</a>
 <a href="https://discord.gg/6r8uXWtXh7">![Discord](https://img.shields.io/discord/1232385660460204122?style=flat-square)</a>
 <a href="https://dicedb.io/get-started/installation/">![Docs](https://img.shields.io/badge/docs-00A1FF?style=flat-square)</a>
+<a href="https://gurubase.io/g/dicedb"/>![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20DiceDB%20Guru-006BFF)
 
 DiceDB is an in-memory, real-time, and reactive database with Redis and SQL support optimized for modern hardware and building real-time applications.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [DiceDB Guru](https://gurubase.io/g/dicedb) to Gurubase. DiceDB Guru uses the data from this repo and data from the [docs](https://dicedb.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "DiceDB Guru", which highlights that DiceDB now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable DiceDB Guru in Gurubase, just let me know that's totally fine.