### PR TITLE
#820 Select command docs

### DIFF
--- a/docs/src/content/docs/commands/AUTH.md
+++ b/docs/src/content/docs/commands/AUTH.md
@@ -7,7 +7,7 @@ The `AUTH` command is a DiceDB command that enables you to authenticate a client
 
 ## Syntax
 
-```
+```bash
 AUTH password
 ```
 

--- a/docs/src/content/docs/commands/BF.EXISTS.md
+++ b/docs/src/content/docs/commands/BF.EXISTS.md
@@ -50,9 +50,9 @@ The `BF.EXISTS` command can raise errors in the following scenarios:
 ### Checking for an existing item
 
 ```bash
-127.0.0.1:6379> BF.ADD myBloomFilter "apple"
+127.0.0.1:7379> BF.ADD myBloomFilter "apple"
 (integer) 1
-127.0.0.1:6379> BF.EXISTS myBloomFilter "apple"
+127.0.0.1:7379> BF.EXISTS myBloomFilter "apple"
 (integer) 1
 ```
 
@@ -61,7 +61,7 @@ In this example, the item "apple" is added to the Bloom Filter `myBloomFilter`. 
 ### Checking for a non-existing item
 
 ```bash
-127.0.0.1:6379> BF.EXISTS myBloomFilter "banana"
+127.0.0.1:7379> BF.EXISTS myBloomFilter "banana"
 (integer) 0
 ```
 
@@ -70,7 +70,7 @@ In this example, the item "banana" is checked in the Bloom Filter `myBloomFilter
 ### Handling a non-existing key
 
 ```bash
-127.0.0.1:6379> BF.EXISTS nonExistingKey "apple"
+127.0.0.1:7379> BF.EXISTS nonExistingKey "apple"
 (integer) 0
 ```
 
@@ -79,9 +79,9 @@ In this example, the key `nonExistingKey` does not exist in the database. The co
 ### Handling a wrong type of key
 
 ```bash
-127.0.0.1:6379> SET myString "hello"
+127.0.0.1:7379> SET myString "hello"
 OK
-127.0.0.1:6379> BF.EXISTS myString "apple"
+127.0.0.1:7379> BF.EXISTS myString "apple"
 (error) WRONGTYPE Operation against a key holding the wrong kind of value
 ```
 
@@ -90,7 +90,7 @@ In this example, the key `myString` is associated with a string value, not a Blo
 ### Incorrect number of arguments
 
 ```bash
-127.0.0.1:6379> BF.EXISTS myBloomFilter
+127.0.0.1:7379> BF.EXISTS myBloomFilter
 (error) ERR wrong number of arguments for 'bf.exists' command
 ```
 

--- a/docs/src/content/docs/commands/BGREWRITEAOF.md
+++ b/docs/src/content/docs/commands/BGREWRITEAOF.md
@@ -7,7 +7,7 @@ The `BGREWRITEAOF` command in DiceDB is used to asynchronously rewrite the Appen
 
 ## Syntax
 
-```
+```bash
 BGREWRITEAOF
 ```
 

--- a/docs/src/content/docs/commands/BGREWRITEAOF.md
+++ b/docs/src/content/docs/commands/BGREWRITEAOF.md
@@ -42,7 +42,7 @@ When the `BGREWRITEAOF` command is issued, DiceDB performs the following steps:
 ## Example Usage
 
 ### Basic Usage
-```sh
+```bash
 127.0.0.1:7379> BGREWRITEAOF
 OK
 ```

