### PR TITLE
#1021 : Add integration tests for HSET/HGET/HDEL

### DIFF
--- a/integration_tests/commands/async/object_test.go
+++ b/integration_tests/commands/async/object_test.go
@@ -1,7 +1,6 @@
 package async
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -124,7 +123,6 @@ func TestObjectCommand(t *testing.T) {
 
 				result := FireCommand(conn, cmd)
 
-				fmt.Println(cmd, result, tc.expected[i])
 				if tc.assertType[i] == "equal" {
 					assert.Equal(t, tc.expected[i], result)
 				} else {

--- a/integration_tests/commands/http/hdel_test.go
+++ b/integration_tests/commands/http/hdel_test.go
@@ -1,0 +1,100 @@
+package http
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHDel(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	testCases := []struct {
+		name     string
+		commands []HTTPCommand
+		expected []interface{}
+		delays   []time.Duration
+	}{
+		{
+			name: "HDEL with wrong number of arguments",
+			commands: []HTTPCommand{
+				{Command: "HDEL", Body: map[string]interface{}{"key": nil}},
+				{Command: "HDEL", Body: map[string]interface{}{"key": "key_hDel1"}},
+			},
+			expected: []interface{}{
+				"ERR wrong number of arguments for 'hdel' command",
+				"ERR wrong number of arguments for 'hdel' command"},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HDEL with single field",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hDel2", "field": "field1", "value": "value1"}},
+				{Command: "HLEN", Body: map[string]interface{}{"key": "key_hDel2"}},
+				{Command: "HDEL", Body: map[string]interface{}{"key": "key_hDel2", "field": "field1"}},
+				{Command: "HLEN", Body: map[string]interface{}{"key": "key_hDel2"}},
+			},
+			expected: []interface{}{float64(1), float64(1), float64(1), float64(0)},
+			delays:   []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "HDEL with multiple fields",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hDel3", "key_values": map[string]interface{}{"field1": "value1", "field2": "value2", "field3": "value3", "field4": "value4"}}},
+				{Command: "HLEN", Body: map[string]interface{}{"key": "key_hDel3"}},
+				{Command: "HDEL", Body: map[string]interface{}{"key": "key_hDel3", "values": []string{"field1", "field2"}}},
+				{Command: "HLEN", Body: map[string]interface{}{"key": "key_hDel3"}},
+			},
+			expected: []interface{}{float64(4), float64(4), float64(2), float64(2)},
+			delays:   []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "HDEL on non-existent field",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hDel4", "key_values": map[string]interface{}{"field1": "value1", "field2": "value2"}}},
+				{Command: "HDEL", Body: map[string]interface{}{"key": "key_hDel4", "field": "field3"}},
+			},
+			expected: []interface{}{float64(2), float64(0)},
+			delays:   []time.Duration{0, 0},
+		},
+		{
+			name: "HDEL on non-existent hash",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hDel5", "key_values": map[string]interface{}{"field1": "value1", "field2": "value2"}}},
+				{Command: "HDEL", Body: map[string]interface{}{"key": "wrong_key_hDel5", "field": "field1"}},
+			},
+			expected: []interface{}{float64(2), float64(0)},
+			delays:   []time.Duration{0, 0},
+		},
+		{
+			name: "HDEL with wrong type",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "string_key", "value": "value"}},
+				{Command: "HDEL", Body: map[string]interface{}{"key": "string_key", "field": "field"}},
+			},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays:   []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"keys": [...]string{"key_hDel1", "key_hDel2", "key_hDel3", "key_hDel4", "key_hDel5", "string_key"}}})
+
+			for i, cmd := range tc.commands {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, err := exec.FireCommand(cmd)
+				if err != nil {
+					log.Println(tc.expected[i])
+					assert.Equal(t, tc.expected[i], err.Error(), "Error message mismatch for cmd %s", cmd)
+				} else {
+					assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s, expected %v, got %v", cmd, tc.expected[i], result)
+				}
+			}
+		})
+	}
+}

