### PR TITLE
Adds support for SMEMBERS.WATCH command

### DIFF
--- a/integration_tests/commands/resp/smemberswatch_test.go
+++ b/integration_tests/commands/resp/smemberswatch_test.go
@@ -1,0 +1,197 @@
+package resp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/dicedb/dice/internal/clientio"
+	dicedb "github.com/dicedb/dicedb-go"
+	"gotest.tools/v3/assert"
+)
+
+type smembersWatchTestCase struct {
+    key    string
+    val    string
+    result any
+}
+
+const (
+    smembersCommand          = "SMEMBERS"
+    smembersWatchKey         = "smemberswatchkey"
+    smembersWatchQuery       = "SMEMBERS.WATCH %s"
+    smembersWatchFingerPrint = "3660753939"
+)
+
+var smembersWatchTestCases = []smembersWatchTestCase{
+    {smembersWatchKey, "member1", []any{"member1"}},
+    {smembersWatchKey, "member2", []any{"member1", "member2"}},
+    {smembersWatchKey, "member3", []any{"member1", "member2", "member3"}},
+}
+
+func TestSMEMBERSWATCH(t *testing.T) {
+    publisher := getLocalConnection()
+    subscribers := setupSubscribers(3)
+
+    FireCommand(publisher, fmt.Sprintf("DEL %s", smembersWatchKey))
+
+    defer func() {
+        if err := publisher.Close(); err != nil {
+            t.Errorf("Error closing publisher connection: %v", err)
+        }
+        for _, sub := range subscribers {
+            time.Sleep(100 * time.Millisecond)
+            if err := sub.Close(); err != nil {
+                t.Errorf("Error closing subscriber connection: %v", err)
+            }
+        }
+    }()
+
+    respParsers := setUpSmembersRespParsers(t, subscribers)
+
+    t.Run("Basic Set Operations", func(t *testing.T) {
+        testSetOperations(t, publisher, respParsers)
+    })
+}
+
+func sortSlice(v any) any {
+    switch v := v.(type) {
+    case []interface{}:
+        sorted := make([]interface{}, len(v))
+        copy(sorted, v)
+        sort.Slice(sorted, func(i, j int) bool {
+            return sorted[i].(string) < sorted[j].(string)
+        })
+        return sorted
+    case []string:
+        sorted := make([]string, len(v))
+        copy(sorted, v)
+        sort.Strings(sorted)
+        return sorted
+    default:
+        return v
+    }
+}
+
+func setUpSmembersRespParsers(t *testing.T, subscribers []net.Conn) []*clientio.RESPParser {
+    respParsers := make([]*clientio.RESPParser, len(subscribers))
+    for i, subscriber := range subscribers {
+        rp := fireCommandAndGetRESPParser(subscriber, fmt.Sprintf(smembersWatchQuery, smembersWatchKey))
+        assert.Assert(t, rp != nil)
+        respParsers[i] = rp
+
+        v, err := rp.DecodeOne()
+        assert.NilError(t, err)
+        castedValue, ok := v.([]interface{})
+        if !ok {
+            t.Errorf("Type assertion to []interface{} failed for value: %v", v)
+        }
+        assert.Equal(t, 3, len(castedValue))
+    }
+    return respParsers
+}
+
+func testSetOperations(t *testing.T, publisher net.Conn, respParsers []*clientio.RESPParser) {
+    for _, tc := range smembersWatchTestCases {
+        res := FireCommand(publisher, fmt.Sprintf("SADD %s %s", tc.key, tc.val))
+        assert.Equal(t, int64(1), res)
+        verifySmembersWatchResults(t, respParsers, tc.result)
+    }
+}
+
+func verifySmembersWatchResults(t *testing.T, respParsers []*clientio.RESPParser, expected any) {
+    for _, rp := range respParsers {
+        v, err := rp.DecodeOne()
+        assert.NilError(t, err)
+        castedValue, ok := v.([]interface{})
+        if !ok {
+            t.Errorf("Type assertion to []interface{} failed for value: %v", v)
+        }
+        assert.Equal(t, 3, len(castedValue))
+        assert.Equal(t, smembersCommand, castedValue[0])
+        assert.Equal(t, smembersWatchFingerPrint, castedValue[1])
+        assert.DeepEqual(t, sortSlice(expected), sortSlice(castedValue[2]))
+    }
+}
+
+type smembersWatchSDKTestCase struct {
+    key    string
+    val    string
+    result []string
+}
+
+var smembersWatchSDKTestCases = []smembersWatchSDKTestCase{
+    {smembersWatchKey, "member1", []string{"member1"}},
+    {smembersWatchKey, "member2", []string{"member1", "member2"}},
+    {smembersWatchKey, "member3", []string{"member1", "member2", "member3"}},
+}
+
+func TestSMEMBERSWATCHWithSDK(t *testing.T) {
+    ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+    defer cancel()
+
+    publisher := getLocalSdk()
+    subscribers := setupSubscribersSDK(3)
+    defer cleanupSubscribersSDK(subscribers)
+
+    publisher.Del(ctx, smembersWatchKey)
+
+    channels := setUpSmembersWatchChannelsSDK(t, ctx, subscribers)
+
+    t.Run("Basic Set Operations", func(t *testing.T) {
+        testSetOperationsSDK(t, ctx, channels, publisher)
+    })
+}
+
+func setUpSmembersWatchChannelsSDK(t *testing.T, ctx context.Context, subscribers []WatchSubscriber) []<-chan *dicedb.WatchResult {
+    channels := make([]<-chan *dicedb.WatchResult, len(subscribers))
+    for i, subscriber := range subscribers {
+        watch := subscriber.client.WatchConn(ctx)
+        subscribers[i].watch = watch
+        assert.Assert(t, watch != nil)
+        firstMsg, err := watch.Watch(ctx, smembersCommand, smembersWatchKey)
+        assert.NilError(t, err)
+        assert.Equal(t, firstMsg.Command, smembersCommand)
+        channels[i] = watch.Channel()
+    }
+    return channels
+}
+
+func testSetOperationsSDK(t *testing.T, ctx context.Context, channels []<-chan *dicedb.WatchResult, publisher *dicedb.Client) {
+    for _, tc := range smembersWatchSDKTestCases {
+        err := publisher.SAdd(ctx, tc.key, tc.val).Err()
+        assert.NilError(t, err)
+        verifySmembersWatchResultsSDK(t, channels, tc.result)
+    }
+}
+
+func verifySmembersWatchResultsSDK(t *testing.T, channels []<-chan *dicedb.WatchResult, expected []string) {
+    for _, channel := range channels {
+        select {
+        case v := <-channel:
+            assert.Equal(t, smembersCommand, v.Command)
+            assert.Equal(t, smembersWatchFingerPrint, v.Fingerprint)
+            
+            received, ok := v.Data.([]interface{})
+            if !ok {
+                t.Fatalf("Expected []interface{}, got %T", v.Data)
+            }
+            
+            receivedStrings := make([]string, len(received))
+            for i, item := range received {
+                str, ok := item.(string)
+                if !ok {
+                    t.Fatalf("Expected string, got %T", item)
+                }
+                receivedStrings[i] = str
+            }
+            
+            assert.DeepEqual(t, sortSlice(expected), sortSlice(receivedStrings))
+        case <-time.After(defaultTimeout):
+            t.Fatal("timeout waiting for watch result")
+        }
+    }
+}