--- a/docs/src/content/docs/commands/BITCOUNT.md
+++ b/docs/src/content/docs/commands/BITCOUNT.md
@@ -7,7 +7,7 @@ The `BITCOUNT` command in DiceDB is used to count the number of set bits (i.e., 
 
 ## Syntax
 
-```
+```bash
 BITCOUNT key [start end [BYTE | BIT]]
 ```
 

--- a/docs/src/content/docs/commands/BITOP.md
+++ b/docs/src/content/docs/commands/BITOP.md
@@ -7,7 +7,7 @@ The `BITOP` command in DiceDB is used to perform bitwise operations between stri
 
 ## Syntax
 
-```plaintext
+```bash
 BITOP operation destkey key [key ...]
 ```
 
@@ -60,7 +60,7 @@ The `BITOP` command can raise errors in the following cases:
 
 ### Example 1: Bitwise AND Operation
 
-```plaintext
+```bash
 SET key1 "foo"
 SET key2 "bar"
 BITOP AND result key1 key2
@@ -76,7 +76,7 @@ GET result
 
 ### Example 2: Bitwise OR Operation
 
-```plaintext
+```bash
 SET key1 "foo"
 SET key2 "bar"
 BITOP OR result key1 key2
@@ -92,7 +92,7 @@ GET result
 
 ### Example 3: Bitwise XOR Operation
 
-```plaintext
+```bash
 SET key1 "foo"
 SET key2 "bar"
 BITOP XOR result key1 key2
@@ -108,7 +108,7 @@ GET result
 
 ### Example 4: Bitwise NOT Operation
 
-```plaintext
+```bash
 SET key1 "foo"
 BITOP NOT result key1
 GET result

--- a/docs/src/content/docs/commands/BITPOS.md
+++ b/docs/src/content/docs/commands/BITPOS.md
@@ -7,7 +7,7 @@ The `BITPOS` command in DiceDB is used to find the position of the first bit set
 
 ## Syntax
 
-```plaintext
+```bash
 BITPOS key bit [start] [end]
 ```
 
@@ -49,14 +49,14 @@ The `BITPOS` command can raise errors in the following cases:
 
 Find the position of the first bit set to 1 in the string stored at key `mykey`:
 
-```plaintext
+```bash
 SET mykey "foobar"
 BITPOS mykey 1
 ```
 
 `Output`:
 
-```plaintext
+```bash
 6
 ```
 
@@ -64,14 +64,14 @@ BITPOS mykey 1
 
 Find the position of the first bit set to 0 in the string stored at key `mykey`, starting from byte position 2 and ending at byte position 4:
 
-```plaintext
+```bash
 SET mykey "foobar"
 BITPOS mykey 0 2 4
 ```
 
 `Output`:
 
-```plaintext
+```bash
 16
 ```
 
@@ -79,14 +79,14 @@ BITPOS mykey 0 2 4
 
 If the specified bit is not found within the specified range, the command returns -1:
 
-```plaintext
+```bash
 SET mykey "foobar"
 BITPOS mykey 1 2 4
 ```
 
 `Output`:
 
-```plaintext
+```bash
 -1
 ```
 
@@ -96,14 +96,14 @@ BITPOS mykey 1 2 4
 
 Attempting to use `BITPOS` on a key that holds a non-string value:
 
-```plaintext
+```bash
 LPUSH mylist "item"
 BITPOS mylist 1
 ```
 
 `Output`:
 
-```plaintext
+```bash
 (error) WRONGTYPE Operation against a key holding the wrong kind of value
 ```
 
@@ -111,14 +111,14 @@ BITPOS mylist 1
 
 Using a bit value other than 0 or 1:
 
-```plaintext
+```bash
 SET mykey "foobar"
 BITPOS mykey 2
 ```
 
 `Output`:
 
-```plaintext
+```bash
 (error) ERR bit is not an integer or out of range
 ```
 
@@ -126,13 +126,13 @@ BITPOS mykey 2
 
 Using non-integer values for the `start` or `end` parameters:
 
-```plaintext
+```bash
 SET mykey "foobar"
 BITPOS mykey 1 "a" "b"
 ```
 
 `Output`:
 
-```plaintext
+```bash
 (error) ERR value is not an integer or out of range
 ```

--- a/docs/src/content/docs/commands/DBSIZE.md
+++ b/docs/src/content/docs/commands/DBSIZE.md
@@ -3,11 +3,13 @@ title: DBSIZE
 description: The `DBSIZE` command in DiceDB returns the number of keys in the currently selected database, providing a quick way to understand the size of your database.
 ---
 
+> **Important Note:** As of the current version, DiceDB does not support multiple databases. Therefore, while the documentation mentions database selection via the `SELECT` command, all operations occur on a single database space.
+
 The `DBSIZE` command in DiceDB is used to return the number of keys in the currently selected database. This command is useful for monitoring and managing the size of your DiceDB database, providing a quick way to understand the number of keys stored.
 
 ## Syntax
 
-```
+```bash
 DBSIZE
 ```
 
@@ -31,8 +33,8 @@ The `DBSIZE` command does not take any parameters.
 - If multiple databases are in use, `DBSIZE` will only count keys in the currently selected database.
 
 ## Errors
-The `DBSIZE` command is straightforward and does not typically result in errors under normal usage. However, there are a few scenarios where errors might be encountered:
 
+The `DBSIZE` command is straightforward and does not typically result in errors under normal usage. However, there are a few scenarios where errors might be encountered:
 
 1. `Connection Issues`:
    - Error Message: `ERR Connection lost`
@@ -57,7 +59,7 @@ In this example, the currently selected database contains 42 keys.
 
 ### Using with Multiple Databases
 
-If you are working with multiple databases, you can switch between them using the `SELECT` command and then use `DBSIZE` to get the number of keys in each database:
+While the following example shows the traditional syntax for working with multiple databases, please note that in the current version of DiceDB, all operations occur on a single database space:
 
 ```shell
 127.0.0.1:7379> SELECT 0
@@ -68,10 +70,10 @@ OK
 127.0.0.1:7379> SELECT 1
 OK
 127.0.0.1:7379> DBSIZE
-(integer) 15
+(integer) 42
 ```
 
-In this example, database 0 contains 42 keys, and database 1 contains 15 keys.
+In the current implementation, both commands will return the same count as they operate on the same database space.
 
 ### Error Scenarios
 
@@ -81,3 +83,7 @@ In this example, database 0 contains 42 keys, and database 1 contains 15 keys.
 127.0.0.1:7379> DBSIZE
 (error) NOAUTH Authentication required
 ```
+
+## Notes
+
+As mentioned at the beginning of this document, the current version of DiceDB operates on a single database space. While the `SELECT` command is available as a placeholder, switching databases will not affect the operation of the `DBSIZE` command, and it will always return the count of keys from the single available database space.

--- a/docs/src/content/docs/commands/DBSIZE.md
+++ b/docs/src/content/docs/commands/DBSIZE.md
@@ -50,7 +50,7 @@ The `DBSIZE` command is straightforward and does not typically result in errors 
 
 Getting the number of keys in the currently selected database:
 
-```shell
+```bash
 127.0.0.1:7379> DBSIZE
 (integer) 42
 ```
@@ -61,7 +61,7 @@ In this example, the currently selected database contains 42 keys.
 
 While the following example shows the traditional syntax for working with multiple databases, please note that in the current version of DiceDB, all operations occur on a single database space:
 
-```shell
+```bash
 127.0.0.1:7379> SELECT 0
 OK
 127.0.0.1:7379> DBSIZE
@@ -79,7 +79,7 @@ In the current implementation, both commands will return the same count as they 
 
 1. Attempting to use `DBSIZE` without proper authentication:
 
-```shell
+```bash
 127.0.0.1:7379> DBSIZE
 (error) NOAUTH Authentication required
 ```

--- a/docs/src/content/docs/commands/DECR.md
+++ b/docs/src/content/docs/commands/DECR.md
@@ -7,7 +7,7 @@ The `DECR` command in DiceDB is used to decrement the integer value of a key by 
 
 ## Syntax
 
-```plaintext
+```bash
 DECR key
 ```
 

--- a/docs/src/content/docs/commands/DECRBY.md
+++ b/docs/src/content/docs/commands/DECRBY.md
@@ -7,7 +7,7 @@ The `DECRBY` command in DiceDB is used to decrement the integer value of a key b
 
 ## Syntax
 
-```
+```bash
 DECRBY key delta
 ```
 

--- a/docs/src/content/docs/commands/DEL.md
+++ b/docs/src/content/docs/commands/DEL.md
@@ -9,7 +9,7 @@ The `DEL` command in DiceDB is used to remove one or more keys from the database
 
 ## Syntax
 
-```
+```bash
 DEL key [key ...]
 ```
 

--- a/docs/src/content/docs/commands/ECHO.md
+++ b/docs/src/content/docs/commands/ECHO.md
@@ -5,7 +5,7 @@ description: The `ECHO` command in DiceDB is used to print a message
 
 ### Syntax
 
-```
+```bash
 ECHO message
 
 ```

--- a/docs/src/content/docs/commands/EXISTS.md
+++ b/docs/src/content/docs/commands/EXISTS.md
@@ -6,7 +6,7 @@ description: The `EXISTS` command in DiceDB is used to determine if one or more 
 The `EXISTS` command in DiceDB is used to determine if one or more specified keys exist in the database. It returns the number of keys that exist among the specified ones.
 
 ## Syntax
-```
+```bash
 EXISTS key [key ...]
 ```
 

--- a/docs/src/content/docs/commands/EXPIRE.md
+++ b/docs/src/content/docs/commands/EXPIRE.md
@@ -7,7 +7,7 @@ The `EXPIRE` command in DiceDB is used to set a timeout on a specified key. Afte
 
 ## Syntax
 
-```
+```bash
 EXPIRE key seconds [NX | XX | GT | LT]
 ```
 

--- a/docs/src/content/docs/commands/EXPIREAT.md
+++ b/docs/src/content/docs/commands/EXPIREAT.md
@@ -7,7 +7,7 @@ The `EXPIREAT` command is used to set the expiration time of a key in DiceDB. Un
 
 ## Syntax
 
-```plaintext
+```bash
 EXPIREAT key timestamp [NX|XX|GT|LT]
 ```
 

--- a/docs/src/content/docs/commands/EXPIRETIME.md
+++ b/docs/src/content/docs/commands/EXPIRETIME.md
@@ -7,7 +7,7 @@ The `EXPIRETIME` command in DiceDB is used to retrieve the absolute Unix timesta
 
 ## Syntax
 
-```
+```bash
 EXPIRETIME key
 ```
 

--- a/docs/src/content/docs/commands/GETBIT.md
+++ b/docs/src/content/docs/commands/GETBIT.md
@@ -7,7 +7,7 @@ The `GETBIT` command is used to retrieve the bit value at a specified offset in 
 
 ## Syntax
 
-```
+```bash
 GETBIT key offset
 ```
 

--- a/docs/src/content/docs/commands/GETDEL.md
+++ b/docs/src/content/docs/commands/GETDEL.md
@@ -7,7 +7,7 @@ The `GETDEL` command in DiceDB is used to retrieve the value of a specified key 
 
 ## Syntax
 
-```
+```bash
 GETDEL key
 ```
 

--- a/docs/src/content/docs/commands/GETEX.md
+++ b/docs/src/content/docs/commands/GETEX.md
@@ -7,7 +7,7 @@ The `GETEX` command in DiceDB is used to retrieve the value of a specified key a
 
 ## Syntax
 
-```
+```bash
 GETEX key [EX seconds|PX milliseconds|EXAT timestamp|PXAT milliseconds-timestamp|PERSIST]
 ```
 

--- a/docs/src/content/docs/commands/GETSET.md
+++ b/docs/src/content/docs/commands/GETSET.md
@@ -7,7 +7,7 @@ The `GETSET` command in DiceDB is a powerful atomic operation that combines the 
 
 ## Syntax
 
-```
+```bash
 GETSET key value
 ```
 
@@ -53,7 +53,7 @@ The `GETSET` command can raise errors in the following scenarios:
 
 ### Basic Example
 
-```DiceDB
+```bash
 127.0.0.1:7379> SET mykey "Hello"
 127.0.0.1:7379> GETSET mykey "World"
 "Hello"
@@ -67,7 +67,7 @@ The `GETSET` command can raise errors in the following scenarios:
 
 ### Example with Non-Existent Key
 
-```DiceDB
+```bash
 127.0.0.1:7379> GETSET newkey "NewValue"
 (nil)
 ```
@@ -80,7 +80,7 @@ The `GETSET` command can raise errors in the following scenarios:
 
 
 ### Example with Key having pre-existing TTL
-```DiceDB
+```bash
 127.0.0.1:7379> SET newkey "test"
 OK
 127.0.0.1:7379> EXPIRE newkey 60
@@ -102,7 +102,7 @@ OK
 
 ### Error Example: Wrong Type
 
-```DiceDB
+```bash
 127.0.0.1:7379> LPUSH mylist "item"
 127.0.0.1:7379> GETSET mylist "NewValue"
 (error) ERROR WRONGTYPE Operation against a key holding the wrong kind of value
@@ -115,7 +115,7 @@ OK
 
 ### Error Example: Syntax Error
 
-```DiceDB
+```bash
 127.0.0.1:7379> GETSET mykey
 (error) ERROR wrong number of arguments for 'getset' command
 ```

--- a/docs/src/content/docs/commands/HGET.md
+++ b/docs/src/content/docs/commands/HGET.md
@@ -7,7 +7,7 @@ The `HGET` command in DiceDB is used to retrieve the value associated with a spe
 
 ## Syntax
 
-```
+```bash
 HGET key field
 ```
 
@@ -38,7 +38,7 @@ When the `HGET` command is executed, DiceDB performs the following steps:
 
 ### Example 1: Retrieving a value from a hash
 
-```DiceDB
+```bash
 HSET user:1000 name "John Doe"
 HSET user:1000 age "30"
 HGET user:1000 name
@@ -52,7 +52,7 @@ HGET user:1000 name
 
 ### Example 2: Field does not exist
 
-```DiceDB
+```bash
 HGET user:1000 email
 ```
 
@@ -64,7 +64,7 @@ HGET user:1000 email
 
 ### Example 3: Key does not exist
 
-```DiceDB
+```bash
 HGET user:2000 name
 ```
 
@@ -76,7 +76,7 @@ HGET user:2000 name
 
 ### Example 4: Key is not a hash
 
-```DiceDB
+```bash
 SET user:3000 "Not a hash"
 HGET user:3000 name
 ```

--- a/docs/src/content/docs/commands/HGETALL.md
+++ b/docs/src/content/docs/commands/HGETALL.md
@@ -7,7 +7,7 @@ The `HGETALL` command in DiceDB is used to retrieve all the fields and values of
 
 ## Syntax
 
-```
+```bash
 HGETALL key
 ```
 
@@ -46,7 +46,7 @@ The `HGETALL` command can raise the following errors:
 
 ### Example 1: Retrieving all fields and values from an existing hash
 
-```DiceDB
+```bash
 127.0.0.1:7379> HSET user:1000 name "John Doe" age "30" country "USA"
 (integer) 3
 127.0.0.1:7379> HGETALL user:1000
@@ -65,7 +65,7 @@ The `HGETALL` command can raise the following errors:
 
 ### Example 2: Retrieving from a non-existing key
 
-```DiceDB
+```bash
 127.0.0.1:7379> HGETALL user:2000
 ```
 
@@ -78,7 +78,7 @@ The `HGETALL` command can raise the following errors:
 ### Error Example:
 Key is not a hash
 
-```DiceDB
+```bash
 127.0.0.1:7379> SET user:3000 "This is a string"
 OK
 127.0.0.1:7379> HGETALL user:3000
@@ -93,7 +93,7 @@ OK
 ### Error Example: 
 Invalid number of arguments are passed
 
-```DiceDB
+```bash
 127.0.0.1:7379> HGETALL user:3000 helloworld
 ```
 `Output:`

--- a/docs/src/content/docs/commands/HLEN.md
+++ b/docs/src/content/docs/commands/HLEN.md
@@ -7,7 +7,7 @@ The `HLEN` command in DiceDB is used to obtain the number of fields contained wi
 
 ## Syntax
 
-```
+```bash
 HLEN key
 ```
 

--- a/docs/src/content/docs/commands/HRANDFIELD.md
+++ b/docs/src/content/docs/commands/HRANDFIELD.md
@@ -7,7 +7,7 @@ The `HRANDFIELD` command in DiceDB is used to return one or more random fields f
 
 ## Syntax
 
-```
+```bash
 HRANDFIELD key [count [WITHVALUES]]
 ```
 
@@ -54,16 +54,16 @@ HRANDFIELD key [count [WITHVALUES]]
 ### Basic Usage
 Executing `HRANDFIELD` on a key without any parameters
 ```bash
-127.0.0.1:6379> HSET keys field1 value1 field2 value2 field3 value3
+127.0.0.1:7379> HSET keys field1 value1 field2 value2 field3 value3
 (integer) 3
-127.0.0.1:6379> HRANDFIELD keys
+127.0.0.1:7379> HRANDFIELD keys
 "field1"
 ```
 
 ### Usage with `count` parameter
 Executing `HRANDFIELD` on a key with a `count` parameter of 2
 ```bash
-127.0.0.1:6379> HRANDFIELD keys 2
+127.0.0.1:7379> HRANDFIELD keys 2
 1) "field2"
 2) "field1"
 ```
@@ -71,7 +71,7 @@ Executing `HRANDFIELD` on a key with a `count` parameter of 2
 ### Usage with `WITHVALUES` parameter
 Executing `HRANDFIELD` with the `WITHVALUES` parameter
 ```bash
-127.0.0.1:6379> HRANDFIELD keys 2 WITHVALUES
+127.0.0.1:7379> HRANDFIELD keys 2 WITHVALUES
 1) "field2"
 2) "value2"
 3) "field1"
@@ -82,9 +82,9 @@ Executing `HRANDFIELD` with the `WITHVALUES` parameter
 Executing `hrandfield` on a non-hash key
 
 ```bash
-127.0.0.1:6379> SET key "not a hash"
+127.0.0.1:7379> SET key "not a hash"
 OK
-127.0.0.1:6379> HRANDFIELD key
+127.0.0.1:7379> HRANDFIELD key
 (error) WRONGTYPE Operation against a key holding the wrong kind of value
 ```
 
@@ -92,14 +92,14 @@ OK
 Non-integer value passed as `count` 
 
 ```bash
-127.0.0.1:6379> HRANDFIELD keys hello
+127.0.0.1:7379> HRANDFIELD keys hello
 (error) ERROR value is not an integer or out of range
 ```
 
 ### Invalid number of arguments
 Passing invalid number of arguments to the `hrandfield` command
 ```bash
-127.0.0.1:6379> HRANDFIELD
+127.0.0.1:7379> HRANDFIELD
 (error) ERR wrong number of arguments for 'hrandfield' command
 ```
 

--- a/docs/src/content/docs/commands/HSCAN.md
+++ b/docs/src/content/docs/commands/HSCAN.md
@@ -7,7 +7,7 @@ The `HSCAN` command is used to incrementally iterate over the fields of a hash s
 
 ## Syntax
 
-```
+```bash
 HSCAN key cursor [MATCH pattern] [COUNT count]
 ```
 

--- a/docs/src/content/docs/commands/HSET.md
+++ b/docs/src/content/docs/commands/HSET.md
@@ -7,7 +7,7 @@ The `HSET` command in DiceDB is used to set the value of a field in a hash. If t
 
 ## Syntax
 
-```
+```bash
 HSET key field value [field value ...]
 ```
 
@@ -42,7 +42,7 @@ The `HSET` command can raise errors in the following scenarios:
 
 ### Basic Example
 
-```DiceDB
+```bash
 HSET user:1000 name "John Doe" age 30
 ```
 
@@ -50,7 +50,7 @@ This command sets the `name` field to "John Doe" and the `age` field to 30 in th
 
 ### Multiple Field-Value Pairs
 
-```DiceDB
+```bash
 HSET user:1000 name "John Doe" age 30 email "john.doe@example.com"
 ```
 
@@ -58,7 +58,7 @@ This command sets the `name`, `age`, and `email` fields in the hash stored at `u
 
 ### Updating Existing Fields
 
-```DiceDB
+```bash
 HSET user:1000 age 31
 ```
 
@@ -68,7 +68,7 @@ This command updates the `age` field to 31 in the hash stored at `user:1000`. If
 
 ### Creating a New Hash
 
-```DiceDB
+```bash
 HSET product:2000 name "Laptop" price 999.99 stock 50
 ```
 
@@ -77,7 +77,7 @@ HSET product:2000 name "Laptop" price 999.99 stock 50
 
 ### Updating an Existing Hash
 
-```DiceDB
+```bash
 HSET product:2000 price 899.99 stock 45
 ```
 
@@ -86,7 +86,7 @@ HSET product:2000 price 899.99 stock 45
 
 ### Error Handling Example
 
-```DiceDB
+```bash
 SET product:2000 "This is a string"
 HSET product:2000 name "Laptop"
 ```

--- a/docs/src/content/docs/commands/HSTRLEN.md
+++ b/docs/src/content/docs/commands/HSTRLEN.md
@@ -7,7 +7,7 @@ The `HSTRLEN` command in DiceDB is used to obtain the string length of value ass
 
 ## Syntax
 
-```
+```bash
 HSTRLEN key field
 ```
 

--- a/docs/src/content/docs/commands/INCR.md
+++ b/docs/src/content/docs/commands/INCR.md
@@ -7,7 +7,7 @@ The `INCR` command in DiceDB is used to increment the integer value of a key by 
 
 ## Syntax
 
-```plaintext
+```bash
 INCR key
 ```
 

--- a/docs/src/content/docs/commands/INCRBY.md
+++ b/docs/src/content/docs/commands/INCRBY.md
@@ -7,7 +7,7 @@ The `INCRBY` command in DiceDB is used to increment the integer value of a key b
 
 ## Syntax
 
-```
+```bash
 INCRBY key delta
 ```
 

--- a/docs/src/content/docs/commands/INCRBYFLOAT.md
+++ b/docs/src/content/docs/commands/INCRBYFLOAT.md
@@ -7,7 +7,7 @@ The `INCRBYFLOAT` command in DiceDB is used to increment the numeric value of a 
 
 ## Syntax
 
-```
+```bash
 INCRBYFLOAT key delta
 ```
 

--- a/docs/src/content/docs/commands/JSON.ARRAPPEND.md
+++ b/docs/src/content/docs/commands/JSON.ARRAPPEND.md
@@ -48,56 +48,56 @@ When the `JSON.ARRAPPEND` command is executed, the specified JSON values are app
 ### Example 1: Appending a single value to an array
 
 ```bash
-127.0.0.1:6379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
+127.0.0.1:7379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
 OK
-127.0.0.1:6379> JSON.ARRAPPEND myjson .numbers 4
+127.0.0.1:7379> JSON.ARRAPPEND myjson .numbers 4
 (integer) 4
-127.0.0.1:6379> JSON.GET myjson
+127.0.0.1:7379> JSON.GET myjson
 "{\"numbers\":[1,2,3,4]}"
 ```
 
 ### Example 2: Appending multiple values to an array
 
 ```bash
-127.0.0.1:6379> JSON.SET myjson . '{"fruits": ["apple", "banana"]}'
+127.0.0.1:7379> JSON.SET myjson . '{"fruits": ["apple", "banana"]}'
 OK
-127.0.0.1:6379> JSON.ARRAPPEND myjson .fruits "cherry" "date"
+127.0.0.1:7379> JSON.ARRAPPEND myjson .fruits "cherry" "date"
 (integer) 4
-127.0.0.1:6379> JSON.GET myjson
+127.0.0.1:7379> JSON.GET myjson
 "{\"fruits\":[\"apple\",\"banana\",\"cherry\",\"date\"]}"
 ```
 
 ### Example 3: Error when key does not exist
 
 ```bash
-127.0.0.1:6379> JSON.ARRAPPEND nonexistingkey .array 1
+127.0.0.1:7379> JSON.ARRAPPEND nonexistingkey .array 1
 (error) ERR key does not exist
 ```
 
 ### Example 4: Error when path does not exist
 
 ```bash
-127.0.0.1:6379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
+127.0.0.1:7379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
 OK
-127.0.0.1:6379> JSON.ARRAPPEND myjson .nonexistingpath 4
+127.0.0.1:7379> JSON.ARRAPPEND myjson .nonexistingpath 4
 (error) ERR path .nonexistingpath does not exist
 ```
 
 ### Example 5: Error when path is not an array
 
 ```bash
-127.0.0.1:6379> JSON.SET myjson . '{"object": {"key": "value"}}'
+127.0.0.1:7379> JSON.SET myjson . '{"object": {"key": "value"}}'
 OK
-127.0.0.1:6379> JSON.ARRAPPEND myjson .object 4
+127.0.0.1:7379> JSON.ARRAPPEND myjson .object 4
 (error) ERR path is not an array
 ```
 
 ### Example 6: Error when invalid JSON is provided
 
 ```bash
-127.0.0.1:6379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
+127.0.0.1:7379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
 OK
-127.0.0.1:6379> JSON.ARRAPPEND myjson .numbers invalidjson
+127.0.0.1:7379> JSON.ARRAPPEND myjson .numbers invalidjson
 (error) ERR invalid JSON
 ```
 

--- a/docs/src/content/docs/commands/JSON.ARRINSERT.md
+++ b/docs/src/content/docs/commands/JSON.ARRINSERT.md
@@ -72,7 +72,7 @@ JSON.ARRINSERT <key> <path> <index> <value> [value ...]
 
 Inserting at a valid index in the root path
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET a $ '[1,2]'
 OK
 127.0.0.1:7379> JSON.ARRINSERT a $ 2 3 4 5
@@ -85,7 +85,7 @@ OK
 
 Inserting at a negative index
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET a $ '[1,2]'
 OK
 127.0.0.1:7379> JSON.ARRINSERT a $ -2 3 4 5
@@ -98,7 +98,7 @@ OK
 
 Handling nested arrays
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET b $ '{"name":"tom","score":[10,20],"partner2":{"score":[10,20]}}'
 OK
 127.0.0.1:7379> JSON.ARRINSERT b $..score 1 5 6 true
@@ -111,7 +111,7 @@ OK
 
 Inserting with an out-of-bounds index
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET a $ '[1,2]'
 OK
 127.0.0.1:7379> JSON.ARRINSERT a $ 4 3
@@ -124,7 +124,7 @@ ERR index out of bounds
 
 Invalid index type
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET a $ '[1,2]'
 OK
 127.0.0.1:7379> JSON.ARRINSERT a $ ss 3

--- a/docs/src/content/docs/commands/JSON.ARRINSERT.md
+++ b/docs/src/content/docs/commands/JSON.ARRINSERT.md
@@ -3,7 +3,7 @@ title: JSON.ARRINSERT
 description: The JSON.ARRINSERT command in DiceDB is used to insert one or more JSON values into an array at a specified path before a given index. This command shifts all existing elements in the array to the right, making room for the new elements.
 ---
 
-The JSON.ARRINSERT command allows you to insert one or more JSON values into an array at a specified path before a given index. All existing elements in the array are shifted to the right to make room for the new elements.
+The `JSON.ARRINSERT` command allows you to insert one or more JSON values into an array at a specified path before a given index. All existing elements in the array are shifted to the right to make room for the new elements.
 
 This command returns an array of integer replies for each path, where each integer represents the new size of the array after the insertion. If the path does not exist or is not an array, it returns an error.
 
@@ -73,11 +73,11 @@ JSON.ARRINSERT <key> <path> <index> <value> [value ...]
 Inserting at a valid index in the root path
 
 ```plaintext
-127.0.0.1:6379> JSON.SET a $ '[1,2]'
+127.0.0.1:7379> JSON.SET a $ '[1,2]'
 OK
-127.0.0.1:6379> JSON.ARRINSERT a $ 2 3 4 5
+127.0.0.1:7379> JSON.ARRINSERT a $ 2 3 4 5
 (integer) 5
-127.0.0.1:6379> JSON.GET a
+127.0.0.1:7379> JSON.GET a
 [1,2,3,4,5]
 ```
 
@@ -86,11 +86,11 @@ OK
 Inserting at a negative index
 
 ```plaintext
-127.0.0.1:6379> JSON.SET a $ '[1,2]'
+127.0.0.1:7379> JSON.SET a $ '[1,2]'
 OK
-127.0.0.1:6379> JSON.ARRINSERT a $ -2 3 4 5
+127.0.0.1:7379> JSON.ARRINSERT a $ -2 3 4 5
 (integer) 5
-127.0.0.1:6379> JSON.GET a
+127.0.0.1:7379> JSON.GET a
 [3,4,5,1,2]
 ```
 
@@ -99,11 +99,11 @@ OK
 Handling nested arrays
 
 ```plaintext
-127.0.0.1:6379> JSON.SET b $ '{"name":"tom","score":[10,20],"partner2":{"score":[10,20]}}'
+127.0.0.1:7379> JSON.SET b $ '{"name":"tom","score":[10,20],"partner2":{"score":[10,20]}}'
 OK
-127.0.0.1:6379> JSON.ARRINSERT b $..score 1 5 6 true
+127.0.0.1:7379> JSON.ARRINSERT b $..score 1 5 6 true
 (integer) 5
-127.0.0.1:6379> JSON.GET b
+127.0.0.1:7379> JSON.GET b
 {"name":"tom","score":[10,5,6,true,20],"partner2":{"score":[10,5,6,true,20]}}
 ```
 
@@ -112,11 +112,11 @@ OK
 Inserting with an out-of-bounds index
 
 ```plaintext
-127.0.0.1:6379> JSON.SET a $ '[1,2]'
+127.0.0.1:7379> JSON.SET a $ '[1,2]'
 OK
-127.0.0.1:6379> JSON.ARRINSERT a $ 4 3
+127.0.0.1:7379> JSON.ARRINSERT a $ 4 3
 ERR index out of bounds
-127.0.0.1:6379> JSON.GET a
+127.0.0.1:7379> JSON.GET a
 [1,2]
 ```
 
@@ -125,10 +125,10 @@ ERR index out of bounds
 Invalid index type
 
 ```plaintext
-127.0.0.1:6379> JSON.SET a $ '[1,2]'
+127.0.0.1:7379> JSON.SET a $ '[1,2]'
 OK
-127.0.0.1:6379> JSON.ARRINSERT a $ ss 3
+127.0.0.1:7379> JSON.ARRINSERT a $ ss 3
 ERR value is not an integer or out of range
-127.0.0.1:6379> JSON.GET a
+127.0.0.1:7379> JSON.GET a
 [1,2]
 ```

--- a/docs/src/content/docs/commands/JSON.ARRPOP.md
+++ b/docs/src/content/docs/commands/JSON.ARRPOP.md
@@ -50,36 +50,36 @@ When the `JSON.ARRPOP` command is executed, the specified element is popped from
 ### Popping value from an array
 
 ```bash
-127.0.0.1:6379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
+127.0.0.1:7379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
 OK
-127.0.0.1:6379> JSON.ARRPOP myjson .numbers 1
+127.0.0.1:7379> JSON.ARRPOP myjson .numbers 1
 (integer) 2
-127.0.0.1:6379> JSON.GET myjson
+127.0.0.1:7379> JSON.GET myjson
 "{\"numbers\":[1,3]}"
 ```
 
 ### Error when key does not exist
 
 ```bash
-127.0.0.1:6379> JSON.ARRPOP nonexistingkey .array 1
+127.0.0.1:7379> JSON.ARRPOP nonexistingkey .array 1
 (error) ERR key does not exist
 ```
 
 ### Error when path does not exist
 
 ```bash
-127.0.0.1:6379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
+127.0.0.1:7379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
 OK
-127.0.0.1:6379> JSON.ARRPOP myjson .nonexistingpath 4
+127.0.0.1:7379> JSON.ARRPOP myjson .nonexistingpath 4
 (error) ERR path .nonexistingpath does not exist
 ```
 
 ### Error when path is not an array
 
 ```bash
-127.0.0.1:6379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
+127.0.0.1:7379> JSON.SET myjson . '{"numbers": [1, 2, 3]}'
 OK
-127.0.0.1:6379> JSON.ARRPOP myjson .numbers 4
+127.0.0.1:7379> JSON.ARRPOP myjson .numbers 4
 (error) ERR path is not an array
 ```
 

--- a/docs/src/content/docs/commands/JSON.ARRTRIM.md
+++ b/docs/src/content/docs/commands/JSON.ARRTRIM.md
@@ -73,13 +73,13 @@ JSON.ARRTRIM <key> <path> <start> <stop>
 Trimming an array to a specific range
 
 ```plaintext
-127.0.0.1:6379> JSON.SET b $ '[1, 2, 3, 4, 5]'
+127.0.0.1:7379> JSON.SET b $ '[1, 2, 3, 4, 5]'
 "OK"
-127.0.0.1:6379> JSON.ARRTRIM b $ 1 3
+127.0.0.1:7379> JSON.ARRTRIM b $ 1 3
 1) "3"
-127.0.0.1:6379> JSON.GET b
+127.0.0.1:7379> JSON.GET b
 "[2,3,4]"
-127.0.0.1:6379>
+127.0.0.1:7379>
 ```
 
 ### Trim array down to 1 element
@@ -87,13 +87,13 @@ Trimming an array to a specific range
 Trimming an array to a single element
 
 ```plaintext
-127.0.0.1:6379> JSON.SET a $ '[0,1,2]'
+127.0.0.1:7379> JSON.SET a $ '[0,1,2]'
 "OK"
-127.0.0.1:6379> JSON.ARRTRIM a $ 1 1
+127.0.0.1:7379> JSON.ARRTRIM a $ 1 1
 "1"
-127.0.0.1:6379> JSON.GET a
+127.0.0.1:7379> JSON.GET a
 "[1]"
-127.0.0.1:6379>
+127.0.0.1:7379>
 ```
 
 ### Trimming array with out of bound index
@@ -101,11 +101,11 @@ Trimming an array to a single element
 Trimming an array with out-of-bounds indices
 
 ```plaintext
-127.0.0.1:6379> JSON.SET c $ '[1, 2, 3, 4, 5]'
+127.0.0.1:7379> JSON.SET c $ '[1, 2, 3, 4, 5]'
 "OK"
-127.0.0.1:6379> JSON.ARRTRIM c $ -10 10
+127.0.0.1:7379> JSON.ARRTRIM c $ -10 10
 1) "5"
-127.0.0.1:6379> JSON.GET c
+127.0.0.1:7379> JSON.GET c
 "[1,2,3,4,5]"
 ```
 
@@ -114,9 +114,9 @@ Trimming an array with out-of-bounds indices
 Error when path does not exist
 
 ```plaintext
-127.0.0.1:6379> JSON.SET d $ '[1, 2, 3, 4, 5]'
+127.0.0.1:7379> JSON.SET d $ '[1, 2, 3, 4, 5]'
 "OK"
-127.0.0.1:6379> JSON.ARRTRIM d . -10 10
+127.0.0.1:7379> JSON.ARRTRIM d . -10 10
 (error) ERROR Path '.' does not exist
 ```
 
@@ -125,9 +125,9 @@ Error when path does not exist
 Error when key does not exist
 
 ```plaintext
-127.0.0.1:6379> JSON.SET a $ '[1, 2, 3, 4, 5]'
+127.0.0.1:7379> JSON.SET a $ '[1, 2, 3, 4, 5]'
 "OK"
-127.0.0.1:6379> JSON.ARRTRIM aa . -10 10
+127.0.0.1:7379> JSON.ARRTRIM aa . -10 10
 (error) ERROR key does not exist
 
 ```

--- a/docs/src/content/docs/commands/JSON.ARRTRIM.md
+++ b/docs/src/content/docs/commands/JSON.ARRTRIM.md
@@ -72,7 +72,7 @@ JSON.ARRTRIM <key> <path> <start> <stop>
 
 Trimming an array to a specific range
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET b $ '[1, 2, 3, 4, 5]'
 "OK"
 127.0.0.1:7379> JSON.ARRTRIM b $ 1 3
@@ -86,7 +86,7 @@ Trimming an array to a specific range
 
 Trimming an array to a single element
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET a $ '[0,1,2]'
 "OK"
 127.0.0.1:7379> JSON.ARRTRIM a $ 1 1
@@ -100,7 +100,7 @@ Trimming an array to a single element
 
 Trimming an array with out-of-bounds indices
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET c $ '[1, 2, 3, 4, 5]'
 "OK"
 127.0.0.1:7379> JSON.ARRTRIM c $ -10 10
@@ -113,7 +113,7 @@ Trimming an array with out-of-bounds indices
 
 Error when path does not exist
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET d $ '[1, 2, 3, 4, 5]'
 "OK"
 127.0.0.1:7379> JSON.ARRTRIM d . -10 10
@@ -124,7 +124,7 @@ Error when path does not exist
 
 Error when key does not exist
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET a $ '[1, 2, 3, 4, 5]'
 "OK"
 127.0.0.1:7379> JSON.ARRTRIM aa . -10 10

--- a/docs/src/content/docs/commands/JSON.CLEAR.md
+++ b/docs/src/content/docs/commands/JSON.CLEAR.md
@@ -7,7 +7,7 @@ The `JSON.CLEAR` command allows you to manipulate JSON data stored in DiceDB. Th
 
 ## Syntax
 
-```
+```bash
 JSON.CLEAR key [path]
 ```
 

--- a/docs/src/content/docs/commands/JSON.DEBUG.md
+++ b/docs/src/content/docs/commands/JSON.DEBUG.md
@@ -9,7 +9,7 @@ The `JSON.DEBUG` command in DiceDB is part of the DiceDBJSON module, which allow
 
 ### Syntax
 
-```
+```bash
 JSON.DEBUG <subcommand> <key> [path]
 ```
 
@@ -57,7 +57,7 @@ The `JSON.DEBUG` command can raise errors in the following scenarios:
 
 ### Example 1: Debugging Memory Usage of Entire JSON Data
 
-```sh
+```bash
 127.0.0.1:7379> JSON.DEBUG MEMORY myjson
 (integer) 256
 ```
@@ -66,7 +66,7 @@ In this example, the `JSON.DEBUG MEMORY` command is used to get the memory usage
 
 ### Example 2: Debugging Memory Usage of a Specific Path
 
-```sh
+```bash
 127.0.0.1:7379> JSON.DEBUG MEMORY myjson $.store.book[0]
 (integer) 64
 ```
@@ -75,7 +75,7 @@ In this example, the `JSON.DEBUG MEMORY` command is used to get the memory usage
 
 ### Example 3: Handling Non-Existent Key
 
-```sh
+```bash
 127.0.0.1:7379> JSON.DEBUG MEMORY nonExistentKey
 (error) ERR no such key
 ```
@@ -84,7 +84,7 @@ In this example, the `JSON.DEBUG MEMORY` command is used on a non-existent key `
 
 ### Example 4: Handling Invalid Path
 
-```sh
+```bash
 127.0.0.1:7379> JSON.DEBUG MEMORY myjson $.nonExistentPath
 (error) ERR path '$.nonExistentPath' does not exist
 ```

--- a/docs/src/content/docs/commands/JSON.DEBUG.md
+++ b/docs/src/content/docs/commands/JSON.DEBUG.md
@@ -58,7 +58,7 @@ The `JSON.DEBUG` command can raise errors in the following scenarios:
 ### Example 1: Debugging Memory Usage of Entire JSON Data
 
 ```sh
-127.0.0.1:6379> JSON.DEBUG MEMORY myjson
+127.0.0.1:7379> JSON.DEBUG MEMORY myjson
 (integer) 256
 ```
 
@@ -67,7 +67,7 @@ In this example, the `JSON.DEBUG MEMORY` command is used to get the memory usage
 ### Example 2: Debugging Memory Usage of a Specific Path
 
 ```sh
-127.0.0.1:6379> JSON.DEBUG MEMORY myjson $.store.book[0]
+127.0.0.1:7379> JSON.DEBUG MEMORY myjson $.store.book[0]
 (integer) 64
 ```
 
@@ -76,7 +76,7 @@ In this example, the `JSON.DEBUG MEMORY` command is used to get the memory usage
 ### Example 3: Handling Non-Existent Key
 
 ```sh
-127.0.0.1:6379> JSON.DEBUG MEMORY nonExistentKey
+127.0.0.1:7379> JSON.DEBUG MEMORY nonExistentKey
 (error) ERR no such key
 ```
 
@@ -85,7 +85,7 @@ In this example, the `JSON.DEBUG MEMORY` command is used on a non-existent key `
 ### Example 4: Handling Invalid Path
 
 ```sh
-127.0.0.1:6379> JSON.DEBUG MEMORY myjson $.nonExistentPath
+127.0.0.1:7379> JSON.DEBUG MEMORY myjson $.nonExistentPath
 (error) ERR path '$.nonExistentPath' does not exist
 ```
 

--- a/docs/src/content/docs/commands/JSON.DEL.md
+++ b/docs/src/content/docs/commands/JSON.DEL.md
@@ -7,7 +7,7 @@ The `JSON.DEL` command is part of the DiceDBJSON module, which allows you to man
 
 ## Syntax
 
-```
+```bash
 JSON.DEL key [path]
 ```
 
@@ -49,40 +49,40 @@ The `JSON.DEL` command can raise the following errors:
 ### Deleting an Entire JSON Document
 
 ```shell
-127.0.0.1:6379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
+127.0.0.1:7379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
-127.0.0.1:6379> JSON.DEL myjson
+127.0.0.1:7379> JSON.DEL myjson
 (integer) 1
-127.0.0.1:6379> JSON.GET myjson
+127.0.0.1:7379> JSON.GET myjson
 (nil)
 ```
 
 ### Deleting a Specific Path
 
 ```shell
-127.0.0.1:6379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
+127.0.0.1:7379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
-127.0.0.1:6379> JSON.DEL myjson $.age
+127.0.0.1:7379> JSON.DEL myjson $.age
 (integer) 1
-127.0.0.1:6379> JSON.GET myjson
+127.0.0.1:7379> JSON.GET myjson
 "{\"name\":\"John\",\"city\":\"New York\"}"
 ```
 
 ### Deleting a Non-Existent Path
 
 ```shell
-127.0.0.1:6379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
+127.0.0.1:7379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
-127.0.0.1:6379> JSON.DEL myjson $.address
+127.0.0.1:7379> JSON.DEL myjson $.address
 (integer) 0
 ```
 
 ### Error: Key Does Not Hold a JSON Document
 
 ```shell
-127.0.0.1:6379> SET mystring "Hello, World!"
+127.0.0.1:7379> SET mystring "Hello, World!"
 OK
-127.0.0.1:6379> JSON.DEL mystring
+127.0.0.1:7379> JSON.DEL mystring
 (error) ERROR Existing key has wrong Dice type
 ```
 

--- a/docs/src/content/docs/commands/JSON.DEL.md
+++ b/docs/src/content/docs/commands/JSON.DEL.md
@@ -48,7 +48,7 @@ The `JSON.DEL` command can raise the following errors:
 
 ### Deleting an Entire JSON Document
 
-```shell
+```bash
 127.0.0.1:7379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
 127.0.0.1:7379> JSON.DEL myjson
@@ -59,7 +59,7 @@ OK
 
 ### Deleting a Specific Path
 
-```shell
+```bash
 127.0.0.1:7379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
 127.0.0.1:7379> JSON.DEL myjson $.age
@@ -70,7 +70,7 @@ OK
 
 ### Deleting a Non-Existent Path
 
-```shell
+```bash
 127.0.0.1:7379> JSON.SET myjson $ '{"name": "John", "age": 30, "city": "New York"}'
 OK
 127.0.0.1:7379> JSON.DEL myjson $.address
@@ -79,7 +79,7 @@ OK
 
 ### Error: Key Does Not Hold a JSON Document
 
-```shell
+```bash
 127.0.0.1:7379> SET mystring "Hello, World!"
 OK
 127.0.0.1:7379> JSON.DEL mystring

--- a/docs/src/content/docs/commands/JSON.FORGET.md
+++ b/docs/src/content/docs/commands/JSON.FORGET.md
@@ -7,7 +7,7 @@ The `JSON.FORGET` command in DiceDB is used to delete a specified path from a JS
 
 ## Syntax
 
-```
+```bash
 JSON.FORGET key path
 ```
 

--- a/docs/src/content/docs/commands/JSON.GET.md
+++ b/docs/src/content/docs/commands/JSON.GET.md
@@ -7,7 +7,7 @@ The `JSON.GET` command allows you to store, update, and retrieve JSON values in 
 
 ## Syntax
 
-```
+```bash
 JSON.GET <key> [path]
 ```
 

--- a/docs/src/content/docs/commands/JSON.MSET.md
+++ b/docs/src/content/docs/commands/JSON.MSET.md
@@ -17,7 +17,7 @@ The `JSON.MSET` command requires an even number of arguments. The arguments are 
 
 ### Example
 
-```plaintext
+```bash
 JSON.MSET key1 json1 key2 json2 ... keyN jsonN
 ```
 
@@ -56,7 +56,7 @@ The `JSON.MSET` command can raise errors in the following scenarios:
 
 ### Setting Multiple JSON Values
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2 '{"name": "Bob", "age": 25}'
 OK
 ```
@@ -65,7 +65,7 @@ In this example, two keys (`user:1` and `user:2`) are set with their respective 
 
 ### Error Example: Odd Number of Arguments
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2
 (error) ERR wrong number of arguments for 'JSON.MSET' command
 ```
@@ -74,7 +74,7 @@ In this example, the command fails because the number of arguments is odd. DiceD
 
 ### Error Example: Invalid JSON
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2 '{name: "Bob", age: 25}'
 (error) ERR invalid JSON string
 ```

--- a/docs/src/content/docs/commands/JSON.MSET.md
+++ b/docs/src/content/docs/commands/JSON.MSET.md
@@ -57,7 +57,7 @@ The `JSON.MSET` command can raise errors in the following scenarios:
 ### Setting Multiple JSON Values
 
 ```plaintext
-127.0.0.1:6379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2 '{"name": "Bob", "age": 25}'
+127.0.0.1:7379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2 '{"name": "Bob", "age": 25}'
 OK
 ```
 
@@ -66,7 +66,7 @@ In this example, two keys (`user:1` and `user:2`) are set with their respective 
 ### Error Example: Odd Number of Arguments
 
 ```plaintext
-127.0.0.1:6379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2
+127.0.0.1:7379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2
 (error) ERR wrong number of arguments for 'JSON.MSET' command
 ```
 
@@ -75,7 +75,7 @@ In this example, the command fails because the number of arguments is odd. DiceD
 ### Error Example: Invalid JSON
 
 ```plaintext
-127.0.0.1:6379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2 '{name: "Bob", age: 25}'
+127.0.0.1:7379> JSON.MSET user:1 '{"name": "Alice", "age": 30}' user:2 '{name: "Bob", age: 25}'
 (error) ERR invalid JSON string
 ```
 

--- a/docs/src/content/docs/commands/JSON.NUMINCRBY.md
+++ b/docs/src/content/docs/commands/JSON.NUMINCRBY.md
@@ -7,7 +7,7 @@ The `JSON.NUMINCRBY` command is part of the DiceDBJSON module, which allows for 
 
 ## Syntax
 
-```plaintext
+```bash
 JSON.NUMINCRBY <key> <path> <increment>
 ```
 
@@ -47,7 +47,7 @@ JSON.NUMINCRBY <key> <path> <increment>
 
 Create a document:
 
-```shell
+```bash
 127.0.0.1:7379> JSON.SET user:1001 $ '{"name": "John Doe", "age": 30, "balance": 100.50, "account": {"id": 0, "lien": 0, "balance": 100.50}}'
 "OK"
 ```
@@ -56,7 +56,7 @@ Create a document:
 
 Incrementing the value of `age` object by 1
 
-```shell
+```bash
 127.0.0.1:7379> JSON.NUMINCRBY user:1001 $.age 1
 "[31]"
 ```
@@ -65,7 +65,7 @@ Incrementing the value of `age` object by 1
 
 Incrementing the value of `balance` object by 25.75
 
-```shell
+```bash
 127.0.0.1:7379> JSON.NUMINCRBY user:1001 $.balance 25.75
 "[126.25]"
 ```
@@ -74,7 +74,7 @@ Incrementing the value of `balance` object by 25.75
 
 Finding and recursively incrementing the values of both `balance` objects by 25.75
 
-```shell
+```bash
 127.0.0.1:7379> JSON.NUMINCRBY user:1001 $..balance 25.75
 "[126.25,126.25]"
 ```
@@ -83,7 +83,7 @@ Finding and recursively incrementing the values of both `balance` objects by 25.
 
 Incrementing a non-numeric value
 
-```shell
+```bash
 127.0.0.1:7379> JSON.NUMINCRBY user:1001 $.name 5
 "[null]"
 ```
@@ -92,7 +92,7 @@ Incrementing a non-numeric value
 
 Incrementing a non-existent path
 
-```shell
+```bash
 127.0.0.1:7379> JSON.NUMINCRBY user:1001 $.nonexistent 10
 "[]"
 ```
@@ -101,7 +101,7 @@ Incrementing a non-existent path
 
 Trying to increment an invalid path will result in an error
 
-```shell
+```bash
 127.0.0.1:7379> JSON.NUMINCRBY user:1001 . 5
 (error) ERROR invalid JSONPath
 ```
@@ -110,7 +110,7 @@ Trying to increment an invalid path will result in an error
 
 Trying to increment a path for a non-existent key will result in an error
 
-```shell
+```bash
 127.0.0.1:7379> JSON.NUMINCRBY user:1002 . 5
 (error) ERROR could not perform this operation on a key that doesn't exist
 ```

--- a/docs/src/content/docs/commands/JSON.OBJKEYS.md
+++ b/docs/src/content/docs/commands/JSON.OBJKEYS.md
@@ -67,7 +67,7 @@ JSON.OBJKEYS key [path]
 
 Retrieving Keys of the Root Object
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET a $ '{"name": "Alice", "age": 30, "address": {"city": "Wonderland", "zipcode": "12345"}}'
 "OK"
 127.0.0.1:7379> JSON.OBJKEYS a $
@@ -80,7 +80,7 @@ Retrieving Keys of the Root Object
 
 Retrieving Keys of a Nested Object
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET b $ '{"name": "Alice", "partner": {"name": "Bob", "age": 28}}'
 "OK"
 127.0.0.1:7379> JSON.OBJKEYS b $.partner
@@ -92,7 +92,7 @@ Retrieving Keys of a Nested Object
 
 Error When Path Points to a Non-Object Type
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET c $ '{"name": "Alice", "age": 30}'
 "OK"
 127.0.0.1:7379> JSON.OBJKEYS c $.age
@@ -103,7 +103,7 @@ Error When Path Points to a Non-Object Type
 
 Error When Path Does Not Exist
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.SET d $ '{"name": "Alice", "address": {"city": "Wonderland"}}'
 "OK"
 127.0.0.1:7379> JSON.OBJKEYS d $.nonexistentPath
@@ -114,7 +114,7 @@ Error When Path Does Not Exist
 
 Error When Key Does Not Exist
 
-```plaintext
+```bash
 127.0.0.1:7379> JSON.OBJKEYS nonexistent_key $
 (error) ERROR could not perform this operation on a key that doesn't exist
 ```

--- a/docs/src/content/docs/commands/JSON.OBJKEYS.md
+++ b/docs/src/content/docs/commands/JSON.OBJKEYS.md
@@ -68,9 +68,9 @@ JSON.OBJKEYS key [path]
 Retrieving Keys of the Root Object
 
 ```plaintext
-127.0.0.1:6379> JSON.SET a $ '{"name": "Alice", "age": 30, "address": {"city": "Wonderland", "zipcode": "12345"}}'
+127.0.0.1:7379> JSON.SET a $ '{"name": "Alice", "age": 30, "address": {"city": "Wonderland", "zipcode": "12345"}}'
 "OK"
-127.0.0.1:6379> JSON.OBJKEYS a $
+127.0.0.1:7379> JSON.OBJKEYS a $
 1) "name"
 2) "age"
 3) "address"