--- a/integration_tests/commands/http/hget_test.go
+++ b/integration_tests/commands/http/hget_test.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHGet(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	testCases := []struct {
+		name     string
+		commands []HTTPCommand
+		expected []interface{}
+		delays   []time.Duration
+	}{
+		{
+			name: "HGET with wrong number of arguments",
+			commands: []HTTPCommand{
+				{Command: "HGET", Body: map[string]interface{}{"key": nil}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "key_hGet1"}},
+			},
+			expected: []interface{}{
+				"ERR wrong number of arguments for 'hget' command",
+				"ERR wrong number of arguments for 'hget' command"},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HGET on existent hash",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hGet2", "key_values": map[string]interface{}{"field1": "value1", "field2": "value2", "field3": "value3"}}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "key_hGet2", "field": "field2"}},
+			},
+			expected: []interface{}{float64(3), "value2"},
+			delays:   []time.Duration{0, 0},
+		},
+		{
+			name: "HGET on non-existent field",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hGet3", "key_values": map[string]interface{}{"field1": "value1", "field2": "value2"}}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "key_hGet3", "field": "field2"}},
+				{Command: "HDEL", Body: map[string]interface{}{"key": "key_hGet3", "field": "field2"}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "key_hGet3", "field": "field2"}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "key_hGet3", "field": "field3"}},
+			},
+			expected: []interface{}{float64(2), "value2", float64(1), nil, nil},
+			delays:   []time.Duration{0, 0, 0, 0, 0},
+		},
+		{
+			name: "HGET on non-existent hash",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hGet4", "key_values": map[string]interface{}{"field1": "value1", "field2": "value2"}}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "wrong_key_hGet4", "field": "field2"}},
+			},
+			expected: []interface{}{float64(2), nil},
+			delays:   []time.Duration{0, 0},
+		},
+		{
+			name: "HGET with wrong type",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "string_key", "value": "value"}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "string_key", "field": "field"}},
+			},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays:   []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"keys": [...]string{"key_hGet1", "key_hGet2", "key_hGet3", "key_hGet4", "key_hGet5", "string_key"}}})
+
+			for i, cmd := range tc.commands {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, err := exec.FireCommand(cmd)
+				if err != nil {
+					log.Println(tc.expected[i])
+					assert.Equal(t, tc.expected[i], err.Error(), "Error message mismatch for cmd %s", cmd)
+				} else {
+					assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s, expected %v, got %v", cmd, tc.expected[i], result)
+				}
+			}
+		})
+	}
+}

