### PR TITLE
#1194: Enhance GETRANGE to support byte array

### DIFF
--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -307,8 +307,8 @@ func testEvalSET(t *testing.T, store *dstore.Store) {
 			migratedOutput: EvalResponse{Result: clientio.OK, Error: nil},
 		},
 		{
-			name: 		 "key val pair and invalid EX and PX",
-			input: 		 []string{"KEY", "VAL", Ex, "2", Px, "2000"},
+			name:           "key val pair and invalid EX and PX",
+			input:          []string{"KEY", "VAL", Ex, "2", Px, "2000"},
 			migratedOutput: EvalResponse{Result: nil, Error: errors.New("ERR syntax error")},
 		},
 		{
@@ -1155,19 +1155,19 @@ func testEvalJSONARRLEN(t *testing.T, store *dstore.Store) {
 			setup:  func() {},
 			input:  nil,
 			output: []byte("-ERR wrong number of arguments for 'json.arrlen' command\r\n"),
-            migratedOutput: EvalResponse{
-                Result: nil,
-			    Error:  diceerrors.ErrWrongArgumentCount("JSON.ARRLEN"),
-            },
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrWrongArgumentCount("JSON.ARRLEN"),
+			},
 		},
 		"key does not exist": {
 			setup:  func() {},
 			input:  []string{"NONEXISTENT_KEY"},
 			output: []byte("$-1\r\n"),
-            migratedOutput: EvalResponse{
-                Result: clientio.NIL,
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: clientio.NIL,
+				Error:  nil,
+			},
 		},
 		"root not array arrlen": {
 			setup: func() {
@@ -1180,10 +1180,10 @@ func testEvalJSONARRLEN(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"EXISTING_KEY"},
 			output: []byte("-ERR Path '$' does not exist or not an array\r\n"),
-            migratedOutput: EvalResponse{
-                Result: nil,
-                Error: diceerrors.ErrWrongTypeOperation,
-            },
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrWrongTypeOperation,
+			},
 		},
 		"root array arrlen": {
 			setup: func() {
@@ -1196,10 +1196,10 @@ func testEvalJSONARRLEN(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"EXISTING_KEY"},
 			output: []byte(":3\r\n"),
-            migratedOutput: EvalResponse{
-                Result: 3,
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: 3,
+				Error:  nil,
+			},
 		},
 		"wildcase no array arrlen": {
 			setup: func() {
@@ -1213,10 +1213,10 @@ func testEvalJSONARRLEN(t *testing.T, store *dstore.Store) {
 
 			input:  []string{"EXISTING_KEY", "$.*"},
 			output: []byte("*5\r\n$-1\r\n$-1\r\n$-1\r\n$-1\r\n$-1\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []interface{}{clientio.NIL,clientio.NIL,clientio.NIL,clientio.NIL,clientio.NIL},
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []interface{}{clientio.NIL, clientio.NIL, clientio.NIL, clientio.NIL, clientio.NIL},
+				Error:  nil,
+			},
 		},
 		"subpath array arrlen": {
 			setup: func() {
@@ -1231,10 +1231,10 @@ func testEvalJSONARRLEN(t *testing.T, store *dstore.Store) {
 
 			input:  []string{"EXISTING_KEY", "$.language"},
 			output: []byte(":2\r\n"),
-            migratedOutput: EvalResponse{
-                Result: 2,
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: 2,
+				Error:  nil,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -1250,8 +1250,8 @@ func testEvalJSONARRLEN(t *testing.T, store *dstore.Store) {
 				if slice, ok := tt.migratedOutput.Result.([]interface{}); ok {
 					assert.Equal(t, slice, response.Result)
 				} else {
-                    assert.Equal(t, tt.migratedOutput.Result, response.Result)
-                }
+					assert.Equal(t, tt.migratedOutput.Result, response.Result)
+				}
 			}
 
 			if tt.migratedOutput.Error != nil {
@@ -2070,10 +2070,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$.a", "6"},
 			output: []byte("*1\r\n$-1\r\n"),
-            migratedOutput: EvalResponse{
-                Result: nil,
-			    Error:  diceerrors.ErrJSONPathNotFound("$.a"),
-            },
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrJSONPathNotFound("$.a"),
+			},
 		},
 		"arr append single element to an array field": {
 			setup: func() {
@@ -2086,10 +2086,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$.a", "6"},
 			output: []byte("*1\r\n:3\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []int64{3},
-		        Error:  nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []int64{3},
+				Error:  nil,
+			},
 		},
 		"arr append multiple elements to an array field": {
 			setup: func() {
@@ -2102,10 +2102,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$.a", "6", "7", "8"},
 			output: []byte("*1\r\n:5\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []int64{5},
-		        Error:  nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []int64{5},
+				Error:  nil,
+			},
 		},
 		"arr append string value": {
 			setup: func() {
@@ -2118,10 +2118,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$.b", `"d"`},
 			output: []byte("*1\r\n:3\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []int64{3},
-		        Error:  nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []int64{3},
+				Error:  nil,
+			},
 		},
 		"arr append nested array value": {
 			setup: func() {
@@ -2134,10 +2134,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$.a", "[1,2,3]"},
 			output: []byte("*1\r\n:2\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []int64{2},
-		        Error:  nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []int64{2},
+				Error:  nil,
+			},
 		},
 		"arr append with json value": {
 			setup: func() {
@@ -2150,10 +2150,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$.a", "{\"c\": 3}"},
 			output: []byte("*1\r\n:2\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []int64{2},
-		        Error:  nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []int64{2},
+				Error:  nil,
+			},
 		},
 		"arr append to append on multiple fields": {
 			setup: func() {
@@ -2166,10 +2166,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$..a", "6"},
 			output: []byte("*2\r\n:2\r\n:3\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []int64{2,3},
-		        Error:  nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []int64{2, 3},
+				Error:  nil,
+			},
 		},
 		"arr append to append on root node": {
 			setup: func() {
@@ -2182,10 +2182,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$", "6"},
 			output: []byte("*1\r\n:4\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []int64{4},
-		        Error:  nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []int64{4},
+				Error:  nil,
+			},
 		},
 		"arr append to an array with different type": {
 			setup: func() {
@@ -2198,10 +2198,10 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"array", "$.a", `"blue"`},
 			output: []byte("*1\r\n:3\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []int64{3},
-		        Error:  nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []int64{3},
+				Error:  nil,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -2211,13 +2211,13 @@ func testEvalJSONARRAPPEND(t *testing.T, store *dstore.Store) {
 			if tt.setup != nil {
 				tt.setup()
 			}
-            response := evalJSONARRAPPEND(tt.input, store)
+			response := evalJSONARRAPPEND(tt.input, store)
 
 			if tt.migratedOutput.Result != nil {
-                actual, ok := response.Result.([]int64)
-                if ok {
-                    assert.Equal(t, tt.migratedOutput.Result, actual)
-                }
+				actual, ok := response.Result.([]int64)
+				if ok {
+					assert.Equal(t, tt.migratedOutput.Result, actual)
+				}
 			}
 
 			if tt.migratedOutput.Error != nil {
@@ -4281,19 +4281,19 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			setup:  func() {},
 			input:  nil,
 			output: []byte("-ERR wrong number of arguments for 'json.arrpop' command\r\n"),
-            migratedOutput: EvalResponse{
-                Result: nil,
-			    Error:  diceerrors.ErrWrongArgumentCount("JSON.ARRPOP"),
-            },
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrWrongArgumentCount("JSON.ARRPOP"),
+			},
 		},
 		"key does not exist": {
 			setup:  func() {},
 			input:  []string{"NOTEXISTANT_KEY"},
 			output: []byte("-ERR could not perform this operation on a key that doesn't exist\r\n"),
-            migratedOutput: EvalResponse{
-                Result: nil,
-                Error: diceerrors.ErrKeyNotFound,
-            },
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrKeyNotFound,
+			},
 		},
 		"empty array at root path": {
 			setup: func() {
@@ -4306,10 +4306,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"MOCK_KEY"},
 			output: []byte("-ERR Path '$' does not exist or not an array\r\n"),
-            migratedOutput: EvalResponse{
-                Result: nil,
-                Error: diceerrors.ErrWrongTypeOperation,
-            },
+			migratedOutput: EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrWrongTypeOperation,
+			},
 		},
 		"empty array at nested path": {
 			setup: func() {
@@ -4322,10 +4322,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"MOCK_KEY", "$.b"},
 			output: []byte("*1\r\n$-1\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []interface{}{clientio.NIL},
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []interface{}{clientio.NIL},
+				Error:  nil,
+			},
 		},
 		"all paths with asterix": {
 			setup: func() {
@@ -4338,10 +4338,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"MOCK_KEY", "$.*"},
 			output: []byte("*2\r\n$-1\r\n$-1\r\n"),
-            migratedOutput: EvalResponse{
-                Result: []interface{}{clientio.NIL,clientio.NIL},
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []interface{}{clientio.NIL, clientio.NIL},
+				Error:  nil,
+			},
 		},
 		"array root path no index": {
 			setup: func() {
@@ -4354,10 +4354,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"MOCK_KEY"},
 			output: []byte(":5\r\n"),
-            migratedOutput: EvalResponse{
-                Result: float64(5),
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: float64(5),
+				Error:  nil,
+			},
 		},
 		"array root path valid positive index": {
 			setup: func() {
@@ -4370,10 +4370,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"MOCK_KEY", "$", "2"},
 			output: []byte(":2\r\n"),
-            migratedOutput: EvalResponse{
-                Result: float64(2),
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: float64(2),
+				Error:  nil,
+			},
 		},
 		"array root path out of bound positive index": {
 			setup: func() {
@@ -4386,10 +4386,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"MOCK_KEY", "$", "10"},
 			output: []byte(":5\r\n"),
-            migratedOutput: EvalResponse{
-                Result: float64(5),
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: float64(5),
+				Error:  nil,
+			},
 		},
 		"array root path valid negative index": {
 			setup: func() {
@@ -4402,10 +4402,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"MOCK_KEY", "$", "-2"},
 			output: []byte(":4\r\n"),
-            migratedOutput: EvalResponse{
-                Result: float64(4),
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: float64(4),
+				Error:  nil,
+			},
 		},
 		"array root path out of bound negative index": {
 			setup: func() {
@@ -4418,10 +4418,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 			},
 			input:  []string{"MOCK_KEY", "$", "-10"},
 			output: []byte(":0\r\n"),
-            migratedOutput: EvalResponse{
-                Result: float64(0),
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: float64(0),
+				Error:  nil,
+			},
 		},
 		"array at root path updated correctly": {
 			setup: func() {
@@ -4441,10 +4441,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 				equal := reflect.DeepEqual(obj.Value, want)
 				assert.Equal(t, equal, true)
 			},
-            migratedOutput: EvalResponse{
-                Result: float64(2),
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: float64(2),
+				Error:  nil,
+			},
 		},
 		"nested array updated correctly": {
 			setup: func() {
@@ -4473,10 +4473,10 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 				equal := reflect.DeepEqual(results[0], want)
 				assert.Equal(t, equal, true)
 			},
-            migratedOutput: EvalResponse{
-                Result: []interface{}{float64(2)},
-                Error: nil,
-            },
+			migratedOutput: EvalResponse{
+				Result: []interface{}{float64(2)},
+				Error:  nil,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -4492,8 +4492,8 @@ func testEvalJSONARRPOP(t *testing.T, store *dstore.Store) {
 				if slice, ok := tt.migratedOutput.Result.([]interface{}); ok {
 					assert.Equal(t, slice, response.Result)
 				} else {
-                    assert.Equal(t, tt.migratedOutput.Result, response.Result)
-                }
+					assert.Equal(t, tt.migratedOutput.Result, response.Result)
+				}
 			}
 
 			if tt.migratedOutput.Error != nil {
@@ -4892,7 +4892,6 @@ func testEvalJSONOBJKEYS(t *testing.T, store *dstore.Store) {
 	}
 }
 
-
 func BenchmarkEvalJSONOBJKEYS(b *testing.B) {
 	sizes := []int{0, 10, 100, 1000, 10000, 100000} // Various sizes of JSON objects
 	store := dstore.NewStore(nil, nil)
@@ -5122,6 +5121,30 @@ func testEvalGETRANGE(t *testing.T, store *dstore.Store) {
 				Result: "",
 				Error:  nil,
 			},
+		},
+		"GETRANGE against byte array with valid range: 0 4": {
+			setup: func() {
+				key := "BYTEARRAY_KEY"
+				store.Put(key, store.NewObj(&ByteArray{data: []byte{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64}}, maxExDuration, object.ObjTypeByteArray, object.ObjEncodingByteArray))
+			},
+			input:          []string{"BYTEARRAY_KEY", "0", "4"},
+			migratedOutput: EvalResponse{Result: "hello", Error: nil},
+		},
+		"GETRANGE against byte array with valid range: 6 -1": {
+			setup: func() {
+				key := "BYTEARRAY_KEY"
+				store.Put(key, store.NewObj(&ByteArray{data: []byte{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64}}, maxExDuration, object.ObjTypeByteArray, object.ObjEncodingByteArray))
+			},
+			input:          []string{"BYTEARRAY_KEY", "6", "-1"},
+			migratedOutput: EvalResponse{Result: "world", Error: nil},
+		},
+		"GETRANGE against byte array with invalid range: 20 30": {
+			setup: func() {
+				key := "BYTEARRAY_KEY"
+				store.Put(key, store.NewObj(&ByteArray{data: []byte{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64}}, maxExDuration, object.ObjTypeByteArray, object.ObjEncodingByteArray))
+			},
+			input:          []string{"BYTEARRAY_KEY", "20", "30"},
+			migratedOutput: EvalResponse{Result: "", Error: nil},
 		},
 	}
 

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -36,169 +36,169 @@ import (
 // Returns encoded OK RESP once new entry is added
 // If the key already exists then the value will be overwritten and expiry will be discarded
 func evalSET(args []string, store *dstore.Store) *EvalResponse {
-    if len(args) <= 1 {
-        return &EvalResponse{
-            Result: nil,
-            Error:  diceerrors.ErrWrongArgumentCount("SET"),
-        }
-    }
+	if len(args) <= 1 {
+		return &EvalResponse{
+			Result: nil,
+			Error:  diceerrors.ErrWrongArgumentCount("SET"),
+		}
+	}
 
-    var key, value string
-    var exDurationMs int64 = -1
-    var state exDurationState = Uninitialized
-    var keepttl bool = false
-	
+	var key, value string
+	var exDurationMs int64 = -1
+	var state exDurationState = Uninitialized
+	var keepttl bool = false
+
 	key, value = args[0], args[1]
-    oType, oEnc := deduceTypeEncoding(value)
+	oType, oEnc := deduceTypeEncoding(value)
 
-    for i := 2; i < len(args); i++ {
-        arg := strings.ToUpper(args[i])
-        switch arg {
-        case Ex, Px:
-            if state != Uninitialized {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrSyntax,
-                }
-            }
-            if keepttl {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrSyntax,
-                }
-            }
-            i++
-            if i == len(args) {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrSyntax,
-                }
-            }
+	for i := 2; i < len(args); i++ {
+		arg := strings.ToUpper(args[i])
+		switch arg {
+		case Ex, Px:
+			if state != Uninitialized {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrSyntax,
+				}
+			}
+			if keepttl {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrSyntax,
+				}
+			}
+			i++
+			if i == len(args) {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrSyntax,
+				}
+			}
 
-            exDuration, err := strconv.ParseInt(args[i], 10, 64)
-            if err != nil {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrIntegerOutOfRange,
-                }
-            }
+			exDuration, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrIntegerOutOfRange,
+				}
+			}
 
-            if exDuration <= 0 || exDuration >= maxExDuration {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrInvalidExpireTime("SET"),
-                }
-            }
+			if exDuration <= 0 || exDuration >= maxExDuration {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrInvalidExpireTime("SET"),
+				}
+			}
 
-            // converting seconds to milliseconds
-            if arg == Ex {
-                exDuration *= 1000
-            }
-            exDurationMs = exDuration
-            state = Initialized
+			// converting seconds to milliseconds
+			if arg == Ex {
+				exDuration *= 1000
+			}
+			exDurationMs = exDuration
+			state = Initialized
 
-        case Pxat, Exat:
-            if state != Uninitialized {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrSyntax,
-                }
-            }
-            if keepttl {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrSyntax,
-                }
-            }
-            i++
-            if i == len(args) {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrSyntax,
-                }
-            }
-            exDuration, err := strconv.ParseInt(args[i], 10, 64)
-            if err != nil {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrIntegerOutOfRange,
-                }
-            }
+		case Pxat, Exat:
+			if state != Uninitialized {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrSyntax,
+				}
+			}
+			if keepttl {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrSyntax,
+				}
+			}
+			i++
+			if i == len(args) {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrSyntax,
+				}
+			}
+			exDuration, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrIntegerOutOfRange,
+				}
+			}
 