@@ -81,9 +81,9 @@ Retrieving Keys of the Root Object
 Retrieving Keys of a Nested Object
 
 ```plaintext
-127.0.0.1:6379> JSON.SET b $ '{"name": "Alice", "partner": {"name": "Bob", "age": 28}}'
+127.0.0.1:7379> JSON.SET b $ '{"name": "Alice", "partner": {"name": "Bob", "age": 28}}'
 "OK"
-127.0.0.1:6379> JSON.OBJKEYS b $.partner
+127.0.0.1:7379> JSON.OBJKEYS b $.partner
 1) "name"
 2) "age"
 ```
@@ -93,9 +93,9 @@ Retrieving Keys of a Nested Object
 Error When Path Points to a Non-Object Type
 
 ```plaintext
-127.0.0.1:6379> JSON.SET c $ '{"name": "Alice", "age": 30}'
+127.0.0.1:7379> JSON.SET c $ '{"name": "Alice", "age": 30}'
 "OK"
-127.0.0.1:6379> JSON.OBJKEYS c $.age
+127.0.0.1:7379> JSON.OBJKEYS c $.age
 (nil)
 ```
 
@@ -104,9 +104,9 @@ Error When Path Points to a Non-Object Type
 Error When Path Does Not Exist
 
 ```plaintext
-127.0.0.1:6379> JSON.SET d $ '{"name": "Alice", "address": {"city": "Wonderland"}}'
+127.0.0.1:7379> JSON.SET d $ '{"name": "Alice", "address": {"city": "Wonderland"}}'
 "OK"
-127.0.0.1:6379> JSON.OBJKEYS d $.nonexistentPath
+127.0.0.1:7379> JSON.OBJKEYS d $.nonexistentPath
 (empty list or set)
 ```
 
