### PR TITLE
#1129 Add support for ZCARD

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -1128,6 +1128,15 @@ var (
 		IsMigrated: true,
 		NewEval:    evalZRANK,
 	}
+	zcardCmdMeta = DiceCmdMeta{
+		Name: "ZCARD",
+		Info: `ZCARD key
+		Returns the sorted set cardinality (number of elements) of the sorted set stored at key.`,
+		Arity:      2,
+		KeySpecs:   KeySpecs{BeginIndex: 1},
+		IsMigrated: true,
+		NewEval:    evalZCARD,
+	}
 	bitfieldCmdMeta = DiceCmdMeta{
 		Name: "BITFIELD",
 		Info: `The command treats a string as an array of bits as well as bytearray data structure,
@@ -1327,6 +1336,7 @@ func init() {
 	DiceCmds["ZRANGE"] = zrangeCmdMeta
 	DiceCmds["ZPOPMIN"] = zpopminCmdMeta
 	DiceCmds["ZRANK"] = zrankCmdMeta
+	DiceCmds["ZCARD"] = zcardCmdMeta
 	DiceCmds["JSON.STRAPPEND"] = jsonstrappendCmdMeta
 }
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -111,6 +111,7 @@ func TestEval(t *testing.T) {
 	testEvalZRANGE(t, store)
 	testEvalZPOPMIN(t, store)
 	testEvalZRANK(t, store)
+	testEvalZCARD(t, store)
 	testEvalHVALS(t, store)
 	testEvalBitField(t, store)
 	testEvalHINCRBYFLOAT(t, store)
@@ -6188,6 +6189,64 @@ func BenchmarkEvalZRANK(b *testing.B) {
 			}
 		})
 	}
+}
+
+func testEvalZCARD(t *testing.T, store *dstore.Store) {
+	tests := map[string]evalTestCase{
+		"ZCARD with wrong number of arguments": {
+			input: []string{"myzset", "field"},
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrWrongArgumentCount("ZCARD"),
+			},
+		},
+		"ZCARD with missing key": {
+			input: []string{},
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrWrongArgumentCount("ZCARD"),
+			},
+		},
+		"ZCARD with wrong type key": {
+			setup: func() {
+				store.Put("string_key", store.NewObj("string_value", -1, object.ObjTypeString, object.ObjEncodingRaw))
+			},
+			input: []string{"string_key"},
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrWrongTypeOperation,
+			},
+		},
+		"ZCARD with non-existent key": {
+			input: []string{"non_existent_key"},
+			migratedOutput: EvalResponse{
+				Result: clientio.IntegerZero,
+				Error:  nil,
+			},
+		},
+		"ZCARD with sorted set holding single element": {
+			setup: func() {
+				evalZADD([]string{"myzset", "1", "one"}, store)
+			},
+			input: []string{"myzset"},
+			migratedOutput: EvalResponse{
+				Result: int64(1),
+				Error:  nil,
+			},
+		},
+		"ZCARD with sorted set holding multiple elements": {
+			setup: func() {
+				evalZADD([]string{"myzset", "1", "one", "2", "two", "3", "three"}, store)
+			},
+			input: []string{"myzset"},
+			migratedOutput: EvalResponse{
+				Result: int64(3),
+				Error:  nil,
+			},
+		},
+	}
+
+	runMigratedEvalTests(t, tests, evalZCARD, store)
 }
 
 func testEvalBitField(t *testing.T, store *dstore.Store) {

--- a/internal/eval/sortedset/sorted_set.go
+++ b/internal/eval/sortedset/sorted_set.go
@@ -202,3 +202,8 @@ func (ss *Set) Get(member string) (float64, bool) {
 	score, exists := ss.memberMap[member]
 	return score, exists
 }
+
+func (ss *Set) Len() int {
+	cardinality := len(ss.memberMap)
+	return cardinality
+}

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -676,7 +676,7 @@ func evalZRANK(args []string, store *dstore.Store) *EvalResponse {
 	}
 
 	if withScore {
-		scoreStr := strconv.FormatFloat(score, 'f', -1, 64) 
+		scoreStr := strconv.FormatFloat(score, 'f', -1, 64)
 		return &EvalResponse{
 			Result: []interface{}{rank, scoreStr},
 			Error:  nil,
@@ -685,6 +685,39 @@ func evalZRANK(args []string, store *dstore.Store) *EvalResponse {
 
 	return &EvalResponse{
 		Result: rank,
+		Error:  nil,
+	}
+}
+
+// evalZCARD returns the cardinality (number of elements) of the sorted set stored at key.
+// Returns 0 if the key does not exist.
+func evalZCARD(args []string, store *dstore.Store) *EvalResponse {
+	if len(args) < 1 || len(args) > 1 {
+		return &EvalResponse{
+			Result: nil,
+			Error:  diceerrors.ErrWrongArgumentCount("ZCARD"),
+		}
+	}
+
+	key := args[0]
+	obj := store.Get(key)
+
+	if obj == nil {
+		return &EvalResponse{
+			Result: clientio.IntegerZero,
+			Error:  nil,
+		}
+	}
+
+	sortedSet, err := sortedset.FromObject(obj)
+	if err != nil {
+		return &EvalResponse{
+			Result: nil,
+			Error:  diceerrors.ErrWrongTypeOperation,
+		}
+	}
+	return &EvalResponse{
+		Result: int64(sortedSet.Len()),
 		Error:  nil,
 	}
 }
@@ -1842,7 +1875,7 @@ func evalHSCAN(args []string, store *dstore.Store) *EvalResponse {
 		Error:  nil,
 	}
 }
-  
+
 // evalBF.RESERVE evaluates the BF.RESERVE command responsible for initializing a
 // new bloom filter and allocation it's relevant parameters based on given inputs.
 // If no params are provided, it uses defaults.

--- a/internal/server/cmd_meta.go
+++ b/internal/server/cmd_meta.go
@@ -86,6 +86,10 @@ var (
 		Cmd:     "ZRANK",
 		CmdType: SingleShard,
 	}
+	zcardCmdMeta = CmdsMeta{
+		Cmd:     "ZCARD",
+		CmdType: SingleShard,
+	}
 	pfaddCmdMeta = CmdsMeta{
 		Cmd:     "PFADD",
 		CmdType: SingleShard,
@@ -113,7 +117,7 @@ var (
 		Cmd:     "JSON.OBJLEN",
 		CmdType: SingleShard,
 	}
-  hlenCmdMeta = CmdsMeta{
+	hlenCmdMeta = CmdsMeta{
 		Cmd:     "HLEN",
 		CmdType: SingleShard,
 	}
@@ -198,6 +202,7 @@ func init() {
 	WorkerCmdsMeta["ZADD"] = zaddCmdMeta
 	WorkerCmdsMeta["ZRANGE"] = zrangeCmdMeta
 	WorkerCmdsMeta["ZRANK"] = zrankCmdMeta
+	WorkerCmdsMeta["ZCARD"] = zcardCmdMeta
 	WorkerCmdsMeta["PFADD"] = pfaddCmdMeta
 	WorkerCmdsMeta["ZPOPMIN"] = zpopminCmdMeta
 	WorkerCmdsMeta["PFCOUNT"] = pfcountCmdMeta

--- a/internal/worker/cmd_meta.go
+++ b/internal/worker/cmd_meta.go
@@ -71,6 +71,7 @@ const (
 	CmdZAdd         = "ZADD"
 	CmdZRange       = "ZRANGE"
 	CmdZRank        = "ZRANK"
+	CmdZCard        = "ZCARD"
 	CmdPFAdd        = "PFADD"
 	CmdPFCount      = "PFCOUNT"
 	CmdPFMerge      = "PFMERGE"
@@ -91,7 +92,6 @@ const (
 	CmdBFReserve    = "BF.RESERVE"
 	CmdBFInfo       = "BF.INFO"
 	CmdBFExists     = "BF.EXISTS"
-
 )
 
 type CmdMeta struct {
@@ -167,7 +167,7 @@ var CommandsMeta = map[string]CmdMeta{
 		CmdType: SingleShard,
 	},
 	CmdHScan: {
- 		CmdType: SingleShard,
+		CmdType: SingleShard,
 	},
 	CmdHIncrBy: {
 		CmdType: SingleShard,
@@ -232,6 +232,9 @@ var CommandsMeta = map[string]CmdMeta{
 		CmdType: SingleShard,
 	},
 	CmdZRange: {
+		CmdType: SingleShard,
+	},
+	CmdZCard: {
 		CmdType: SingleShard,
 	},
 	CmdAppend: {


### PR DESCRIPTION
Adds support for [ZCARD](https://redis.io/docs/latest/commands/zcard/)

PR Checklist 
- [x] Add support
- [x] Add unit tests
- [ ] Add integration tests
- [ ] Add docs

closes #1129 