-            if exDuration < 0 {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrInvalidExpireTime("SET"),
-                }
-            }
+			if exDuration < 0 {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrInvalidExpireTime("SET"),
+				}
+			}
 
-            if arg == Exat {
-                exDuration *= 1000
-            }
-            exDurationMs = exDuration - utils.GetCurrentTime().UnixMilli()
-            // If the expiry time is in the past, set exDurationMs to 0
-            // This will be used to signal immediate expiration
-            if exDurationMs < 0 {
-                exDurationMs = 0
-            }
-            state = Initialized
+			if arg == Exat {
+				exDuration *= 1000
+			}
+			exDurationMs = exDuration - utils.GetCurrentTime().UnixMilli()
+			// If the expiry time is in the past, set exDurationMs to 0
+			// This will be used to signal immediate expiration
+			if exDurationMs < 0 {
+				exDurationMs = 0
+			}
+			state = Initialized
 
-        case XX:
-            // Get the key from the hash table
-            obj := store.Get(key)
+		case XX:
+			// Get the key from the hash table
+			obj := store.Get(key)
 
-            // if key does not exist, return RESP encoded nil
-            if obj == nil {
-                return &EvalResponse{
-                    Result: clientio.NIL,
-                    Error:  nil,
-                }
-            }
-        case NX:
-            obj := store.Get(key)
-            if obj != nil {
-                return &EvalResponse{
-                    Result: clientio.NIL,
-                    Error:  nil,
-                }
-            }
-        case KeepTTL:
-            if state != Uninitialized {
-                return &EvalResponse{
-                    Result: nil,
-                    Error:  diceerrors.ErrSyntax,
-                }
-            }
-            keepttl = true
-        default:
-            return &EvalResponse{
-                Result: nil,
-                Error:  diceerrors.ErrSyntax,
-            }
-        }
-    }
+			// if key does not exist, return RESP encoded nil
+			if obj == nil {
+				return &EvalResponse{
+					Result: clientio.NIL,
+					Error:  nil,
+				}
+			}
+		case NX:
+			obj := store.Get(key)
+			if obj != nil {
+				return &EvalResponse{
+					Result: clientio.NIL,
+					Error:  nil,
+				}
+			}
+		case KeepTTL:
+			if state != Uninitialized {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrSyntax,
+				}
+			}
+			keepttl = true
+		default:
+			return &EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrSyntax,
+			}
+		}
+	}
 