--- a/integration_tests/commands/resp/smemberswatch_test.go
+++ b/integration_tests/commands/resp/smemberswatch_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"sort"
 	"testing"
 	"time"
 
 	"github.com/dicedb/dice/internal/clientio"
 	dicedb "github.com/dicedb/dicedb-go"
 	"gotest.tools/v3/assert"
+    testifyAssert "github.com/stretchr/testify/assert"
 )
 
 type smembersWatchTestCase struct {
@@ -57,25 +57,6 @@ func TestSMEMBERSWATCH(t *testing.T) {
     })
 }
 
-func sortSlice(v any) any {
-    switch v := v.(type) {
-    case []interface{}:
-        sorted := make([]interface{}, len(v))
-        copy(sorted, v)
-        sort.Slice(sorted, func(i, j int) bool {
-            return sorted[i].(string) < sorted[j].(string)
-        })
-        return sorted
-    case []string:
-        sorted := make([]string, len(v))
-        copy(sorted, v)
-        sort.Strings(sorted)
-        return sorted
-    default:
-        return v
-    }
-}
-
 func setUpSmembersRespParsers(t *testing.T, subscribers []net.Conn) []*clientio.RESPParser {
     respParsers := make([]*clientio.RESPParser, len(subscribers))
     for i, subscriber := range subscribers {
@@ -113,7 +94,7 @@ func verifySmembersWatchResults(t *testing.T, respParsers []*clientio.RESPParser
         assert.Equal(t, 3, len(castedValue))
         assert.Equal(t, smembersCommand, castedValue[0])
         assert.Equal(t, smembersWatchFingerPrint, castedValue[1])
-        assert.DeepEqual(t, sortSlice(expected), sortSlice(castedValue[2]))
+        testifyAssert.ElementsMatch(t, expected, castedValue[2])
     }
 }
 
@@ -189,7 +170,7 @@ func verifySmembersWatchResultsSDK(t *testing.T, channels []<-chan *dicedb.Watch
                 receivedStrings[i] = str
             }
             
-            assert.DeepEqual(t, sortSlice(expected), sortSlice(receivedStrings))
+            testifyAssert.ElementsMatch(t, expected, receivedStrings)
         case <-time.After(defaultTimeout):
             t.Fatal("timeout waiting for watch result")
         }