--- a/integration_tests/commands/http/hset_test.go
+++ b/integration_tests/commands/http/hset_test.go
@@ -76,6 +76,7 @@ func TestHSet(t *testing.T) {
 				if tc.delays[i] > 0 {
 					time.Sleep(tc.delays[i])
 				}
+
 				result, err := exec.FireCommand(cmd)
 				if err != nil {
 					log.Println(tc.expected[i])

--- a/integration_tests/commands/http/hset_test.go
+++ b/integration_tests/commands/http/hset_test.go
@@ -1,0 +1,89 @@
+package http
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHSet(t *testing.T) {
+	exec := NewHTTPCommandExecutor()
+
+	testCases := []struct {
+		name     string
+		commands []HTTPCommand
+		expected []interface{}
+		delays   []time.Duration
+	}{
+		{
+			name: "HSET with wrong number of arguments",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": nil}},
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hSet1", "field": nil}},
+			},
+			expected: []interface{}{
+				"ERR wrong number of arguments for 'hset' command",
+				"ERR wrong number of arguments for 'hset' command"},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HSET with single field",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hSet2", "field": "field1", "value": "value1"}},
+				{Command: "HLEN", Body: map[string]interface{}{"key": "key_hSet2"}},
+			},
+			expected: []interface{}{float64(1), float64(1)},
+			delays:   []time.Duration{0, 0},
+		},
+		{
+			name: "HSET with multiple fields",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hSet3", "key_values": map[string]interface{}{"field1": "value1", "field2": "value2", "field3": "value3"}}},
+				{Command: "HLEN", Body: map[string]interface{}{"key": "key_hSet3"}},
+			},
+			expected: []interface{}{float64(3), float64(3)},
+			delays:   []time.Duration{0, 0},
+		},
+		{
+			name: "HSET on existing hash",
+			commands: []HTTPCommand{
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hSet4", "key_values": map[string]interface{}{"field1": "value1", "field2": "value2"}}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "key_hSet4", "field": "field2"}},
+				{Command: "HSET", Body: map[string]interface{}{"key": "key_hSet4", "key_values": map[string]interface{}{"field2": "newvalue2"}}},
+				{Command: "HGET", Body: map[string]interface{}{"key": "key_hSet4", "field": "field2"}},
+			},
+			expected: []interface{}{float64(2), "value2", float64(0), "newvalue2"},
+			delays:   []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "HSET with wrong type",
+			commands: []HTTPCommand{
+				{Command: "SET", Body: map[string]interface{}{"key": "string_key", "value": "value"}},
+				{Command: "HSET", Body: map[string]interface{}{"key": "string_key", "field": "field", "value": "value"}},
+			},
+			expected: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays:   []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer exec.FireCommand(HTTPCommand{Command: "DEL", Body: map[string]interface{}{"keys": [...]string{"key_hSet1", "key_hSet2", "key_hSet3", "key_hSet4", "string_key"}}})
+
+			for i, cmd := range tc.commands {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, err := exec.FireCommand(cmd)
+				if err != nil {
+					log.Println(tc.expected[i])
+					assert.Equal(t, tc.expected[i], err.Error(), "Error message mismatch for cmd %s", cmd)
+				} else {
+					assert.Equal(t, tc.expected[i], result, "Value mismatch for cmd %s, expected %v, got %v", cmd, tc.expected[i], result)
+				}
+			}
+		})
+	}
+}

--- a/integration_tests/commands/http/hvals_test.go
+++ b/integration_tests/commands/http/hvals_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +41,6 @@ func TestHVals(t *testing.T) {
 
 			for i, cmd := range tc.commands {
 				result, _ := cmdExec.FireCommand(cmd)
-				fmt.Printf("%v | %v\n", result, tc.expected[i])
 				switch e := tc.expected[i].(type) {
 				case []interface{}:
 					assert.ElementsMatch(t, e, tc.expected[i])

--- a/integration_tests/commands/http/json_test.go
+++ b/integration_tests/commands/http/json_test.go
@@ -727,7 +727,6 @@ func TestJSONMGET(t *testing.T) {
 			},
 		})
 
-		fmt.Printf("expacting: %s with got: %s\n", "OK", resp)
 		assert.Equal(t, "OK", resp)
 	}
 
@@ -1433,8 +1432,8 @@ func TestJsonObjKeys(t *testing.T) {
 					if _, ok := result.([]interface{}); ok {
 						assert.ElementsMatch(t, tc.expected[i].([]interface{}), result.([]interface{}))
 					} else {
-							// handle the case where result is not a []interface{}
-							assert.Equal(t, tc.expected[i], result)
+						// handle the case where result is not a []interface{}
+						assert.Equal(t, tc.expected[i], result)
 					}
 
 				}

