### PR TITLE
Brainstorm tests: transform string to http body

### DIFF
--- a/integration_tests/dicedbadapter/decoder.go
+++ b/integration_tests/dicedbadapter/decoder.go
@@ -1,0 +1,101 @@
+package dicedbadapter
+
+import (
+	"fmt"
+	"strings"
+)
+
+// decodeArgs decodes a Redis command string based on the command metadata.
+func decodeArgs(commandParts []string, meta DiceDBAdapterMeta) (map[string]interface{}, error) {
+	// Ensure command name matches and that we have sufficient parts
+	if len(commandParts) == 0 {
+		return nil, fmt.Errorf("empty command parts")
+	}
+
+	decodedArgs := make(map[string]interface{})
+	argIndex := 0 // Start after the command name
+
+	// Decode required arguments
+	for argName, position := range meta.RequiredArgs {
+		// the required argument is a list till the end of the command
+		if position.EndIndex == -1 {
+			position.EndIndex = len(commandParts) - 1
+			argVal := make([]interface{}, 0)
+			if position.Step > 1 {
+				for i := position.BeginIndex; i <= position.EndIndex; i += position.Step {
+					temp := make([]interface{}, 0, position.Step)
+					for j := 0; ; j++ {
+						// if we have reached the end of the command
+						// and we still need more arguments
+						// then we append an empty string
+						if i+j >= len(commandParts) && j < position.Step {
+							temp = append(temp, "")
+							break
+						}
+						// if we have reached the end of the command
+						if j >= position.Step {
+							break
+						}
+						temp = append(temp, commandParts[i+j])
+					}
+					argVal = append(argVal, temp)
+				}
+				decodedArgs[argName] = argVal
+
+			} else {
+				for i := position.BeginIndex; i <= position.EndIndex; i += position.Step {
+					argVal = append(argVal, commandParts[i])
+				}
+				decodedArgs[argName] = argVal
+			}
+			argIndex += position.EndIndex - position.BeginIndex + 1
+			// the required argument is a string
+		} else if position.BeginIndex < len(commandParts) {
+			decodedArgs[argName] = commandParts[position.BeginIndex]
+			argIndex++
+		} else {
+			return nil, fmt.Errorf("missing required argument '%s'", argName)
+		}
+	}
+	fmt.Println(decodedArgs, argIndex, (commandParts))
+	for i := argIndex; i < len(commandParts); i++ {
+		// Decode optional arguments
+		arg := strings.ToLower(commandParts[i])
+		if _, exists := meta.OptionalArgs[arg]; exists {
+			if i+1 < len(commandParts) {
+				decodedArgs[arg] = commandParts[i+1]
+			} else {
+				return nil, fmt.Errorf("missing value for optional argument '%s'", arg)
+			}
+			i++
+		} else if _, exists := meta.Flags[arg]; exists {
+			decodedArgs[arg] = arg
+		} else {
+			return nil, fmt.Errorf("unexpected argument '%s'", arg)
+		}
+	}
+	return decodedArgs, nil
+}
+
+// setDecoder decodes the SET command.
+func setDecoder(commandParts []string) (map[string]interface{}, error) {
+	return decodeArgs(commandParts, DiceCmdAdapters["SET"])
+}
+
+// getDecoder decodes the GET command.
+func getDecoder(parts []string) (map[string]interface{}, error) {
+	return decodeArgs(parts, DiceCmdAdapters["GET"])
+}
+
+// delDecoder decodes the DEL command.
+func delDecoder(parts []string) (map[string]interface{}, error) {
+	return decodeArgs(parts, DiceCmdAdapters["DEL"])
+}
+
+func mgetDecoder(commandParts []string) (map[string]interface{}, error) {
+	return decodeArgs(commandParts, DiceCmdAdapters["MGET"])
+}
+
+func msetDecoder(commandParts []string) (map[string]interface{}, error) {
+	return decodeArgs(commandParts, DiceCmdAdapters["MSET"])
+}

