### PR TITLE
Enh: Add bytearray support to APPEND

### DIFF
--- a/docs/src/content/docs/commands/APPEND.md
+++ b/docs/src/content/docs/commands/APPEND.md
@@ -3,7 +3,7 @@ title: APPEND
 description: The `APPEND` command in DiceDB is used to either set the value of a key or append a value to an existing key. This command allows for both creating and updating key-value pairs.
 ---
 
-The `APPEND` command in DiceDB is used to either set the value of a key or append a value to an existing key. This command allows for both creating and updating key-value pairs.
+The `APPEND` command in DiceDB is used to either set the value of a key or append a value to an existing key and returns the length of the value stored at the specified key after appending. This command allows for both creating and updating key-value pairs.
 
 ## Syntax
 
@@ -56,8 +56,34 @@ Appending to key `foo` that contains `bar` with `baz`
 
 ```bash
 127.0.0.1:7379> SET foo bar
+OK
 127.0.0.1:7379> APPEND foo baz
 (integer) 6
+127.0.0.1:7379> GET foo
+"barbaz"
+```
+
+Appending "1" to key `bmkey` that contains a bitmap equivalent of `42`
+
+```bash
+127.0.0.1:7379> SETBIT bmkey 2 1
+(integer) 0
+127.0.0.1:7379> SETBIT bmkey 3 1
+(integer) 0
+127.0.0.1:7379> SETBIT bmkey 5 1
+(integer) 0
+127.0.0.1:7379> SETBIT bmkey 10 1
+(integer) 0
+127.0.0.1:7379> SETBIT bmkey 11 1
+(integer) 0
+127.0.0.1:7379> SETBIT bmkey 14 1
+(integer) 0
+127.0.0.1:7379> GET bmkey
+"42"
+127.0.0.1:7379> APPEND bmkey 1
+(integer) 3
+127.0.0.1:7379> GET bmkey
+"421"
 ```
 
 ### Invalid usage

--- a/integration_tests/commands/http/append_test.go
+++ b/integration_tests/commands/http/append_test.go
@@ -101,6 +101,23 @@ func TestAPPEND(t *testing.T) {
 				{Command: "del", Body: map[string]interface{}{"key": "myzset"}},
 			},
 		},
+		{
+			name: "APPEND to key created using SETBIT",
+			commands: []HTTPCommand{
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "bitkey", "values": []string{"2", "1"}}},
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "bitkey", "values": []string{"3", "1"}}},
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "bitkey", "values": []string{"5", "1"}}},
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "bitkey", "values": []string{"10", "1"}}},
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "bitkey", "values": []string{"11", "1"}}},
+				{Command: "SETBIT", Body: map[string]interface{}{"key": "bitkey", "values": []string{"14", "1"}}},
+				{Command: "APPEND", Body: map[string]interface{}{"key": "bitkey", "value": "1"}},
+				{Command: "GET", Body: map[string]interface{}{"key": "bitkey"}},
+			},
+			expected: []interface{}{float64(0), float64(0), float64(0), float64(0), float64(0), float64(0), float64(3), "421"},
+			cleanup: []HTTPCommand{
+				{Command: "del", Body: map[string]interface{}{"key": "bitkey"}},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/integration_tests/commands/resp/append_test.go
+++ b/integration_tests/commands/resp/append_test.go
@@ -65,6 +65,12 @@ func TestAPPEND(t *testing.T) {
 			expected: []interface{}{int64(1), "WRONGTYPE Operation against a key holding the wrong kind of value"},
 			cleanup:  []string{"del key"},
 		},
+		{
+			name:     "APPEND to key created using SETBIT",
+			commands: []string{"SETBIT bitkey 2 1", "SETBIT bitkey 3 1", "SETBIT bitkey 5 1", "SETBIT bitkey 10 1", "SETBIT bitkey 11 1", "SETBIT bitkey 14 1", "APPEND bitkey 1", "GET bitkey"},
+			expected: []interface{}{int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(3), "421"},
+			cleanup:  []string{"del bitkey"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/integration_tests/commands/websocket/append_test.go
+++ b/integration_tests/commands/websocket/append_test.go
@@ -51,6 +51,12 @@ func TestAppend(t *testing.T) {
 			expected:   []interface{}{float64(1), "WRONGTYPE Operation against a key holding the wrong kind of value"},
 			cleanupKey: "key",
 		},
+		{
+			name:       "APPEND to key created using SETBIT",
+			commands:   []string{"SETBIT bitkey 2 1", "SETBIT bitkey 3 1", "SETBIT bitkey 5 1", "SETBIT bitkey 10 1", "SETBIT bitkey 11 1", "SETBIT bitkey 14 1", "APPEND bitkey 1", "GET bitkey"},
+			expected:   []interface{}{float64(0), float64(0), float64(0), float64(0), float64(0), float64(0), float64(3), "421"},
+			cleanupKey: "bitkey",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -7031,17 +7031,22 @@ func testEvalAPPEND(t *testing.T, store *dstore.Store) {
 			input:          []string{"hashKey", "val"},
 			migratedOutput: EvalResponse{Result: nil, Error: diceerrors.ErrWrongTypeOperation},
 		},
-		"append to key created using SETBIT": {
+		"append to key containing byte array": {
 			setup: func() {
 				key := "bitKey"
 				// Create a new byte array object
-				initialByteArray := NewByteArray(1) // Initialize with 1 byte
-				initialByteArray.SetBit(0, true)    // Set the first bit to 1
+				initialByteArray := NewByteArray(2) // Initialize with 2 byte
+				initialByteArray.SetBit(2, true)    // Set the third bit to 1
+				initialByteArray.SetBit(3, true)    // Set the fourth bit to 1
+				initialByteArray.SetBit(5, true)    // Set the sixth bit to 1
+				initialByteArray.SetBit(10, true)   // Set the eleventh bit to 1
+				initialByteArray.SetBit(11, true)   // Set the twelfth bit to 1
+				initialByteArray.SetBit(14, true)   // Set the fifteenth bit to 1
 				obj := store.NewObj(initialByteArray, -1, object.ObjTypeByteArray, object.ObjEncodingByteArray)
 				store.Put(key, obj)
 			},
-			input:          []string{"bitKey", "val"},
-			migratedOutput: EvalResponse{Result: nil, Error: diceerrors.ErrWrongTypeOperation},
+			input:          []string{"bitKey", "1"},
+			migratedOutput: EvalResponse{Result: 3, Error: nil},
 		},
 		"append value with leading zeros": {
 			setup: func() {


### PR DESCRIPTION
PR adds bytearray/bitmap support to [APPEND](https://redis.io/docs/latest/commands/append/) commands to match with REDIS behaviour.

- [x] Implement Eval logic
- [x] Add unit test case
- [x] Add integration test cases
- [x] Update documentation