### PR TITLE
Fix typo in benchmarks.md

### DIFF
--- a/docs/src/data/benchmarks.md
+++ b/docs/src/data/benchmarks.md
@@ -21,7 +21,7 @@ which has 48 vCPUs, 96 GB memory, and 12 Gbps network bandwidth. The benchmarks 
 
 ### Infrastructure Setup
 
-Take two AWS c5.12xlarge machines, one machine to run meatier while the other to run DiceDB.
+Take two AWS c5.12xlarge machines, one machine to run memtier while the other to run DiceDB.
 
 ## DiceDB Benchmark
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/src/data/benchmarks.md` file. The change corrects a typo by replacing "meatier" with "memtier".