--- a/internal/commandhandler/cmd_meta.go
+++ b/internal/commandhandler/cmd_meta.go
@@ -125,6 +125,7 @@ const (
 	CmdSrem                = "SREM"
 	CmdScard               = "SCARD"
 	CmdSmembers            = "SMEMBERS"
+	CmdSMembersWatch       = "SMEMBERS.WATCH"
 	CmdDump                = "DUMP"
 	CmdRestore             = "RESTORE"
 	CmdGeoAdd              = "GEOADD"
@@ -674,6 +675,9 @@ var CommandsMeta = map[string]CmdMeta{
 		CmdType: Watch,
 	},
 	CmdPFCountWatch: {
+		CmdType: Watch,
+	},
+	CmdSMembersWatch: {
 		CmdType: Watch,
 	},
 

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -4772,15 +4772,8 @@ func evalSADD(args []string, store *dstore.Store) *EvalResponse {
         // If the object does not exist, create a new set
         set = make(map[string]struct{}, lengthOfItems)
     } else {
-        // Type and encoding checks
-        if err := object.AssertType(obj.TypeEncoding, object.ObjTypeSet); err != nil {
-            return &EvalResponse{
-                Result: nil,
-                Error:  diceerrors.ErrWrongTypeOperation,
-            }
-        }
-
-        if err := object.AssertEncoding(obj.TypeEncoding, object.ObjEncodingSetStr); err != nil {
+        // Type checks
+        if err := object.AssertType(obj.Type, object.ObjTypeSet); err != nil {
             return &EvalResponse{
                 Result: nil,
                 Error:  diceerrors.ErrWrongTypeOperation,
@@ -4799,7 +4792,7 @@ func evalSADD(args []string, store *dstore.Store) *EvalResponse {
     }
 
     // Single Put operation at the end
-    obj = store.NewObj(set, -1, object.ObjTypeSet, object.ObjEncodingSetStr)
+    obj = store.NewObj(set, -1, object.ObjTypeSet)
     store.Put(key, obj, dstore.WithKeepTTL(false), dstore.WithPutCmd(dstore.SADD))
 
     return &EvalResponse{

--- a/internal/store/constants.go
+++ b/internal/store/constants.go
@@ -31,6 +31,8 @@ const (
 	PFMERGE          string = "PFMERGE"
 	KEYSPERSHARD     string = "KEYSPERSHARD"
 	Evict            string = "EVICT"
+	SADD         string = "SADD"
+	SMEMBERS     string = "SMEMBERS"
 	SingleShardSize  string = "SINGLEDBSIZE"
 	SingleShardTouch string = "SINGLETOUCH"
 	SingleShardKeys  string = "SINGLEKEYS"

--- a/internal/watchmanager/watch_manager.go
+++ b/internal/watchmanager/watch_manager.go
@@ -50,6 +50,7 @@ var (
 		dstore.ZAdd:    {dstore.ZRange: struct{}{}},
 		dstore.PFADD:   {dstore.PFCOUNT: struct{}{}},
 		dstore.PFMERGE: {dstore.PFCOUNT: struct{}{}},
+		dstore.SADD:    {dstore.SMEMBERS: struct{}{}},
 	}
 )
 


### PR DESCRIPTION
This PR implements the feature described in the issue #1132. The new `SMEMBERS.WATCH` command allows subscribed clients to receive push responses whenever the data in a respective set is modified. 

---

### Changed Introduced

- Modified the `evalSADD` function
- Added command constants
- Updated command watch manager
- Defined metadata for `SMEMBERS.WATCH`
- Added integration tests

---

### Why did I modified the `evalSADD` function

I have had to modify this function because the subscribers were receiving double notifications for the first `SADD` command. The old implementation caused double notifications because it performed a `store.PUT` for the initial set creation and subsequent additions. The new implementation defers the `store.PUT` operation until all additions are complete, ensuring subscribers are notified only once. 

### Why Sorting the Results in Integration Tests Is Necessary

To validate the correctness of the reactive system, we care about the contents and not the order of the set. Sorting both the expected and received results allows us to 

- Ignore the effects of the asynchronous delivery.
- Focus solely on whether the correct data was transmitted.

---

### Screenshot

![SCR-20241116-q7s](https://github.com/user-attachments/assets/f369b259-157a-4a0a-862e-824a893c556b)