@@ -115,7 +115,7 @@ Error When Path Does Not Exist
 Error When Key Does Not Exist
 
 ```plaintext
-127.0.0.1:6379> JSON.OBJKEYS nonexistent_key $
+127.0.0.1:7379> JSON.OBJKEYS nonexistent_key $
 (error) ERROR could not perform this operation on a key that doesn't exist
 ```
 

--- a/docs/src/content/docs/commands/JSON.STRLEN.md
+++ b/docs/src/content/docs/commands/JSON.STRLEN.md
@@ -7,7 +7,7 @@ The `JSON.STRLEN` command is used to determine the length of a JSON string at a 
 
 ## Syntax
 
-```
+```bash
 JSON.STRLEN <key> <path>
 ```
 

--- a/docs/src/content/docs/commands/JSON.TOGGLE.md
+++ b/docs/src/content/docs/commands/JSON.TOGGLE.md
@@ -76,13 +76,13 @@ The `JSON.TOGGLE` command can raise the following errors:
 
 #### Command
 
-```shell
+```bash
 JSON.TOGGLE user:1001 $.active
 ```
 
 #### Result
 
-```shell
+```bash
 (integer) 1
 ```
 
@@ -102,13 +102,13 @@ JSON.TOGGLE user:1001 $.active
 
 #### Command
 
-```shell
+```bash
 JSON.TOGGLE user:1001 $.settings.notifications
 ```
 
 #### Result
 