-    // Cast the value properly based on the encoding type
-    var storedValue interface{}
-    switch oEnc {
-    case object.ObjEncodingInt:
-        storedValue, _ = strconv.ParseInt(value, 10, 64)
-    case object.ObjEncodingEmbStr, object.ObjEncodingRaw:
-        storedValue = value
-    default:
-        return &EvalResponse{
-            Result: nil,
-            Error:  diceerrors.ErrUnsupportedEncoding(int(oEnc)),
-        }
-    }
+	// Cast the value properly based on the encoding type
+	var storedValue interface{}
+	switch oEnc {
+	case object.ObjEncodingInt:
+		storedValue, _ = strconv.ParseInt(value, 10, 64)
+	case object.ObjEncodingEmbStr, object.ObjEncodingRaw:
+		storedValue = value
+	default:
+		return &EvalResponse{
+			Result: nil,
+			Error:  diceerrors.ErrUnsupportedEncoding(int(oEnc)),
+		}
+	}
 
-    // putting the k and value in a Hash Table
-    store.Put(key, store.NewObj(storedValue, exDurationMs, oType, oEnc), dstore.WithKeepTTL(keepttl))
+	// putting the k and value in a Hash Table
+	store.Put(key, store.NewObj(storedValue, exDurationMs, oType, oEnc), dstore.WithKeepTTL(keepttl))
 