--- a/integration_tests/dicedbadapter/decoder.go
+++ b/integration_tests/dicedbadapter/decoder.go
@@ -141,3 +141,7 @@ func bitopDecoder(commandParts []string) (map[string]interface{}, error) {
 func bitfieldDecoder(commandParts []string) (map[string]interface{}, error) {
 	return decodeArgs(commandParts, DiceCmdAdapters["BITFIELD"])
 }
+
+func zaddDecoder(commandParts []string) (map[string]interface{}, error) {
+	return decodeArgs(commandParts, DiceCmdAdapters["ZADD"])
+}

--- a/integration_tests/dicedbadapter/encoder.go
+++ b/integration_tests/dicedbadapter/encoder.go
@@ -1,0 +1,157 @@
+package dicedbadapter
+
+import (
+	"fmt"
+	"strings"
+)
+
+// flattenArgs flattens a list of arguments into a single string.
+// arguments can be a list of strings or a list of lists of strings.
+// nesting should be uniform.
+func flattenStringArgs(args interface{}) (string, error) {
+	if v, ok := args.(string); ok {
+		return v, nil
+	}
+	if _, ok := args.([]interface{}); !ok {
+		return "", fmt.Errorf("unexpected argument type: %T", args)
+	}
+	var result []string
+
+	// Helper function to recursively flatten the arguments
+	var flatten func([]interface{}) error
+	flatten = func(items []interface{}) error {
+
+		for _, item := range items {
+			switch v := item.(type) {
+			case string:
+				// If the item is a string, add it to the result
+				result = append(result, v)
+			case int, int64, float64, bool, int16, int32, int8, uint, uint16, uint32, uint64:
+				// If the item is a number, add it to the result
+				result = append(result, fmt.Sprintf("%v", v))
+			case []interface{}:
+				// If the item is a nested list, recursively flatten it
+				if err := flatten(v); err != nil {
+					return err
+				}
+			default:
+				// Return an error if an unexpected type is encountered
+				return fmt.Errorf("unexpected argument type: %T", item)
+			}
+		}
+		return nil
+	}
+	// Start the recursive flattening process
+	if err := flatten(args.([]interface{})); err != nil {
+		return "", err
+	}
+
+	// Join all flattened elements with spaces
+	return strings.Join(result, " "), nil
+}
+
+// orderAndEncodeArgs encodes arguments based on ArgsOrder for any Redis command.
+func orderAndEncodeArgs(command string, args map[string]interface{}) (string, error) {
+	argsOrder := DiceCmdAdapters[command].ArgsOrder
+	// Start with the command name
+	result := command
+
+	for _, arg := range argsOrder {
+		switch v := arg.(type) {
+		case string:
+			// For regular fields like "key" and "value"
+			if argVal, ok := args[v]; ok {
+				// If it's a flag (e.g., "nx": "nx"), only add the value once
+				if argVal == v {
+					result += fmt.Sprintf(" %s", v)
+				} else if v == "key" || v == "value" {
+					result += fmt.Sprintf(" %s", argVal)
+				} else {
+					result += fmt.Sprintf(" %s %s", v, argVal)
+				}
+			}
+		case []interface{}:
+			// For optional parameters or flags like ["ex", "EX", "px", "PX"] and any order
+			for i := 0; i < len(v); i += 2 {
+				paramKey := v[i].(string)
+				redisKeyword := v[i+1].(string)
+				if argVal, ok := args[paramKey]; ok {
+					// Add only the Redis keyword if it's a flag
+					if argVal == redisKeyword {
+						result += fmt.Sprintf(" %s", redisKeyword)
+					} else {
+						result += fmt.Sprintf(" %s %s", redisKeyword, argVal)
+					}
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// encodeArgs encodes arguments into a Redis command string based on command metadata.
+func encodeArgs(args map[string]interface{}, meta DiceDBAdapterMeta) (string, error) {
+	// Initialize command parts with the command name
+	commandParts := []string{meta.Command}
+
+	// Append required arguments
+	for argName, _ := range meta.RequiredArgs {
+		value, exists := args[argName]
+		if !exists {
+			return "", fmt.Errorf("missing required argument '%s'", argName)
+		}
+		switch v := value.(type) {
+		case string:
+			fmt.Println("value is sting", value)
+			commandParts = append(commandParts, v) // Add the value
+		default:
+			fmt.Println("value is possible list", value)
+			s, err := flattenStringArgs(value)
+			if err != nil {
+				return "", err
+			}
+			commandParts = append(commandParts, s) // Add the values
+		}
+	}
+
+	// Append flags
+	for flagName, flagKey := range meta.Flags {
+		if _, exists := args[flagName]; exists {
+			commandParts = append(commandParts, flagKey) // Add the flag
+		}
+	}
+
+	// Append optional arguments
+	for optArgName, optArgKey := range meta.OptionalArgs {
+		if value, exists := args[optArgName]; exists {
+			commandParts = append(commandParts, optArgKey, value.(string)) // Add key-value pair
+		}
+	}
+
+	// Join command parts to form the complete command string
+	return strings.Join(commandParts, " "), nil
+}
+
+// setEncoder encodes the SET command.
+func setEncoder(args map[string]interface{}) (string, error) {
+	return encodeArgs(args, DiceCmdAdapters["SET"])
+}
+
+// getEncoder encodes the GET command.
+func getEncoder(args map[string]interface{}) (string, error) {
+	return encodeArgs(args, DiceCmdAdapters["GET"])
+}
+
+// delEncoder encodes the DEL command.
+func delEncoder(args map[string]interface{}) (string, error) {
+	return encodeArgs(args, DiceCmdAdapters["DEL"])
+}
+
+func mgetEncoder(args map[string]interface{}) (string, error) {
+	return encodeArgs(args, DiceCmdAdapters["MGET"])
+}
+
+func msetEncoder(args map[string]interface{}) (string, error) {
+	return encodeArgs(args, DiceCmdAdapters["MSET"])
+}

--- a/integration_tests/dicedbadapter/encoder.go
+++ b/integration_tests/dicedbadapter/encoder.go
@@ -20,7 +20,6 @@ func flattenStringArgs(args interface{}) (string, error) {
 	// Helper function to recursively flatten the arguments
 	var flatten func([]interface{}) error
 	flatten = func(items []interface{}) error {
-
 		for _, item := range items {
 			switch v := item.(type) {
 			case string:
@@ -99,7 +98,6 @@ func encodeArgs(args map[string]interface{}, meta DiceDBAdapterMeta) (string, er
 					return "", err
 				}
 				commandParts = append(commandParts, subCommandStrings)
-
 			}
 		}
 	}

--- a/integration_tests/dicedbadapter/meta.go
+++ b/integration_tests/dicedbadapter/meta.go
@@ -14,7 +14,7 @@ type DiceDBAdapterMeta struct {
 	Flags        map[string]string
 	RequiredArgs map[string]Position
 	OptionalArgs map[string]string
-	SubCommands  map[string]DiceDBAdapterMeta
+	Subcommands  map[string]DiceDBAdapterMeta
 }
 
 var DiceCmdAdapters = map[string]DiceDBAdapterMeta{}
@@ -98,6 +98,90 @@ func init() {
 		OptionalArgs: map[string]string{}, // No optional args for MSET
 	}
 
+	bitopCmdAdapterMeta := DiceDBAdapterMeta{
+		Route:   "/bitop",
+		Command: "BITOP",
+		Encoder: bitopEncoder,
+		Decoder: bitopDecoder,
+		RequiredArgs: map[string]Position{
+			"operation": {
+				BeginIndex: 0,
+				EndIndex:   0,
+				Step:       1,
+			},
+			"destkey": {
+				BeginIndex: 1,
+				EndIndex:   1,
+				Step:       1,
+			},
+			"keys": {
+				BeginIndex: 2,
+				EndIndex:   -1,
+				Step:       1,
+			},
+		},
+		Flags:        map[string]string{},
+		OptionalArgs: map[string]string{},
+	}
+	bitfieldSubcommandGetAdapterMeta := DiceDBAdapterMeta{
+		RequiredArgs: map[string]Position{
+			"encoding": {
+				BeginIndex: 0,
+				EndIndex:   0,
+				Step:       1,
+			},
+			"offset": {
+				BeginIndex: 1,
+				EndIndex:   1,
+				Step:       1,
+			},
+		},
+		Flags:        map[string]string{},
+		OptionalArgs: map[string]string{},
+	}
+
+	bitfieldSubcommandSetAdapterMeta := DiceDBAdapterMeta{
+		RequiredArgs: map[string]Position{
+			"encoding": {
+				BeginIndex: 0,
+				EndIndex:   0,
+				Step:       1,
+			},
+			"offset": {
+				BeginIndex: 1,
+				EndIndex:   1,
+				Step:       1,
+			},
+			"value": {
+				BeginIndex: 2,
+				EndIndex:   2,
+				Step:       1,
+			},
+		},
+		Flags:        map[string]string{},
+		OptionalArgs: map[string]string{},
+	}
+
+	bitfieldCmdAdapterMeta := DiceDBAdapterMeta{
+		Route:   "/bitfield",
+		Command: "BITFIELD",
+		Encoder: bitfieldEncoder,
+		Decoder: bitfieldDecoder,
+		RequiredArgs: map[string]Position{
+			"key": {
+				BeginIndex: 0,
+				EndIndex:   0,
+				Step:       1,
+			},
+		},
+		Subcommands: map[string]DiceDBAdapterMeta{
+			"get": bitfieldSubcommandGetAdapterMeta,
+			"set": bitfieldSubcommandSetAdapterMeta,
+			// "incrby":   bitfieldSubcommandIncrbyAdapterMeta,
+			// "overflow": bitfieldSubcommandOverflowAdapterMeta,
+		},
+	}
+
 	DiceCmdAdapters["SET"] = setCmdAdapterMeta
 
 	DiceCmdAdapters["GET"] = getCmdAdapterMeta
@@ -107,5 +191,9 @@ func init() {
 	DiceCmdAdapters["MGET"] = mgetCmdAdapterMeta
 
 	DiceCmdAdapters["MSET"] = msetCmdAdapterMeta
+
+	DiceCmdAdapters["BITOP"] = bitopCmdAdapterMeta
+
+	DiceCmdAdapters["BITFIELD"] = bitfieldCmdAdapterMeta
 
 }

--- a/integration_tests/dicedbadapter/meta.go
+++ b/integration_tests/dicedbadapter/meta.go
@@ -20,7 +20,6 @@ type DiceDBAdapterMeta struct {
 var DiceCmdAdapters = map[string]DiceDBAdapterMeta{}
 
 func init() {
-
 	setCmdAdapterMeta := DiceDBAdapterMeta{
 		Route:   "/set",
 		Command: "SET",
@@ -207,5 +206,4 @@ func init() {
 	DiceCmdAdapters["BITFIELD"] = bitfieldCmdAdapterMeta
 
 	DiceCmdAdapters["ZADD"] = zaddCmdAdapterMeta
-
 }

--- a/integration_tests/dicedbadapter/meta.go
+++ b/integration_tests/dicedbadapter/meta.go
@@ -1,0 +1,111 @@
+package dicedbadapter
+
+type Position struct {
+	BeginIndex int
+	EndIndex   int
+	Step       int
+}
+type DiceDBAdapterMeta struct {
+	Route        string
+	Command      string
+	Encoder      CommandEncoder
+	Decoder      CommandDecoder
+	ArgsOrder    []interface{}
+	Flags        map[string]string
+	RequiredArgs map[string]Position
+	OptionalArgs map[string]string
+	SubCommands  map[string]DiceDBAdapterMeta
+}
+
+var DiceCmdAdapters = map[string]DiceDBAdapterMeta{}
+
+func init() {
+
+	setCmdAdapterMeta := DiceDBAdapterMeta{
+		Route:   "/set",
+		Command: "SET",
+		Encoder: setEncoder,
+		Decoder: setDecoder,
+		RequiredArgs: map[string]Position{"key": {
+			BeginIndex: 0,
+			EndIndex:   0,
+			Step:       1,
+		}, "value": {
+			BeginIndex: 1,
+			EndIndex:   1,
+			Step:       1,
+		}},
+		Flags:        map[string]string{"nx": "nx", "xx": "xx", "keepttl": "keepttl", "get": "get"},
+		OptionalArgs: map[string]string{"ex": "ex", "px": "px", "pxat": "pxat", "exat": "exat"},
+	}
+
+	getCmdAdapterMeta := DiceDBAdapterMeta{
+
+		Route:     "/get",
+		Command:   "GET",
+		Encoder:   getEncoder,
+		Decoder:   getDecoder,
+		ArgsOrder: []interface{}{"key"},
+		RequiredArgs: map[string]Position{"key": {
+			BeginIndex: 0,
+			EndIndex:   0,
+			Step:       1,
+		}},
+	}
+
+	delCmdAdapterMeta := DiceDBAdapterMeta{
+
+		Route:   "/del",
+		Command: "DEL",
+		Encoder: delEncoder,
+		Decoder: delDecoder,
+		RequiredArgs: map[string]Position{"keys": {
+			BeginIndex: 0,
+			EndIndex:   -1,
+			Step:       1,
+		}},
+	}
+
+	mgetCmdAdapterMeta := DiceDBAdapterMeta{
+		Route:   "/mget",
+		Command: "MGET",
+		Encoder: mgetEncoder,
+		Decoder: mgetDecoder,
+		RequiredArgs: map[string]Position{
+			"keys": {
+				BeginIndex: 0,
+				EndIndex:   -1,
+				Step:       1,
+			},
+		}, // MGET requires keys but no specific required args
+		Flags:        map[string]string{}, // No flags for MGET
+		OptionalArgs: map[string]string{}, // No optional args for MGET
+	}
+
+	msetCmdAdapterMeta := DiceDBAdapterMeta{
+		Route:   "/mset",
+		Command: "MSET",
+		Encoder: msetEncoder,
+		Decoder: msetDecoder,
+		RequiredArgs: map[string]Position{
+			"key-values": {
+				BeginIndex: 0,
+				EndIndex:   -1,
+				Step:       2,
+			},
+		}, // MSET requires key-value pairs but no specific required args
+		Flags:        map[string]string{}, // No flags for MSET
+		OptionalArgs: map[string]string{}, // No optional args for MSET
+	}
+
+	DiceCmdAdapters["SET"] = setCmdAdapterMeta
+
+	DiceCmdAdapters["GET"] = getCmdAdapterMeta
+
+	DiceCmdAdapters["DEL"] = delCmdAdapterMeta
+
+	DiceCmdAdapters["MGET"] = mgetCmdAdapterMeta
+
+	DiceCmdAdapters["MSET"] = msetCmdAdapterMeta
+
+}

--- a/integration_tests/dicedbadapter/meta.go
+++ b/integration_tests/dicedbadapter/meta.go
@@ -11,9 +11,9 @@ type DiceDBAdapterMeta struct {
 	Encoder      CommandEncoder
 	Decoder      CommandDecoder
 	ArgsOrder    []interface{}
-	Flags        map[string]string
+	Flags        map[string]int
 	RequiredArgs map[string]Position
-	OptionalArgs map[string]string
+	OptionalArgs map[string]int
 	Subcommands  map[string]DiceDBAdapterMeta
 }
 
@@ -35,8 +35,8 @@ func init() {
 			EndIndex:   1,
 			Step:       1,
 		}},
-		Flags:        map[string]string{"nx": "nx", "xx": "xx", "keepttl": "keepttl", "get": "get"},
-		OptionalArgs: map[string]string{"ex": "ex", "px": "px", "pxat": "pxat", "exat": "exat"},
+		Flags:        map[string]int{"nx": 0, "xx": 1, "keepttl": 2, "get": 3},
+		OptionalArgs: map[string]int{"ex": 0, "px": 1, "pxat": 2, "exat": 3},
 	}
 
 	getCmdAdapterMeta := DiceDBAdapterMeta{
@@ -78,8 +78,6 @@ func init() {
 				Step:       1,
 			},
 		}, // MGET requires keys but no specific required args
-		Flags:        map[string]string{}, // No flags for MGET
-		OptionalArgs: map[string]string{}, // No optional args for MGET
 	}
 
 	msetCmdAdapterMeta := DiceDBAdapterMeta{
@@ -94,8 +92,6 @@ func init() {
 				Step:       2,
 			},
 		}, // MSET requires key-value pairs but no specific required args
-		Flags:        map[string]string{}, // No flags for MSET
-		OptionalArgs: map[string]string{}, // No optional args for MSET
 	}
 
 	bitopCmdAdapterMeta := DiceDBAdapterMeta{
@@ -120,8 +116,6 @@ func init() {
 				Step:       1,
 			},
 		},
-		Flags:        map[string]string{},
-		OptionalArgs: map[string]string{},
 	}
 	bitfieldSubcommandGetAdapterMeta := DiceDBAdapterMeta{
 		RequiredArgs: map[string]Position{
@@ -136,8 +130,6 @@ func init() {
 				Step:       1,
 			},
 		},
-		Flags:        map[string]string{},
-		OptionalArgs: map[string]string{},
 	}
 
 	bitfieldSubcommandSetAdapterMeta := DiceDBAdapterMeta{
@@ -158,8 +150,6 @@ func init() {
 				Step:       1,
 			},
 		},
-		Flags:        map[string]string{},
-		OptionalArgs: map[string]string{},
 	}
 
 	bitfieldCmdAdapterMeta := DiceDBAdapterMeta{
@@ -182,6 +172,26 @@ func init() {
 		},
 	}
 
+	zaddCmdAdapterMeta := DiceDBAdapterMeta{
+		Route:   "/zadd",
+		Command: "ZADD",
+		Encoder: zaddEncoder,
+		Decoder: zaddDecoder,
+		RequiredArgs: map[string]Position{
+			"key": {
+				BeginIndex: 0,
+				EndIndex:   0,
+				Step:       1,
+			},
+			"score-members": {
+				BeginIndex: -1,
+				EndIndex:   -1,
+				Step:       2,
+			},
+		},
+		Flags: map[string]int{"nx": 0, "xx": 1, "gt": 2, "lt": 3, "ch": 4, "incr": 5},
+	}
+
 	DiceCmdAdapters["SET"] = setCmdAdapterMeta
 
 	DiceCmdAdapters["GET"] = getCmdAdapterMeta
@@ -195,5 +205,7 @@ func init() {
 	DiceCmdAdapters["BITOP"] = bitopCmdAdapterMeta
 
 	DiceCmdAdapters["BITFIELD"] = bitfieldCmdAdapterMeta
+
+	DiceCmdAdapters["ZADD"] = zaddCmdAdapterMeta
 
 }

--- a/integration_tests/dicedbadapter/parser.go
+++ b/integration_tests/dicedbadapter/parser.go
@@ -1,0 +1,55 @@
+package dicedbadapter
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DiceDBCommand represents a DiceDB command with its route and arguments.
+type DiceDBCommand struct {
+	Route string                 `json:"route"`
+	Body  map[string]interface{} `json:"body"`
+}
+
+// CommandEncoder is a function type for encoding a command from map format to string.
+type CommandEncoder func(args map[string]interface{}) (string, error)
+
+// CommandDecoder is a function type for decoding a command from string to map format.
+type CommandDecoder func(parts []string) (map[string]interface{}, error)
+
+// EncodeCommand encodes a DiceDBCommand to a string using the appropriate encoder.
+func EncodeCommand(cmd DiceDBCommand) (string, error) {
+	commandKey := strings.Split(cmd.Route, "/")
+	if len(commandKey) < 2 {
+		return "", fmt.Errorf("command string is empty")
+	}
+	commandStr := strings.ToUpper(commandKey[1])
+	commandData, exists := DiceCmdAdapters[commandStr]
+	if !exists {
+		return "", fmt.Errorf("command '%s' not supported", cmd.Route)
+	}
+	return commandData.Encoder(cmd.Body)
+}
+
+// DecodeCommand decodes a command string into a DiceDBCommand struct.
+func DecodeCommand(commandStr string) (DiceDBCommand, error) {
+	parts := strings.Fields(commandStr)
+	if len(parts) == 0 {
+		return DiceDBCommand{}, fmt.Errorf("command string is empty")
+	}
+
+	commandData, exists := DiceCmdAdapters[strings.ToUpper(parts[0])]
+	if !exists {
+		return DiceDBCommand{}, fmt.Errorf("command '%s' not supported", parts[0])
+	}
+
+	body, err := commandData.Decoder(parts[1:])
+	if err != nil {
+		return DiceDBCommand{}, err
+	}
+
+	return DiceDBCommand{
+		Route: commandData.Route,
+		Body:  body,
+	}, nil
+}

--- a/integration_tests/dicedbadapter/parser_test.go
+++ b/integration_tests/dicedbadapter/parser_test.go
@@ -1,0 +1,313 @@
+package dicedbadapter
+
+import (
+	"fmt"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+)
+
+func TestFlattenArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      interface{}
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "Single string",
+			args:     "SET",
+			expected: "SET",
+		},
+		{
+			name:     "Flat list of strings",
+			args:     []interface{}{"SET", "key", "value"},
+			expected: "SET key value",
+		},
+		{
+			name: "Simple nested list",
+			args: []interface{}{
+				"SET",
+				"key",
+				"value",
+				[]interface{}{"EX", "100"},
+				[]interface{}{"NX"},
+			},
+			expected: "SET key value EX 100 NX",
+		},
+		{
+			name: "Three levels of nesting",
+			args: []interface{}{
+				"SET",
+				[]interface{}{"key", []interface{}{"value", "EX"}},
+				"100",
+			},
+			expected: "SET key value EX 100",
+		},
+		{
+			name: "Complex nested list",
+			args: []interface{}{
+				"SET",
+				"key",
+				"value",
+				[]interface{}{"PX", "200"},
+				[]interface{}{"XX", "KEEPTTL"},
+			},
+			expected: "SET key value PX 200 XX KEEPTTL",
+		},
+		{
+			name:     "Number in the list",
+			args:     []interface{}{"SET", "key", 100},
+			expected: "SET key 100",
+		},
+		{
+			name:      "Completely invalid type",
+			args:      123, // root level is an integer, which is unexpected
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := flattenStringArgs(tt.args)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected result %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestEncodeCommandSet(t *testing.T) {
+	cmd := DiceDBCommand{
+		Route: "/set",
+		Body: map[string]interface{}{
+			"key":   "myKey",
+			"value": "myValue",
+			"ex":    "60",
+		},
+	}
+	expected := "SET myKey myValue ex 60"
+	result, err := EncodeCommand(cmd)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestDecodeCommandSetWithKeetTTL(t *testing.T) {
+	commandStr := "SET myKey myValue keepTTL"
+	expected := DiceDBCommand{
+		Route: "/set",
+		Body: map[string]interface{}{
+			"key":     "myKey",
+			"value":   "myValue",
+			"keepttl": "keepttl",
+		},
+	}
+
+	result, err := DecodeCommand(commandStr)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.Route != expected.Route {
+		t.Errorf("expected route %q, got %q", expected.Route, result.Route)
+	}
+	fmt.Println(result)
+	for k, v := range expected.Body {
+		if result.Body[k] != v {
+			t.Errorf("expected body %q for key %q, got %q", v, k, result.Body[k])
+		}
+	}
+}
+
+func TestDecodeCommandSetWithEX(t *testing.T) {
+	commandStr := "SET myKey myValue ex 60"
+	expected := DiceDBCommand{
+		Route: "/set",
+		Body: map[string]interface{}{
+			"key":   "myKey",
+			"value": "myValue",
+			"ex":    "60",
+		},
+	}
+
+	result, err := DecodeCommand(commandStr)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.Route != expected.Route {
+		t.Errorf("expected route %q, got %q", expected.Route, result.Route)
+	}
+	fmt.Println(result)
+	for k, v := range expected.Body {
+		if result.Body[k] != v {
+			t.Errorf("expected body %q for key %q, got %q", v, k, result.Body[k])
+		}
+	}
+}
+
+func TestEncodeCommandGet(t *testing.T) {
+	cmd := DiceDBCommand{
+		Route: "/get",
+		Body: map[string]interface{}{
+			"key": "myKey",
+		},
+	}
+	expected := "GET myKey"
+	result, err := EncodeCommand(cmd)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestDecodeCommandGet(t *testing.T) {
+	commandStr := "GET myKey"
+	expected := DiceDBCommand{
+		Route: "/get",
+		Body: map[string]interface{}{
+			"key": "myKey",
+		},
+	}
+
+	result, err := DecodeCommand(commandStr)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.Route != expected.Route {
+		t.Errorf("expected route %q, got %q", expected.Route, result.Route)
+	}
+	for k, v := range expected.Body {
+		if result.Body[k] != v {
+			t.Errorf("expected body %q for key %q, got %q", v, k, result.Body[k])
+		}
+	}
+}
+
+func TestEncodeCommandMGET(t *testing.T) {
+	cmd := DiceDBCommand{
+		Route: "/mget",
+		Body: map[string]interface{}{
+			"keys": []interface{}{"key1", "key2", "key3"},
+		},
+	}
+	expected := "MGET key1 key2 key3"
+	result, err := EncodeCommand(cmd)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestDecodeCommandMGET(t *testing.T) {
+	commandStr := "MGET key1 key2 key3"
+	expected := DiceDBCommand{
+		Route: "/mget",
+		Body: map[string]interface{}{
+			"keys": []interface{}{"key1", "key2", "key3"},
+		},
+	}
+
+	result, err := DecodeCommand(commandStr)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.Route != expected.Route {
+		t.Errorf("expected route %q, got %q", expected.Route, result.Route)
+	}
+	fmt.Println("result", result, "expected", expected)
+	assert.Equal(t, expected.Route, result.Route)
+	assert.Equal(t, expected.Body, result.Body)
+}
+
+func TestEncodeCommandMSET(t *testing.T) {
+	cmd := DiceDBCommand{
+		Route: "/mset",
+		Body: map[string]interface{}{
+			"key-values": []interface{}{[]interface{}{"key1", "value1"}, []interface{}{"key2", "value2"}, []interface{}{"key3", "value3"}},
+		},
+	}
+	expected := "MSET key1 value1 key2 value2 key3 value3"
+	result, err := EncodeCommand(cmd)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+
+	// Test with missing values
+	cmd = DiceDBCommand{
+		Route: "/mset",
+		Body: map[string]interface{}{
+			"key-values": []interface{}{[]interface{}{"key1", "value1"}, []interface{}{"key2", "value2"}, []interface{}{"key3", ""}},
+		},
+	}
+	expected = "MSET key1 value1 key2 value2 key3 "
+	result, err = EncodeCommand(cmd)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestDecodeCommandMSET(t *testing.T) {
+	commandStr := "MSET key1 value1 key2 value2 key3 value3"
+	expected := DiceDBCommand{
+		Route: "/mset",
+		Body: map[string]interface{}{
+			"key-values": []interface{}{[]interface{}{"key1", "value1"}, []interface{}{"key2", "value2"}, []interface{}{"key3", "value3"}},
+		},
+	}
+
+	result, err := DecodeCommand(commandStr)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assert.Equal(t, expected.Route, result.Route)
+	assert.Equal(t, expected.Body, result.Body)
+
+
+	// Test with missing values
+	commandStr = "MSET key1 value1 key2 value2 key3 "
+	expected = DiceDBCommand{
+		Route: "/mset",
+		Body: map[string]interface{}{
+			"key-values": []interface{}{[]interface{}{"key1", "value1"}, []interface{}{"key2", "value2"}, []interface{}{"key3", ""}},
+		},
+	}
+
+	result, err = DecodeCommand(commandStr)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	assert.Equal(t, expected.Route, result.Route)
+	assert.Equal(t, expected.Body, result.Body)
+}

--- a/integration_tests/dicedbadapter/parser_test.go
+++ b/integration_tests/dicedbadapter/parser_test.go
@@ -479,10 +479,8 @@ func TestEncodeCommandZadd(t *testing.T) {
 		Body: map[string]interface{}{
 			"key": "myKey",
 			"score-members": []interface{}{
-				"1",
-				"one",
-				"2",
-				"two",
+				[]interface{}{"1", "one"},
+				[]interface{}{"2", "two"},
 			},
 		},
 	}
@@ -497,10 +495,8 @@ func TestEncodeCommandZadd(t *testing.T) {
 		Body: map[string]interface{}{
 			"key": "myKey",
 			"score-members": []interface{}{
-				"1",
-				"one",
-				"2",
-				"two",
+				[]interface{}{"1", "one"},
+				[]interface{}{"2", "two"},
 			},
 			"nx": "nx",
 			"ch": "ch",
@@ -517,10 +513,8 @@ func TestEncodeCommandZadd(t *testing.T) {
 		Body: map[string]interface{}{
 			"key": "myKey",
 			"score-members": []interface{}{
-				"1",
-				"one",
-				"2",
-				"two",
+				[]interface{}{"1", "one"},
+				[]interface{}{"2", "two"},
 			},
 			"xx":   "xx",
 			"incr": "incr",
@@ -533,4 +527,48 @@ func TestEncodeCommandZadd(t *testing.T) {
 	result, err = EncodeCommand(cmd)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, result)
+}
+
+func TestDecodeCommandZadd(t *testing.T) {
+	commandStr := "ZADD myKey nx ch 1 one 2 two"
+	expected := DiceDBCommand{
+		Route: "/zadd",
+		Body: map[string]interface{}{
+			"key": "myKey",
+			"score-members": []interface{}{
+				[]interface{}{"1", "one"},
+				[]interface{}{"2", "two"},
+			},
+			"nx": "nx",
+			"ch": "ch",
+		},
+	}
+
+	result, err := DecodeCommand(commandStr)
+	assert.Nil(t, err)
+	assert.Equal(t, expected.Route, result.Route)
+	assert.Equal(t, expected.Body, result.Body)
+
+	// zadd with extra flags
+	commandStr = "ZADD myKey xx gt lt ch incr 1 one 2 two"
+	expected = DiceDBCommand{
+		Route: "/zadd",
+		Body: map[string]interface{}{
+			"key": "myKey",
+			"score-members": []interface{}{
+				[]interface{}{"1", "one"},
+				[]interface{}{"2", "two"},
+			},
+			"xx":   "xx",
+			"incr": "incr",
+			"ch":   "ch",
+			"lt":   "lt",
+			"gt":   "gt",
+		},
+	}
+
+	result, err = DecodeCommand(commandStr)
+	assert.Nil(t, err)
+	assert.Equal(t, expected.Route, result.Route)
+	assert.Equal(t, expected.Body, result.Body)
 }

--- a/integration_tests/dicedbadapter/parser_test.go
+++ b/integration_tests/dicedbadapter/parser_test.go
@@ -472,3 +472,65 @@ func TestDecodeCommandBitfield(t *testing.T) {
 	assert.Equal(t, expected.Route, result.Route)
 	assert.Equal(t, expected.Body, result.Body)
 }
+
+func TestEncodeCommandZadd(t *testing.T) {
+	cmd := DiceDBCommand{
+		Route: "/zadd",
+		Body: map[string]interface{}{
+			"key": "myKey",
+			"score-members": []interface{}{
+				"1",
+				"one",
+				"2",
+				"two",
+			},
+		},
+	}
+	expected := "ZADD myKey 1 one 2 two"
+	result, err := EncodeCommand(cmd)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+
+	// zadd with NX and CH flags
+	cmd = DiceDBCommand{
+		Route: "/zadd",
+		Body: map[string]interface{}{
+			"key": "myKey",
+			"score-members": []interface{}{
+				"1",
+				"one",
+				"2",
+				"two",
+			},
+			"nx": "nx",
+			"ch": "ch",
+		},
+	}
+	expected = "ZADD myKey nx ch 1 one 2 two"
+	result, err = EncodeCommand(cmd)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+
+	// zadd with extra flags
+	cmd = DiceDBCommand{
+		Route: "/zadd",
+		Body: map[string]interface{}{
+			"key": "myKey",
+			"score-members": []interface{}{
+				"1",
+				"one",
+				"2",
+				"two",
+			},
+			"xx":   "xx",
+			"incr": "incr",
+			"ch":   "ch",
+			"lt":   "lt",
+			"gt":   "gt",
+		},
+	}
+	expected = "ZADD myKey xx gt lt ch incr 1 one 2 two"
+	result, err = EncodeCommand(cmd)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -674,7 +674,7 @@ func evalZRANK(args []string, store *dstore.Store) *EvalResponse {
 	}
 
 	if withScore {
-		scoreStr := strconv.FormatFloat(score, 'f', -1, 64) 
+		scoreStr := strconv.FormatFloat(score, 'f', -1, 64)
 		return &EvalResponse{
 			Result: []interface{}{rank, scoreStr},
 			Error:  nil,


### PR DESCRIPTION
Hi team,

Please find a POC for using only one set of test for possibly resp, HTTP and websockets.

I have created a separate package for parser named `dicedbadapter`. Core idea is to use a meta file about each command and use that to decode and encode the command. Here, encode refers to encoding HTTP body to string and vice versa. This way, we can added new adapters when new commands are added. For new commands, we need to add new meta, new encoder/decoder wrappers and tests for the wrapper.

Please let me know your thoughts, if you think this can be used for all commands out there, we can pull this off using our community. For now I have support for six commands:
1. SET: lots of optional params
2. GET
3. DEL
4. MGET
5. MSET: have key-value pairs
6. BITOP: have required params + variable params
7. BITFIELD: have subcommands

I would like to ensure any syntax error to be thrown by the server and not the parse. (I am working on handling extra params in HTTP body, and send them into string and let DiceDB handle syntax errors"