-```shell
+```bash
 (integer) 1
 ```
 
@@ -128,13 +128,13 @@ JSON.TOGGLE user:1001 $.settings.notifications
 
 #### Command
 
-```shell
+```bash
 JSON.TOGGLE user:1001 $.nonexistent
 ```
 
 #### Result
 
-```shell
+```bash
 (integer) 0
 ```
 
@@ -142,12 +142,12 @@ JSON.TOGGLE user:1001 $.nonexistent
 
 #### Command
 
-```shell
+```bash
 JSON.TOGGLE user:1001 $.name
 ```
 
 #### Result
 
-```shell
+```bash
 (error) ERR value at path is not a boolean
 ```

--- a/docs/src/content/docs/commands/JSON.TYPE.md
+++ b/docs/src/content/docs/commands/JSON.TYPE.md
@@ -7,7 +7,7 @@ The `JSON.TYPE` command allows you to work with JSON data structures in DiceDB. 
 
 ## Syntax
 
-```
+```bash
 JSON.TYPE <key> <path>
 ```
 

--- a/docs/src/content/docs/commands/KEYS.md
+++ b/docs/src/content/docs/commands/KEYS.md
@@ -7,7 +7,7 @@ The `KEYS` command in DiceDB is used to find all keys matching a given pattern. 
 
 ## Syntax
 