-    return &EvalResponse{
-        Result: clientio.OK,
-        Error:  nil,
-    }
+	return &EvalResponse{
+		Result: clientio.OK,
+		Error:  nil,
+	}
 }
 
 // evalGET returns the value for the queried key in args
@@ -531,6 +531,15 @@ func evalGETRANGE(args []string, store *dstore.Store) *EvalResponse {
 		}
 	case object.ObjEncodingInt:
 		str = strconv.FormatInt(obj.Value.(int64), 10)
+	case object.ObjEncodingByteArray:
+		if val, ok := obj.Value.(*ByteArray); ok {
+			str = string(val.data)
+		} else {
+			return &EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrWrongTypeOperation,
+			}
+		}
 	default:
 		return &EvalResponse{
 			Result: nil,

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -533,6 +533,7 @@ func evalGETRANGE(args []string, store *dstore.Store) *EvalResponse {
 		str = strconv.FormatInt(obj.Value.(int64), 10)
 	case object.ObjEncodingByteArray:
 		if val, ok := obj.Value.(*ByteArray); ok {
+			fmt.Println(val)
 			str = string(val.data)
 		} else {
 			return &EvalResponse{


### PR DESCRIPTION
Enhances [GETRANGE](https://redis.io/docs/latest/commands/getrange/) to support byte array.
PR Checklist 
- [x] All datatypes are supported and error handling must be consistent.
- [x] updating unit tests to cover new enhancement
- [ ] updating all integration test to test new enhancement
- [ ] documentation updates with new enhancement

closes #1194 