--- a/integration_tests/commands/websocket/hdel_test.go
+++ b/integration_tests/commands/websocket/hdel_test.go
@@ -1,0 +1,101 @@
+package websocket
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHDEL(t *testing.T) {
+	exec := NewWebsocketCommandExecutor()
+	conn := exec.ConnectToServer()
+	DeleteKey(t, conn, exec, "key_hDel1")
+	DeleteKey(t, conn, exec, "key_hDel2")
+	DeleteKey(t, conn, exec, "key_hDel3")
+	DeleteKey(t, conn, exec, "key_hDel4")
+	DeleteKey(t, conn, exec, "key_hDel5")
+	DeleteKey(t, conn, exec, "string_key")
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []interface{}
+		delays []time.Duration
+	}{
+		{
+			name: "HDEL with wrong number of arguments",
+			cmds: []string{
+				"HDEL",
+				"HDEL key_hDel1",
+			},
+			expect: []interface{}{
+				"ERR wrong number of arguments for 'hdel' command",
+				"ERR wrong number of arguments for 'hdel' command"},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HDEL with single field",
+			cmds: []string{
+				"HSET key_hDel2 field1 value1",
+				"HLEN key_hDel2",
+				"HDEL key_hDel2 field1",
+				"HLEN key_hDel2",
+			},
+			expect: []interface{}{float64(1), float64(1), float64(1), float64(0)},
+			delays: []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "HDEL with multiple fields",
+			cmds: []string{
+				"HSET key_hDel3 field1 value1 field2 value2 field3 value3 field4 value4",
+				"HLEN key_hDel3",
+				"HDEL key_hDel3 field1 field2",
+				"HLEN key_hDel3",
+			},
+			expect: []interface{}{float64(4), float64(4), float64(2), float64(2)},
+			delays: []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "HDEL on non-existent field",
+			cmds: []string{
+				"HSET key_hDel4 field1 value1 field2 value2",
+				"HDEL key_hDel4 field3",
+			},
+			expect: []interface{}{float64(2), float64(0)},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HDEL on non-existent hash",
+			cmds: []string{
+				"HSET key_hDel5 field1 value1 field2 value2",
+				"HDEL wrong_key_hDel5 field1",
+			},
+			expect: []interface{}{float64(2), float64(0)},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HDEL with wrong type",
+			cmds: []string{
+				"SET string_key value",
+				"HDEL string_key field",
+			},
+			expect: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays: []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			for i, cmd := range tc.cmds {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}

--- a/integration_tests/commands/websocket/hget_test.go
+++ b/integration_tests/commands/websocket/hget_test.go
@@ -1,0 +1,90 @@
+package websocket
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHGET(t *testing.T) {
+	exec := NewWebsocketCommandExecutor()
+	conn := exec.ConnectToServer()
+	DeleteKey(t, conn, exec, "key_hGet1")
+	DeleteKey(t, conn, exec, "key_hGet2")
+	DeleteKey(t, conn, exec, "key_hGet3")
+	DeleteKey(t, conn, exec, "key_hGet4")
+	DeleteKey(t, conn, exec, "string_key")
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []interface{}
+		delays []time.Duration
+	}{
+		{
+			name: "HGET with wrong number of arguments",
+			cmds: []string{
+				"HGET",
+				"HGET key_hGet1",
+			},
+			expect: []interface{}{
+				"ERR wrong number of arguments for 'hget' command",
+				"ERR wrong number of arguments for 'hget' command"},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HGET on existent hash",
+			cmds: []string{
+				"HSET key_hGet2 field1 value1 field2 value2 field3 value3",
+				"HGET key_hGet2 field2",
+			},
+			expect: []interface{}{float64(3), "value2"},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HGET on non-existent field",
+			cmds: []string{
+				"HSET key_hGet3 field1 value1 field2 value2",
+				"HGET key_hGet3 field2",
+				"HDEL key_hGet3 field2",
+				"HGET key_hGet3 field2",
+				"HGET key_hGet3 field3",
+			},
+			expect: []interface{}{float64(2), "value2", float64(1), nil, nil},
+			delays: []time.Duration{0, 0, 0, 0, 0},
+		},
+		{
+			name: "HGET on non-existent hash",
+			cmds: []string{
+				"HSET key_hGet4 field1 value1 field2 value2",
+				"HGET wrong_key_hGet4 field2",
+			},
+			expect: []interface{}{float64(2), nil},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HGET with wrong type",
+			cmds: []string{
+				"SET string_key value",
+				"HGET string_key field",
+			},
+			expect: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays: []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			for i, cmd := range tc.cmds {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}

--- a/integration_tests/commands/websocket/hset_test.go
+++ b/integration_tests/commands/websocket/hset_test.go
@@ -1,0 +1,89 @@
+package websocket
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHSET(t *testing.T) {
+	exec := NewWebsocketCommandExecutor()
+	conn := exec.ConnectToServer()
+	DeleteKey(t, conn, exec, "key_hSet1")
+	DeleteKey(t, conn, exec, "key_hSet2")
+	DeleteKey(t, conn, exec, "key_hSet3")
+	DeleteKey(t, conn, exec, "key_hSet4")
+	DeleteKey(t, conn, exec, "string_key")
+
+	testCases := []struct {
+		name   string
+		cmds   []string
+		expect []interface{}
+		delays []time.Duration
+	}{
+		{
+			name: "HSET with wrong number of arguments",
+			cmds: []string{
+				"HSET",
+				"HSET key_hSet1",
+			},
+			expect: []interface{}{
+				"ERR wrong number of arguments for 'hset' command",
+				"ERR wrong number of arguments for 'hset' command"},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HSET with single field",
+			cmds: []string{
+				"HSET key_hSet2 field1 value1",
+				"HLEN key_hSet2",
+			},
+			expect: []interface{}{float64(1), float64(1)},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HSET with multiple fields",
+			cmds: []string{
+				"HSET key_hSet3 field1 value1 field2 value2 field3 value3",
+				"HLEN key_hSet3",
+			},
+			expect: []interface{}{float64(3), float64(3)},
+			delays: []time.Duration{0, 0},
+		},
+		{
+			name: "HSET on existing hash",
+			cmds: []string{
+				"HSET key_hSet4 field1 value1 field2 value2",
+				"HGET key_hSet4 field2",
+				"HSET key_hSet4 field2 newvalue2",
+				"HGET key_hSet4 field2",
+			},
+			expect: []interface{}{float64(2), "value2", float64(0), "newvalue2"},
+			delays: []time.Duration{0, 0, 0, 0},
+		},
+		{
+			name: "HSET with wrong type",
+			cmds: []string{
+				"SET string_key value",
+				"HSET string_key field value",
+			},
+			expect: []interface{}{"OK", "WRONGTYPE Operation against a key holding the wrong kind of value"},
+			delays: []time.Duration{0, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			for i, cmd := range tc.cmds {
+				if tc.delays[i] > 0 {
+					time.Sleep(tc.delays[i])
+				}
+				result, err := exec.FireCommandAndReadResponse(conn, cmd)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.expect[i], result, "Value mismatch for cmd %s", cmd)
+			}
+		})
+	}
+}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -3254,15 +3254,12 @@ func testEvalHVALS(t *testing.T, store *dstore.Store) {
 
 			response := evalHVALS(tt.input, store)
 
-			fmt.Printf("Eval Response: %v\n", response)
-
 			// Handle comparison for byte slices
 			if responseBytes, ok := response.Result.([]byte); ok && tt.migratedOutput.Result != nil {
 				if expectedBytes, ok := tt.migratedOutput.Result.([]byte); ok {
 					assert.True(t, bytes.Equal(responseBytes, expectedBytes), "expected and actual byte slices should be equal")
 				}
 			} else {
-				fmt.Printf("G1: %v | %v\n", response.Result, tt.migratedOutput.Result)
 				switch e := tt.migratedOutput.Result.(type) {
 				case []interface{}, []string:
 					assert.ElementsMatch(t, e, response.Result)


### PR DESCRIPTION
Adds missing integration tests for HSET/HGET/HDEL migrated as part of #1021 