-```plaintext
+```bash
 KEYS pattern
 ```
 
@@ -37,7 +37,7 @@ Use `\` to escape special characters if you want to match them verbatim.
 
 ### Basic example
 
-```plaintext
+```bash
 127.0.0.1:7379> SET key1 "value1"
 OK
 127.0.0.1:7379> SET key2 "value2"
@@ -51,7 +51,7 @@ OK
 
 ### Using wildcards
 
-```plaintext
+```bash
 127.0.0.1:7379> SET key1 "value1"
 OK
 127.0.0.1:7379> SET key2 "value2"
@@ -66,7 +66,7 @@ OK
 
 ### Using character ranges
 
-```plaintext
+```bash
 127.0.0.1:7379> SET key1 "value1"
 OK
 127.0.0.1:7379> SET key2 "value2"
@@ -80,7 +80,7 @@ OK
 
 ### Using \ to escape special characters
 
-```plaintext
+```bash
 127.0.0.1:7379> SET key1 "value1"
 OK
 127.0.0.1:7379> SET key2 "value2"
@@ -122,7 +122,7 @@ The `KEYS` command is straightforward and does not have many error conditions. H
 
 - `SCAN`: The `SCAN` command is a cursor-based iterator that allows you to incrementally iterate over the keyspace without blocking the server. It is a more efficient alternative to `KEYS` for large datasets.
 
-```plaintext
+```bash
 127.0.0.1:7379> SCAN 0 MATCH key*
 1) "0"
 2) 1) "key1"

--- a/docs/src/content/docs/commands/LATENCY.md
+++ b/docs/src/content/docs/commands/LATENCY.md
@@ -8,7 +8,7 @@ The `LATENCY` command in DiceDB is used to measure and analyze the latency of va
 
 ## Command Syntax
 
-```plaintext
+```bash
 LATENCY [SUBCOMMAND] [ARGUMENTS]
 ```
 

--- a/docs/src/content/docs/commands/LLEN.md
+++ b/docs/src/content/docs/commands/LLEN.md
@@ -7,7 +7,7 @@ The `LLEN` command in DiceDB is used to obtain the length of a list stored at a 
 
 ## Syntax
 
-```
+```bash
 LLEN key
 ```
 

--- a/docs/src/content/docs/commands/LPOP.md
+++ b/docs/src/content/docs/commands/LPOP.md
@@ -7,7 +7,7 @@ The `LPOP` command in DiceDB removes and returns the first element of a list at 
 
 ## Syntax
 
-```plaintext
+```bash
 LPOP key
 ```
 

