### PR TITLE
#1245: Fix RESP parser to parse strings with multiple \r

### DIFF
--- a/internal/clientio/resp.go
+++ b/internal/clientio/resp.go
@@ -73,13 +73,15 @@ func readStringUntilSr(buf *bytes.Buffer) (string, error) {
 
 			// If the next byte is '\n', we've found a valid end of string
 			if nextByte == '\n' {
-				return string(result[:len(result)-1]), nil // Return without the '\r'
+				break
 			} else {
 				// Otherwise, add the next byte to the result and continue
 				result = append(result, nextByte)
 			}
 		}
 	}
+	// Return without the last '\r'
+	return string(result[:len(result)-1]), nil
 }
 
 // reads a RESP encoded simple string from data and returns

--- a/internal/clientio/resp.go
+++ b/internal/clientio/resp.go
@@ -75,6 +75,7 @@ func readStringUntilSr(buf *bytes.Buffer) (string, error) {
 			if nextByte == '\n' {
 				break
 			}
+
 			// Otherwise, add the next byte to the result and continue
 			result = append(result, nextByte)
 		}

--- a/internal/clientio/resp.go
+++ b/internal/clientio/resp.go
@@ -74,10 +74,9 @@ func readStringUntilSr(buf *bytes.Buffer) (string, error) {
 			// If the next byte is '\n', we've found a valid end of string
 			if nextByte == '\n' {
 				break
-			} else {
-				// Otherwise, add the next byte to the result and continue
-				result = append(result, nextByte)
 			}
+			// Otherwise, add the next byte to the result and continue
+			result = append(result, nextByte)
 		}
 	}
 	// Return without the last '\r'

--- a/internal/clientio/resp.go
+++ b/internal/clientio/resp.go
@@ -54,15 +54,32 @@ func readLength(buf *bytes.Buffer) (int64, error) {
 }
 
 func readStringUntilSr(buf *bytes.Buffer) (string, error) {
-	s, err := buf.ReadString('\r')
-	if err != nil {
-		return utils.EmptyStr, err
+	var result []byte
+
+	for {
+		byteRead, err := buf.ReadByte()
+		if err != nil {
+			return utils.EmptyStr, err
+		}
+
+		result = append(result, byteRead)
+
+		// If we find '\r', we check the next byte for '\n'
+		if byteRead == '\r' {
+			nextByte, err := buf.ReadByte() // Peek the next byte
+			if err != nil {
+				return utils.EmptyStr, err
+			}
+
+			// If the next byte is '\n', we've found a valid end of string
+			if nextByte == '\n' {
+				return string(result[:len(result)-1]), nil // Return without the '\r'
+			} else {
+				// Otherwise, add the next byte to the result and continue
+				result = append(result, nextByte)
+			}
+		}
 	}
-	// incrementing to skip `\n`
-	if _, err := buf.ReadByte(); err != nil {
-		return utils.EmptyStr, err
-	}
-	return s[:len(s)-1], nil
 }
 
 // reads a RESP encoded simple string from data and returns

--- a/internal/clientio/resp_test.go
+++ b/internal/clientio/resp_test.go
@@ -13,7 +13,9 @@ import (
 
 func TestSimpleStringDecode(t *testing.T) {
 	cases := map[string]string{
-		"+OK\r\n": "OK",
+		"+OK\r\n":                  "OK",
+		"+Hello\rWorld\r\n":        "Hello\rWorld",
+		"+Hello\rWorld\rAgain\r\n": "Hello\rWorld\rAgain",
 	}
 	for k, v := range cases {
 		p := clientio.NewRESPParser(bytes.NewBuffer([]byte(k)))
@@ -25,6 +27,7 @@ func TestSimpleStringDecode(t *testing.T) {
 		if v != value {
 			t.Fail()
 		}
+		fmt.Println(v, value)
 	}
 }
 


### PR DESCRIPTION
Adds fix for RESP parser to parse string containing multiple `\r` until it encounters the first `\r` immediately followed by a `\n`.

Fixes #1245 and unblocks #1089
