### PR TITLE
#869 Added per-worker id generation logic

### DIFF
--- a/internal/id/id.go
+++ b/internal/id/id.go
@@ -1,38 +1,59 @@
 package id
 
 import (
-	"sync"
+	"sync/atomic"
 )
 
-var mu sync.Mutex
-var turn, cycle, counter uint32 = 0, 0, 0
+const (
+	totalBits   uint32 = 32                                // Total bits for the ID
+	turnBits    uint32 = 4                                 // Bits for turn (allows up to 16 turns before wrap-around
+	workerBits  uint32 = 4                                 // Bits allocated for worker ID (supports up to 16 workers, 2^4)
+	counterBits uint32 = totalBits - workerBits - turnBits // Remaining bits for counter (24 bits)
+)
 
-var totalBits uint32 = 32
-var turnBits uint32 = 4
-var counterBits = totalBits - turnBits
-
-var cycleMap []uint32
+var (
+	counter  []uint32        // Per-worker counter
+	turn     []uint32        // Per-worker turn counter
+	cycleMap [][]uint32      // Per-worker cycle map
+	maxTurns = 1 << turnBits // Max turns before wrap-around
+)
 
 func init() {
-	cycleMap = make([]uint32, 1<<turnBits)
-}
+	numWorkers := 1 << workerBits
+	counter = make([]uint32, numWorkers)
+	turn = make([]uint32, numWorkers)
+	cycleMap = make([][]uint32, numWorkers)
 
-func ExpandID(id uint32) uint64 {
-	_id := uint64(id)
-	_id |= uint64(cycleMap[id>>counterBits]) << counterBits
-	return _id
-}
-
-// NextID returns a new unique ID
-// TODO: Persisting the cycle on disk and reloading it when we start the server
-func NextID() uint32 {
-	mu.Lock()
-	defer mu.Unlock()
-	counter = (counter + 1) & ((1 << counterBits) - 1)
-	if counter == 0 {
-		cycle++
-		turn = (turn + 1) & ((1 << turnBits) - 1)
-		cycleMap[turn] = cycle
+	for i := range cycleMap {
+		cycleMap[i] = make([]uint32, maxTurns)
 	}
-	return (turn << counterBits) | counter
+}
+
+// NextID generates a lock-free, unique ID per worker.
+// TODO: Persist the cycleMap to disk for server restart.
+func NextID(workerID uint32) uint32 {
+	if workerID >= (1 << workerBits) {
+		panic("workerID exceeds limit for allocated bits")
+	}
+
+	// Increment the counter for this worker and mask it to stay within limit
+	counterVal := atomic.AddUint32(&counter[workerID], 1) & ((1 << counterBits) - 1)
+	if counterVal == 0 {
+		// Counter wrapped, so increment turn
+		turnVal := atomic.AddUint32(&turn[workerID], 1) & ((1 << turnBits) - 1)
+		cycleMap[workerID][turnVal]++
+	}
+
+	// Form the unique ID: workerID (4 bits) + turn (4 bits) + counter (24 bits)
+	return (workerID << (turnBits + counterBits)) | (turn[workerID] << counterBits) | counterVal
+}
+
+// ExpandID extends the ID with the cycle value from the cycleMap.
+func ExpandID(id uint32) uint64 {
+	workerID := id >> (turnBits + counterBits)
+	turnVal := (id >> counterBits) & ((1 << turnBits) - 1)
+
+	// Add cycle information from cycleMap to make the ID globally unique over time
+	cycle := uint64(cycleMap[workerID][turnVal])
+	return (cycle << (workerBits + turnBits + counterBits)) | uint64(id)
 }

--- a/internal/id/id_test.go
+++ b/internal/id/id_test.go
@@ -1,11 +1,55 @@
 package id
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
 func BenchmarkNextID(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		ExpandID(NextID())
+	var workerCounter uint32
+
+	// Run the benchmark in parallel for each workerID to simulate high-concurrency environment
+	b.RunParallel(func(pb *testing.PB) {
+		workerID := atomic.AddUint32(&workerCounter, 1) - 1
+
+		for pb.Next() {
+			NextID(workerID)
+		}
+	})
+}
+
+func TestNextID(t *testing.T) {
+	const (
+		numWorkers   = 16   // Number of worker threads
+		idsPerWorker = 1000 // Number of IDs each worker should generate
+	)
+
+	uniqueIDs := make(map[uint32]bool)
+	var mu sync.Mutex
+
+	var wg sync.WaitGroup
+	for workerID := uint32(0); workerID < numWorkers; workerID++ {
+		wg.Add(1)
+		go func(wID uint32) {
+			defer wg.Done()
+			for i := 0; i < idsPerWorker; i++ {
+				id := NextID(wID)
+
+				// Lock used only for updating the test map (not in ID generation)
+				mu.Lock()
+				if uniqueIDs[id] {
+					t.Errorf("Duplicate ID found: %d", id)
+				}
+				uniqueIDs[id] = true
+				mu.Unlock()
+			}
+		}(workerID)
+	}
+
+	wg.Wait()
+	expectedCount := numWorkers * idsPerWorker
+	if len(uniqueIDs) != expectedCount {
+		t.Errorf("Expected %d unique IDs, got %d", expectedCount, len(uniqueIDs))
 	}
 }


### PR DESCRIPTION
Fixes #869

- Implemented a lock-free, per-worker ID generation method to enhance concurrency performance.
- Removed mutex locks, using atomic operations for thread-safe ID generation.
- Integrated unique worker IDs into the ID format for distinctiveness. Reserved 4 bits for worker ID.
- Updated ExpandID to align with the new generation logic.
- Added tests and benchmarks to ensure correctness and measure performance improvements for NextID func.