--- a/docs/src/content/docs/commands/LPUSH.md
+++ b/docs/src/content/docs/commands/LPUSH.md
@@ -7,7 +7,7 @@ The `LPUSH` command is used to insert one or multiple values at the head (left) 
 
 ## Syntax
 
-```
+```bash
 LPUSH key value [value ...]
 ```
 
@@ -50,7 +50,7 @@ LPUSH key value [value ...]
 
 Insert the value `world` at the head of the list stored at key `mylist`. If `mylist` does not exist, a new list is created.
 
-```shell
+```bash
 127.0.0.1:7379> LPUSH mylist "world"
 (integer) 1
 ```
@@ -60,7 +60,7 @@ Insert the value `world` at the head of the list stored at key `mylist`. If `myl
 Insert the value `hello` and `world` at the head of the list stored at key `mylist`.  After execution, `world` will be the first element, followed by `hello`.
 <!-- Once LRANGE command is added, update docs to use LRANGE in examples. -->
 
-```shell
+```bash
 127.0.0.1:7379> LPUSH mylist "hello" "world"
 (integer) 2
 ```
@@ -69,7 +69,7 @@ Insert the value `hello` and `world` at the head of the list stored at key `myli
 
 Create a new list with the key `newlist` and inserts the value `first` at the head.
 
-```shell
+```bash
 127.0.0.1:7379> LPUSH newlist "first"
 (integer) 1
 ```
@@ -78,7 +78,7 @@ Create a new list with the key `newlist` and inserts the value `first` at the he
 
 Insert the value `value` at the head of the key `mystring`, which stores a string, not a list.
 
-```shell
+```bash
 127.0.0.1:7379> SET mystring "not a list"
 OK
 127.0.0.1:7379> LPUSH mystring "value"

--- a/docs/src/content/docs/commands/MGET.md
+++ b/docs/src/content/docs/commands/MGET.md
@@ -7,7 +7,7 @@ The `MGET` command in DiceDB is used to retrieve the values of multiple keys in 
 
 ## Syntax
 
-```
+```bash
 MGET key [key ...]
 ```
 

--- a/docs/src/content/docs/commands/MSET.md
+++ b/docs/src/content/docs/commands/MSET.md
@@ -7,7 +7,7 @@ The `MSET` command in DiceDB is used to set multiple key-value pairs in a single
 
 ## Syntax
 
-```plaintext
+```bash
 MSET key1 value1 [key2 value2 ...]
 ```
 
@@ -76,7 +76,7 @@ OK
 
 Attempting to set an odd number of arguments:
 
-```sh
+```bash
 127.0.0.1:7379> MSET key1 "value1" key2
 (error) ERROR wrong number of arguments for 'mset' command
 ```

--- a/docs/src/content/docs/commands/OBJECT.md
+++ b/docs/src/content/docs/commands/OBJECT.md
@@ -7,7 +7,7 @@ The `OBJECT` command in DiceDB is used to inspect the internals of DiceDB object
 
 ## Syntax
 
-```plaintext
+```bash
 OBJECT <subcommand> <key>
 ```
 
@@ -54,13 +54,13 @@ The `OBJECT` command can raise errors in the following scenarios:
 
 ### Example 1: Using the `REFCOUNT` Subcommand
 
-```plaintext
+```bash
 OBJECT REFCOUNT mykey
 ```
 
 `Response:`
 
-```plaintext
+```bash
 (integer) 1
 ```
 
@@ -68,13 +68,13 @@ This response indicates that the value associated with `mykey` has a reference c
 
 ### Example 2: Using the `ENCODING` Subcommand
 
-```plaintext
+```bash
 OBJECT ENCODING mykey
 ```
 
 `Response:`
 
-```plaintext
+```bash
 "embstr"
 ```
 
@@ -82,13 +82,13 @@ This response indicates that the value associated with `mykey` is stored using t
 
 ### Example 3: Using the `IDLETIME` Subcommand
 
-```plaintext
+```bash
 OBJECT IDLETIME mykey
 ```
 
 `Response:`
 
-```plaintext
+```bash
 (integer) 120
 ```
 
@@ -96,13 +96,13 @@ This response indicates that `mykey` has been idle for 120 seconds.
 
 ### Example 4: Using the `FREQ` Subcommand
 
-```plaintext
+```bash
 OBJECT FREQ mykey
 ```
 
 `Response:`
 
-```plaintext
+```bash
 (integer) 5
 ```
 

--- a/docs/src/content/docs/commands/PERSIST.md
+++ b/docs/src/content/docs/commands/PERSIST.md
@@ -7,7 +7,7 @@ The `PERSIST` command is used to remove the expiration from a key in DiceDB. If 
 
 ## Syntax
 
-```
+```bash
 PERSIST key
 ```
 

--- a/docs/src/content/docs/commands/PFADD.md
+++ b/docs/src/content/docs/commands/PFADD.md
@@ -7,7 +7,7 @@ The `PFADD` command in DiceDB is used to add elements to a HyperLogLog data stru
 
 ## Syntax
 
-```
+```bash
 PFADD key element [element ...]
 ```
 

--- a/docs/src/content/docs/commands/PFCOUNT.md
+++ b/docs/src/content/docs/commands/PFCOUNT.md
@@ -7,7 +7,7 @@ The `PFCOUNT` command in DiceDB is used to return the approximate cardinality (i
 
 ## Syntax
 
-```
+```bash
 PFCOUNT key [key ...]
 ```
 

--- a/docs/src/content/docs/commands/PFMERGE.md
+++ b/docs/src/content/docs/commands/PFMERGE.md
@@ -7,7 +7,7 @@ The `PFMERGE` command in DiceDB is used to merge multiple HyperLogLog data struc
 
 ## Syntax
 
-```
+```bash
 PFMERGE destkey sourcekey [sourcekey ...]
 ```
 
@@ -52,7 +52,7 @@ The `PFMERGE` command can raise errors in the following scenarios:
 
 Suppose you have three HyperLogLogs stored at keys `hll1`, `hll2`, and `hll3`, and you want to merge them into a new HyperLogLog stored at key `hll_merged`.
 
-```sh
+```bash
 127.0.0.1:7379> PFADD hll1 "a" "b" "c"
 (integer) 1
 127.0.0.1:7379> PFADD hll2 "c" "d" "e"
@@ -69,7 +69,7 @@ OK
 
 If the `destkey` already exists, it will be overwritten by the merged HyperLogLog.
 
-```sh
+```bash
 127.0.0.1:7379> PFADD hll_merged "x" "y" "z"
 (integer) 1
 127.0.0.1:7379> PFMERGE hll_merged hll1 hll2 hll3
@@ -82,7 +82,7 @@ OK
 
 If a `sourcekey` does not exist, DiceDB will treat it as an empty HyperLogLog.
 
-```sh
+```bash
 127.0.0.1:7379> PFMERGE hll_merged hll1 hll2 non_existent_key
 OK
 127.0.0.1:7379> PFCOUNT hll_merged
@@ -93,7 +93,7 @@ OK
 
 if a `sourcekey` exists and is not of type HyperLogLog, the command will result in an error
 
-```sh
+```bash
 127.0.0.1:7379> PFMERGE hll_merged not_hyperLogLog
 (error) WRONGTYPE Key is not a valid HyperLogLog string value
 

--- a/docs/src/content/docs/commands/PING.md
+++ b/docs/src/content/docs/commands/PING.md
@@ -9,7 +9,7 @@ The `PING` command in DiceDB is used to test the connection between the client a
 
 The basic syntax of the `PING` command is as follows:
 
-```
+```bash
 PING [message]
 ```
 

--- a/docs/src/content/docs/commands/PTTL.md
+++ b/docs/src/content/docs/commands/PTTL.md
@@ -7,7 +7,7 @@ The `PTTL` command in DiceDB is used to retrieve the remaining time to live (TTL
 
 ## Syntax
 
-```
+```bash
 PTTL key
 ```
 

--- a/docs/src/content/docs/commands/RENAME.md
+++ b/docs/src/content/docs/commands/RENAME.md
@@ -7,7 +7,7 @@ The `RENAME` command in DiceDB is used to change the name of an existing key to 
 
 ## Syntax
 
-```plaintext
+```bash
 RENAME oldkey newkey
 ```
 

--- a/docs/src/content/docs/commands/RPOP.md
+++ b/docs/src/content/docs/commands/RPOP.md
@@ -7,7 +7,7 @@ The `RPOP` command in DiceDB is used to remove and return the last element of a 
 
 ## Syntax
 
-```
+```bash
 RPOP key
 ```
 

--- a/docs/src/content/docs/commands/RPUSH.md
+++ b/docs/src/content/docs/commands/RPUSH.md
@@ -7,7 +7,7 @@ The `RPUSH` command is used in DiceDB to insert one or multiple values at the ta
 
 ## Syntax
 
-```
+```bash
 RPUSH key value [value ...]
 ```
 

--- a/docs/src/content/docs/commands/SADD.md
+++ b/docs/src/content/docs/commands/SADD.md
@@ -7,7 +7,7 @@ The `SADD` command in DiceDB is used to add one or more members to a set. If the
 
 ## Syntax
 
-```
+```bash
 SADD key member [member ...]
 ```
 

--- a/docs/src/content/docs/commands/SCARD.md
+++ b/docs/src/content/docs/commands/SCARD.md
@@ -7,7 +7,7 @@ The `SCARD` command in DiceDB is used to get the number of members in a set. Thi
 
 ## Syntax
 
-```
+```bash
 SCARD key
 ```
 

--- a/docs/src/content/docs/commands/SDIFF.md
+++ b/docs/src/content/docs/commands/SDIFF.md
@@ -7,7 +7,7 @@ The `SDIFF` command in DiceDB is used to compute the difference between multiple
 
 ## Syntax
 
-```
+```bash
 SDIFF key1 [key2 ... keyN]
 ```
 

--- a/docs/src/content/docs/commands/SELECT.md
+++ b/docs/src/content/docs/commands/SELECT.md
@@ -3,13 +3,13 @@ title: SELECT
 description: Documentation for the DiceDB command SELECT
 ---
 
-**Note:** As of today, DiceDB does not support multiple databases. Therefore, the `SELECT` command is currently a dummy method and does not affect the database. It remains as a placeholder.
+> **Important Note:** As of the current version, DiceDB does not support multiple databases. Therefore, the `SELECT` command is currently a dummy method and does not affect the database. It remains as a placeholder.
 
 The `SELECT` command is used to switch the currently selected database for the current connection in DiceDB. By default, DiceDB starts with database 0, but it supports multiple databases, which can be accessed by using the `SELECT` command. This command is essential for managing data across different logical databases within a single DiceDB instance.
 
 ## Syntax
 
-```
+```bash
 SELECT index
 ```
 
@@ -39,48 +39,45 @@ When the `SELECT` command is issued, the current connection's context is switche
 
 1. `Invalid Database Index`:
 
-   - `Error`: `(error) ERR DB index is out of range`
-   - `Condition`: If the specified database index is outside the range of available databases.
+   - Error Message: `(error) ERR DB index is out of range`
+   - Occurs when the specified database index exceeds the configured maximum (default 15)
 
 2. `Non-Integer Index`:
-
-   - `Error`: `(error) ERR value is not an integer or out of range`
-   - `Condition`: If the provided index is not a valid integer.
+   - Error Message: `(error) ERR value is not an integer or out of range`
+   - Occurs when the provided index is not a valid integer
 
 ## Example Usage
 
 ### Switching to Database 1
 
-```shell
+```bash
 127.0.0.1:7379> SELECT 1
 OK
 ```
 
-In this example, the connection switches to database 1. All subsequent commands will operate on database 1.
+### Switching Back to Default Database
 
-### Switching to Database 0
-
-```shell
+```bash
 127.0.0.1:7379> SELECT 0
 OK
 ```
 
-Here, the connection switches back to the default database 0.
+### Invalid Database Index
 
 ### Error Example: Invalid Database Index
 
-```shell
+```bash
 127.0.0.1:7379> SELECT 16
 (error) ERR DB index is out of range
 ```
 
-In this example, an error is raised because the specified database index 16 is outside the default range of 0-15.
+### Invalid Input Type
 
-### Error Example: Non-Integer Index
-
-```shell
+```bash
 127.0.0.1:7379> SELECT one
 (error) ERR value is not an integer or out of range
 ```
 
-In this example, an error is raised because the provided index is not a valid integer.
+## Notes
+
+As mentioned at the beginning of this document, the current version of DiceDB does not support multiple databases. The `SELECT` command is implemented as a placeholder for future functionality. All operations, regardless of the SELECT command, will continue to operate on a single database space.

--- a/docs/src/content/docs/commands/SET.md
+++ b/docs/src/content/docs/commands/SET.md
@@ -7,7 +7,7 @@ The `SET` command in DiceDB is used to set the value of a key. If the key alread
 
 ## Syntax
 
-```
+```bash
 SET key value [EX seconds | PX milliseconds | EXAT unix-time-seconds | PXAT unix-time-milliseconds | KEEPTTL] [NX | XX]
 ```
 

--- a/docs/src/content/docs/commands/SETBIT.md
+++ b/docs/src/content/docs/commands/SETBIT.md
@@ -7,7 +7,7 @@ The `SETBIT` command in DiceDB is used to set or clear the bit at a specified of
 
 ## Syntax
 
-```
+```bash
 SETBIT key offset value
 ```
 
@@ -37,7 +37,7 @@ The command returns the original bit value stored at the specified offset before
 
 ### Setting a Bit
 
-```DiceDB
+```bash
 SETBIT mykey 7 1
 ```
 
@@ -45,7 +45,7 @@ This command sets the bit at offset 7 in the string value stored at `mykey` to 1
 
 ### Clearing a Bit
 
-```DiceDB
+```bash
 SETBIT mykey 7 0
 ```
 
@@ -53,7 +53,7 @@ This command clears the bit at offset 7 in the string value stored at `mykey` to
 
 ### Checking the Original Bit Value
 
-```DiceDB
+```bash
 SETBIT mykey 7 1
 ```
 
@@ -61,7 +61,7 @@ If the bit at offset 7 was previously 0, this command will return 0 and then set
 
 ### Extending the String
 
-```DiceDB
+```bash
 SETBIT mykey 100 1
 ```
 
@@ -71,7 +71,7 @@ If the string stored at `mykey` is shorter than 101 bits, it will be extended, a
 
 ### Invalid Offset
 
-```DiceDB
+```bash
 SETBIT mykey -1 1
 ```
 
@@ -79,7 +79,7 @@ This command will raise an error: `ERR bit is not an integer or out of range` be
 
 ### Invalid Value
 
-```DiceDB
+```bash
 SETBIT mykey 7 2
 ```
 
@@ -87,7 +87,7 @@ This command will raise an error: `ERR bit is not an integer or out of range` be
 
 ### Wrong Type
 
-```DiceDB
+```bash
 SET mykey "Hello"
 SETBIT mykey 7 1
 ```

--- a/docs/src/content/docs/commands/SINTER.md
+++ b/docs/src/content/docs/commands/SINTER.md
@@ -7,7 +7,7 @@ The `SINTER` command in DiceDB is used to compute the intersection of multiple s
 
 ## Syntax
 
-```
+```bash
 SINTER key [key ...]
 ```
 ## Parameters
@@ -45,7 +45,7 @@ If any of the specified keys do not exist, they are treated as empty sets. The i
 
 ### Example 1: Basic Intersection
 
-```shell
+```bash
 # Add elements to sets
 127.0.0.1:7379> SADD set1 "a" "b" "c"
 (integer) 3
@@ -61,7 +61,7 @@ If any of the specified keys do not exist, they are treated as empty sets. The i
 
 ### Example 2: Intersection with Non-Existent Set
 
-```shell
+```bash
 # Add elements to sets
 127.0.0.1:7379> SADD set1 "a" "b" "c"
 (integer) 3
@@ -76,7 +76,7 @@ Note: By default, non-existent keys (such as set3 in the example above) are trea
 
 ### Example 3: Error Handling - Wrong Type
 
-```shell
+```bash
 # Add elements to sets
 127.0.0.1:7379> SADD set1 "a" "b" "c"
 (integer) 3
@@ -91,7 +91,7 @@ SINTER set1 stringKey
 
 ### Example 4: Error Handling - No Keys Provided
 
-```shell
+```bash
 # Attempt to compute intersection without providing any keys
 127.0.0.1:7379> SINTER
 (error) ERR wrong number of arguments for 'sinter' command

--- a/docs/src/content/docs/commands/SREM.md
+++ b/docs/src/content/docs/commands/SREM.md
@@ -7,7 +7,7 @@ The `SREM` command is used to remove one or more members from a set stored at a 
 
 ## Syntax
 
-```
+```bash
 SREM key member [member ...]
 ```
 
@@ -39,7 +39,7 @@ When the `SREM` command is executed, the following steps occur:
 
 ### Example 1: Removing a single member from a set
 
-```DiceDB
+```bash
 SADD myset "one" "two" "three"
 SREM myset "two"
 ```
@@ -54,7 +54,7 @@ SREM myset "two"
 
 ### Example 2: Removing multiple members from a set
 
-```DiceDB
+```bash
 SADD myset "one" "two" "three"
 SREM myset "two" "three"
 ```
@@ -69,7 +69,7 @@ SREM myset "two" "three"
 
 ### Example 3: Removing a non-existing member from a set
 
-```DiceDB
+```bash
 SADD myset "one" "two" "three"
 SREM myset "four"
 ```
@@ -84,7 +84,7 @@ SREM myset "four"
 
 ### Example 4: Removing members from a non-existing set
 
-```DiceDB
+```bash
 SREM myset "one"
 ```
 
@@ -98,7 +98,7 @@ SREM myset "one"
 
 ### Example 5: Error when key is not a set
 
-```DiceDB
+```bash
 SET mykey "value"
 SREM mykey "one"
 ```

--- a/docs/src/content/docs/commands/TOUCH.md
+++ b/docs/src/content/docs/commands/TOUCH.md
@@ -7,7 +7,7 @@ The `TOUCH` command in DiceDB is used to update the last access time of one or m
 
 ## Syntax
 
-```plaintext
+```bash
 TOUCH key [key ...]
 ```
 
@@ -43,7 +43,7 @@ The `TOUCH` command can raise the following errors:
 
 ### Single Key
 
-```plaintext
+```bash
 SET mykey "Hello"
 TOUCH mykey
 ```
@@ -52,7 +52,7 @@ In this example, the `TOUCH` command updates the last access time of the key `my
 
 ### Multiple Keys
 
-```plaintext
+```bash
 SET key1 "value1"
 SET key2 "value2"
 TOUCH key1 key2 key3
@@ -64,7 +64,7 @@ In this example, the `TOUCH` command attempts to update the last access time for
 
 Trying to touch key `mylist` will result in a `WRONGTYPE` error because `mylist` is a list, not a string.
 
-```plaintext
+```bash
 LPUSH mylist "element"
 TOUCH mylist
 ``` 

--- a/docs/src/content/docs/commands/ZCARD.md
+++ b/docs/src/content/docs/commands/ZCARD.md
@@ -7,7 +7,7 @@ The `ZCARD` command in DiceDB is used to obtain the cardinality (number of eleme
 
 ## Syntax
 
-```
+```bash
 ZCARD key
 ```
 

--- a/docs/src/content/docs/commands/ZCOUNT.md
+++ b/docs/src/content/docs/commands/ZCOUNT.md
@@ -7,7 +7,7 @@ The ZCOUNT command in DiceDB counts the number of members in a sorted set at the
 
 ## Syntax
 
-```
+```bash
 ZCOUNT key min max
 ```
 

--- a/docs/src/content/docs/commands/ZPOPMAX.md
+++ b/docs/src/content/docs/commands/ZPOPMAX.md
@@ -7,7 +7,7 @@ The `ZPOPMAX` command in DiceDB is used to remove and return the members with th
 
 ## Syntax
 
-```
+```bash
 ZPOPMAX key [count]
 ```
 

--- a/docs/src/content/docs/commands/ZREM.md
+++ b/docs/src/content/docs/commands/ZREM.md
@@ -7,7 +7,7 @@ The `ZREM` command in DiceDB is used to remove the specified members from the so
 
 ## Syntax
 
-```
+```bash
 ZREM key member [member ...]
 ```
 


### PR DESCRIPTION
1. Added notes in SELECT, FLUSHDB, DBSIZE Docs for usage related to SELECT Command.
2. use of PORT 7379 in FLUSH DB, BF.EXISTS, HRANDFIELD, JSON.ARRAPPEND, JSON.ARRINSERT, JSON.ARRPOP, JSON.ARRTRIM, JSON.DEBUG, JSON.DEL, JSON.MSET, JSON.OBJKEYS
3. bash syntax in EXISTS, HRANDFIELD,JSON.DEL,AUTH, BGREWRITEAOF, BITCOUNT,  Docs (Consistent with all DOCs)

One doubt i have 
in golang SDK the port should be 7379 instead of 6379?

cc @apoorvyadav1111 , @JyotinderSingh 