### PR TITLE
Fixed goroutine leaks and deadlocks in Worker and Resp Integrations Tests

### DIFF
--- a/integration_tests/commands/resp/append_test.go
+++ b/integration_tests/commands/resp/append_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestAPPEND(t *testing.T) {
 	conn := getLocalConnection()
-	FireCommand(conn, "FLUSHDB")
 	defer conn.Close()
+	FireCommand(conn, "FLUSHDB")
 
 	testCases := []struct {
 		name     string

--- a/integration_tests/commands/resp/bit_test.go
+++ b/integration_tests/commands/resp/bit_test.go
@@ -265,6 +265,7 @@ import (
 
 func TestBitCount(t *testing.T) {
 	conn := getLocalConnection()
+	defer conn.Close()
 	testcases := []struct {
 		InCmds []string
 		Out    []interface{}
@@ -342,6 +343,7 @@ func TestBitCount(t *testing.T) {
 
 func TestBitPos(t *testing.T) {
 	conn := getLocalConnection()
+	defer conn.Close()
 	testcases := []struct {
 		name         string
 		val          interface{}

--- a/integration_tests/commands/resp/getunwatch_test.go
+++ b/integration_tests/commands/resp/getunwatch_test.go
@@ -33,7 +33,7 @@ func TestGETUNWATCH(t *testing.T) {
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
 	defer func() {
-		err := closePublisherSubscribers(publisher, subscribers)
+		err := ClosePublisherSubscribers(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 
@@ -130,10 +130,10 @@ func unsubscribeFromUpdates(t *testing.T, subscribers []net.Conn) {
 
 func TestGETUNWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 
 	defer func() {
-		err := closePublisherSubscribersSDK(publisher, subscribers)
+		err := ClosePublisherSubscribersSDK(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 
@@ -179,7 +179,7 @@ func TestGETUNWATCHWithSDK(t *testing.T) {
 	}
 }
 
-func unsubscribeFromUpdatesSDK(t *testing.T, subscribers []watchSubscriber) {
+func unsubscribeFromUpdatesSDK(t *testing.T, subscribers []WatchSubscriber) {
 	for _, subscriber := range subscribers {
 		err := subscriber.watch.Unwatch(context.Background(), "GET", "426696421")
 		assert.Nil(t, err)

--- a/integration_tests/commands/resp/getunwatch_test.go
+++ b/integration_tests/commands/resp/getunwatch_test.go
@@ -33,14 +33,8 @@ func TestGETUNWATCH(t *testing.T) {
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
 	defer func() {
-		if err := publisher.Close(); err != nil {
-			t.Errorf("Error closing publisher connection: %v", err)
-		}
-		for _, sub := range subscribers {
-			if err := sub.Close(); err != nil {
-				t.Errorf("Error closing subscriber connection: %v", err)
-			}
-		}
+		err := closePublisherSubscribers(publisher, subscribers)
+		assert.Nil(t, err)
 	}()
 
 	FireCommand(publisher, fmt.Sprintf("DEL %s", getUnwatchKey))
@@ -86,18 +80,8 @@ func TestGETUNWATCH(t *testing.T) {
 	}
 
 	// unsubscribe from updates
-	for _, subscriber := range subscribers {
-		rp := fireCommandAndGetRESPParser(subscriber, fmt.Sprintf("GET.UNWATCH %s", "426696421"))
-		assert.NotNil(t, rp)
+	unsubscribeFromUpdates(t, subscribers)
 
-		v, err := rp.DecodeOne()
-		assert.NoError(t, err)
-		castedValue, ok := v.(string)
-		if !ok {
-			t.Errorf("Type assertion to string failed for value: %v", v)
-		}
-		assert.Equal(t, castedValue, "OK")
-	}
 	// Test updates are not sent after unsubscribing
 	for _, tc := range getUnwatchTestCases[2:] {
 		res := FireCommand(publisher, fmt.Sprintf("SET %s %s", tc.key, tc.val))
@@ -129,9 +113,29 @@ func TestGETUNWATCH(t *testing.T) {
 	}
 }
 
+func unsubscribeFromUpdates(t *testing.T, subscribers []net.Conn) {
+	for _, subscriber := range subscribers {
+		rp := fireCommandAndGetRESPParser(subscriber, fmt.Sprintf("GET.UNWATCH %s", "426696421"))
+		assert.NotNil(t, rp)
+
+		v, err := rp.DecodeOne()
+		assert.NoError(t, err)
+		castedValue, ok := v.(string)
+		if !ok {
+			t.Errorf("Type assertion to string failed for value: %v", v)
+		}
+		assert.Equal(t, castedValue, "OK")
+	}
+}
+
 func TestGETUNWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+
+	defer func() {
+		err := closePublisherSubscribersSDK(publisher, subscribers)
+		assert.Nil(t, err)
+	}()
 
 	publisher.Del(context.Background(), getUnwatchKey)
 
@@ -160,10 +164,7 @@ func TestGETUNWATCHWithSDK(t *testing.T) {
 	}
 
 	// unsubscribe from updates
-	for _, subscriber := range subscribers {
-		err := subscriber.watch.Unwatch(context.Background(), "GET", "426696421")
-		assert.Nil(t, err)
-	}
+	unsubscribeFromUpdatesSDK(t, subscribers)
 
 	// fire updates and validate that they are not received
 	err = publisher.Set(context.Background(), getUnwatchKey, "final", 0).Err()
@@ -175,5 +176,12 @@ func TestGETUNWATCHWithSDK(t *testing.T) {
 		case <-time.After(100 * time.Millisecond):
 			// This is the expected behavior - no response within the timeout
 		}
+	}
+}
+
+func unsubscribeFromUpdatesSDK(t *testing.T, subscribers []watchSubscriber) {
+	for _, subscriber := range subscribers {
+		err := subscriber.watch.Unwatch(context.Background(), "GET", "426696421")
+		assert.Nil(t, err)
 	}
 }

--- a/integration_tests/commands/resp/getwatch_test.go
+++ b/integration_tests/commands/resp/getwatch_test.go
@@ -32,7 +32,7 @@ func TestGETWATCH(t *testing.T) {
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 
 	defer func() {
-		err := closePublisherSubscribers(publisher, subscribers)
+		err := ClosePublisherSubscribers(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 
@@ -82,10 +82,10 @@ func TestGETWATCH(t *testing.T) {
 
 func TestGETWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 
 	defer func() {
-		err := closePublisherSubscribersSDK(publisher, subscribers)
+		err := ClosePublisherSubscribersSDK(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 
@@ -121,10 +121,10 @@ func TestGETWATCHWithSDK(t *testing.T) {
 
 func TestGETWATCHWithSDK2(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 
 	defer func() {
-		err := closePublisherSubscribersSDK(publisher, subscribers)
+		err := ClosePublisherSubscribersSDK(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 

--- a/integration_tests/commands/resp/getwatch_test.go
+++ b/integration_tests/commands/resp/getwatch_test.go
@@ -5,17 +5,11 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/dicedb/dice/internal/clientio"
 	"github.com/dicedb/dicedb-go"
 	"github.com/stretchr/testify/assert"
 )
-
-type WatchSubscriber struct {
-	client *dicedb.Client
-	watch  *dicedb.WatchConn
-}
 
 const (
 	getWatchKey = "getwatchkey"
@@ -36,20 +30,13 @@ var getWatchTestCases = []getWatchTestCase{
 func TestGETWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
-	FireCommand(publisher, fmt.Sprintf("DEL %s", getWatchKey))
 
 	defer func() {
-		if err := publisher.Close(); err != nil {
-			t.Errorf("Error closing publisher connection: %v", err)
-		}
-		for _, sub := range subscribers {
-			//FireCommand(sub, fmt.Sprintf("GET.UNWATCH %s", fingerprint))
-			time.Sleep(100 * time.Millisecond)
-			if err := sub.Close(); err != nil {
-				t.Errorf("Error closing subscriber connection: %v", err)
-			}
-		}
+		err := closePublisherSubscribers(publisher, subscribers)
+		assert.Nil(t, err)
 	}()
+
+	FireCommand(publisher, fmt.Sprintf("DEL %s", getWatchKey))
 
 	// Fire a SET command to set a key
 	res := FireCommand(publisher, fmt.Sprintf("SET %s %s", getWatchKey, "value"))
@@ -88,11 +75,19 @@ func TestGETWATCH(t *testing.T) {
 			assert.Equal(t, tc.val, castedValue[2])
 		}
 	}
+
+	// unsubscribe from updates
+	unsubscribeFromUpdates(t, subscribers)
 }
 
 func TestGETWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+
+	defer func() {
+		err := closePublisherSubscribersSDK(publisher, subscribers)
+		assert.Nil(t, err)
+	}()
 
 	publisher.Del(context.Background(), getWatchKey)
 
@@ -119,11 +114,19 @@ func TestGETWATCHWithSDK(t *testing.T) {
 			assert.Equal(t, tc.val, v.Data.(string))     // data
 		}
 	}
+
+	// unsubscribe from updates
+	unsubscribeFromUpdatesSDK(t, subscribers)
 }
 
 func TestGETWATCHWithSDK2(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+
+	defer func() {
+		err := closePublisherSubscribersSDK(publisher, subscribers)
+		assert.Nil(t, err)
+	}()
 
 	publisher.Del(context.Background(), getWatchKey)
 
@@ -150,4 +153,7 @@ func TestGETWATCHWithSDK2(t *testing.T) {
 			assert.Equal(t, tc.val, v.Data.(string))     // data
 		}
 	}
+
+	// unsubscribe from updates
+	unsubscribeFromUpdatesSDK(t, subscribers)
 }

--- a/integration_tests/commands/resp/main_test.go
+++ b/integration_tests/commands/resp/main_test.go
@@ -21,15 +21,14 @@ func TestMain(m *testing.M) {
 	// Wait for the server to start
 	time.Sleep(2 * time.Second)
 
+	// Run the test suite
+	exitCode := m.Run()
+
 	conn := getLocalConnection()
 	if conn == nil {
 		panic("Failed to connect to the test server")
 	}
 	defer conn.Close()
-
-	// Run the test suite
-	exitCode := m.Run()
-
 	result := FireCommand(conn, "ABORT")
 	if result != "OK" {
 		panic("Failed to abort the server")

--- a/integration_tests/commands/resp/pfcountwatch_test.go
+++ b/integration_tests/commands/resp/pfcountwatch_test.go
@@ -50,7 +50,7 @@ func TestPFCOUNTWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := setupSubscribers(3)
 	defer func() {
-		err := closePublisherSubscribers(publisher, subscribers)
+		err := ClosePublisherSubscribers(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 
@@ -178,7 +178,7 @@ func TestPFCountWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
 	subscribers := setupSubscribersSDK(3)
 	defer func() {
-		err := closePublisherSubscribersSDK(publisher, subscribers)
+		err := ClosePublisherSubscribersSDK(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 
@@ -199,15 +199,15 @@ func TestPFCountWATCHWithSDK(t *testing.T) {
 	// TODO - unsubscribe from updates once PFCOUNT.UNWATCH is implemented
 }
 
-func setupSubscribersSDK(count int) []watchSubscriber {
-	subscribers := make([]watchSubscriber, count)
+func setupSubscribersSDK(count int) []WatchSubscriber {
+	subscribers := make([]WatchSubscriber, count)
 	for i := range subscribers {
 		subscribers[i].client = getLocalSdk()
 	}
 	return subscribers
 }
 
-func setUpWatchChannelsSDK(t *testing.T, ctx context.Context, subscribers []watchSubscriber) []<-chan *dicedb.WatchResult {
+func setUpWatchChannelsSDK(t *testing.T, ctx context.Context, subscribers []WatchSubscriber) []<-chan *dicedb.WatchResult {
 	channels := make([]<-chan *dicedb.WatchResult, len(subscribers))
 	for i, subscriber := range subscribers {
 		watch := subscriber.client.WatchConn(ctx)

--- a/integration_tests/commands/resp/pfcountwatch_test.go
+++ b/integration_tests/commands/resp/pfcountwatch_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dicedb/dice/internal/clientio"
 	dicedb "github.com/dicedb/dicedb-go"
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type pfcountWatchTestCase struct {
@@ -19,11 +19,11 @@ type pfcountWatchTestCase struct {
 }
 
 type pfcountWatchWithPFMergeTestCase struct {
-	destKey1    string
-	destValue1  []string
-	destKey2 	string
-	destValue2  []string
-	result 		int64
+	destKey1   string
+	destValue1 []string
+	destKey2   string
+	destValue2 []string
+	result     int64
 }
 
 const (
@@ -49,55 +49,49 @@ var pfcountWatchhWithPFMergeTestCases = []pfcountWatchWithPFMergeTestCase{
 func TestPFCOUNTWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := setupSubscribers(3)
+	defer func() {
+		err := closePublisherSubscribers(publisher, subscribers)
+		assert.Nil(t, err)
+	}()
 
 	FireCommand(publisher, fmt.Sprintf("DEL %s", pfcountWatchKey))
-
-	defer func() {
-		if err := publisher.Close(); err != nil {
-			t.Errorf("Error closing publisher connection: %v", err)
-		}
-		for _, sub := range subscribers {
-			time.Sleep(100 * time.Millisecond)
-			if err := sub.Close(); err != nil {
-				t.Errorf("Error closing subscriber connection: %v", err)
-			}
-		}
-	}()
 
 	res := FireCommand(publisher, fmt.Sprintf("PFADD %s %s", pfcountWatchKey, "randomvalue"))
 	assert.Equal(t, int64(1), res)
 
 	respParsers := setUpRespParsers(t, subscribers)
 
-	t.Run("Basic PFCount Operations", func(t *testing.T) { 
-			testPFCountAdd(t, publisher, respParsers)
-		},
+	t.Run("Basic PFCount Operations", func(t *testing.T) {
+		testPFCountAdd(t, publisher, respParsers)
+	},
 	)
 
-	t.Run("PFCount Operations including PFMerge", func(t *testing.T) { 
-			testPFCountMerge(t, publisher, respParsers)
-		},
+	t.Run("PFCount Operations including PFMerge", func(t *testing.T) {
+		testPFCountMerge(t, publisher, respParsers)
+	},
 	)
+
+	// TODO - unsubscribe from updates once PFCOUNT.UNWATCH is implemented
 }
 
 func setupSubscribers(count int) []net.Conn {
-    subscribers := make([]net.Conn, 0, count)
-    for i := 0; i < count; i++ {
-        conn := getLocalConnection()
-        subscribers = append(subscribers, conn)
-    }
-    return subscribers
+	subscribers := make([]net.Conn, 0, count)
+	for i := 0; i < count; i++ {
+		conn := getLocalConnection()
+		subscribers = append(subscribers, conn)
+	}
+	return subscribers
 }
 
 func setUpRespParsers(t *testing.T, subscribers []net.Conn) []*clientio.RESPParser {
 	respParsers := make([]*clientio.RESPParser, len(subscribers))
 	for i, subscriber := range subscribers {
 		rp := fireCommandAndGetRESPParser(subscriber, fmt.Sprintf(pfcountWatchQuery, pfcountWatchKey))
-		assert.Assert(t, rp != nil)
+		assert.NotNil(t, rp)
 		respParsers[i] = rp
 
 		v, err := rp.DecodeOne()
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 		castedValue, ok := v.([]interface{})
 		if !ok {
 			t.Errorf("Type assertion to []interface{} failed for value: %v", v)
@@ -111,7 +105,7 @@ func testPFCountAdd(t *testing.T, publisher net.Conn, respParsers []*clientio.RE
 	for _, tc := range pfcountWatchTestCases {
 		res := FireCommand(publisher, fmt.Sprintf("PFADD %s %s", tc.key, tc.val))
 		assert.Equal(t, int64(1), res)
-		
+
 		verifyWatchResults(t, respParsers, tc.result)
 	}
 }
@@ -122,7 +116,7 @@ func testPFCountMerge(t *testing.T, publisher net.Conn, respParsers []*clientio.
 		FireCommand(publisher, fmt.Sprintf("PFADD %s %s", tc.destKey1, tc.destValue1))
 		FireCommand(publisher, fmt.Sprintf("PFADD %s %s", tc.destKey2, tc.destValue2))
 		FireCommand(publisher, fmt.Sprintf("PFMERGE %s %s %s", pfcountWatchKey, tc.destKey1, tc.destKey2))
-		
+
 		verifyWatchResults(t, respParsers, tc.result)
 	}
 }
@@ -130,7 +124,7 @@ func testPFCountMerge(t *testing.T, publisher net.Conn, respParsers []*clientio.
 func verifyWatchResults(t *testing.T, respParsers []*clientio.RESPParser, expected int64) {
 	for _, rp := range respParsers {
 		v, err := rp.DecodeOne()
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 		castedValue, ok := v.([]interface{})
 		if !ok {
 			t.Errorf("Type assertion to []interface{} failed for value: %v", v)
@@ -138,7 +132,7 @@ func verifyWatchResults(t *testing.T, respParsers []*clientio.RESPParser, expect
 		assert.Equal(t, 3, len(castedValue))
 		assert.Equal(t, pfcountCommand, castedValue[0])
 		assert.Equal(t, pfcountWatchFingerPrint, castedValue[1])
-		assert.DeepEqual(t, expected, castedValue[2])
+		assert.Equal(t, int64(expected), castedValue[2])
 	}
 }
 
@@ -157,11 +151,11 @@ type pfcountWatchSDKTestCase struct {
 }
 
 type pfcountWatchSDKWithPFMergeTestCase struct {
-	destKey1    string
-	destValue1  []string
-	destKey2 	string
-	destValue2  []string
-	result 		int64
+	destKey1   string
+	destValue1 []string
+	destKey2   string
+	destValue2 []string
+	result     int64
 }
 
 var PFCountWatchSDKTestCases = []pfcountWatchSDKTestCase{
@@ -178,52 +172,49 @@ var pfcountWatchSDKhWithPFMergeTestCases = []pfcountWatchSDKWithPFMergeTestCase{
 }
 
 func TestPFCountWATCHWithSDK(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout) 
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
 	publisher := getLocalSdk()
 	subscribers := setupSubscribersSDK(3)
-	defer cleanupSubscribersSDK(subscribers)
+	defer func() {
+		err := closePublisherSubscribersSDK(publisher, subscribers)
+		assert.Nil(t, err)
+	}()
 
 	publisher.Del(ctx, pfcountWatchKey)
 
 	channels := setUpWatchChannelsSDK(t, ctx, subscribers)
 
-	t.Run("Basic PFCount Operations", func(t *testing.T) { 
-			testPFCountAddSDK(t, ctx, channels, publisher) 
-		},
+	t.Run("Basic PFCount Operations", func(t *testing.T) {
+		testPFCountAddSDK(t, ctx, channels, publisher)
+	},
 	)
 
-	t.Run("PFCount Operations including PFMerge", func(t *testing.T) { 
-			testPFCountMergeSDK(t, ctx, channels, publisher) 
-		},
+	t.Run("PFCount Operations including PFMerge", func(t *testing.T) {
+		testPFCountMergeSDK(t, ctx, channels, publisher)
+	},
 	)
+
+	// TODO - unsubscribe from updates once PFCOUNT.UNWATCH is implemented
 }
 
-func setupSubscribersSDK(count int) []WatchSubscriber { 
-	subscribers := make([]WatchSubscriber, count) 
-	for i := range subscribers { 
+func setupSubscribersSDK(count int) []watchSubscriber {
+	subscribers := make([]watchSubscriber, count)
+	for i := range subscribers {
 		subscribers[i].client = getLocalSdk()
-	} 
-	return subscribers 
+	}
+	return subscribers
 }
 
-func cleanupSubscribersSDK(subscribers []WatchSubscriber) { 
-	for _, sub := range subscribers { 
-		if sub.watch != nil { 
-			sub.watch.Close() 
-		} 
-	} 
-}
-
-func setUpWatchChannelsSDK(t *testing.T, ctx context.Context, subscribers []WatchSubscriber) []<-chan *dicedb.WatchResult {
+func setUpWatchChannelsSDK(t *testing.T, ctx context.Context, subscribers []watchSubscriber) []<-chan *dicedb.WatchResult {
 	channels := make([]<-chan *dicedb.WatchResult, len(subscribers))
 	for i, subscriber := range subscribers {
 		watch := subscriber.client.WatchConn(ctx)
 		subscribers[i].watch = watch
-		assert.Assert(t, watch != nil)
+		assert.NotNil(t, watch)
 		firstMsg, err := watch.Watch(ctx, pfcountCommandSDK, pfcountWatchKey)
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 		assert.Equal(t, firstMsg.Command, pfcountCommandSDK)
 		channels[i] = watch.Channel()
 	}
@@ -233,7 +224,7 @@ func setUpWatchChannelsSDK(t *testing.T, ctx context.Context, subscribers []Watc
 func testPFCountAddSDK(t *testing.T, ctx context.Context, channels []<-chan *dicedb.WatchResult, publisher *dicedb.Client) {
 	for _, tc := range PFCountWatchSDKTestCases {
 		err := publisher.PFAdd(ctx, tc.key, tc.val).Err()
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 
 		verifyWatchResultsSDK(t, channels, tc.result)
 	}
@@ -253,12 +244,12 @@ func testPFCountMergeSDK(t *testing.T, ctx context.Context, channels []<-chan *d
 func verifyWatchResultsSDK(t *testing.T, channels []<-chan *dicedb.WatchResult, expected int64) {
 	for _, channel := range channels {
 		select {
-			case v := <-channel:
-				assert.Equal(t, pfcountCommandSDK, v.Command)         // command
-				assert.Equal(t, pfcountWatchFingerPrint, v.Fingerprint) // Fingerprint
-				assert.DeepEqual(t, expected, v.Data)       // data
-			case <-time.After(defaultTimeout):
-				t.Fatal("timeout waiting for watch result")
+		case v := <-channel:
+			assert.Equal(t, pfcountCommandSDK, v.Command)           // command
+			assert.Equal(t, pfcountWatchFingerPrint, v.Fingerprint) // Fingerprint
+			assert.Equal(t, int64(expected), v.Data)                // data
+		case <-time.After(defaultTimeout):
+			t.Fatal("timeout waiting for watch result")
 		}
 	}
 }

--- a/integration_tests/commands/resp/set_data_cmd_test.go
+++ b/integration_tests/commands/resp/set_data_cmd_test.go
@@ -1,10 +1,11 @@
 package resp
 
 import (
-	"gotest.tools/v3/assert"
 	"sort"
 	"testing"
 	"time"
+
+	"gotest.tools/v3/assert"
 )
 
 func CustomDeepEqual(t *testing.T, a, b interface{}) {

--- a/integration_tests/commands/resp/set_test.go
+++ b/integration_tests/commands/resp/set_test.go
@@ -51,8 +51,8 @@ func TestSet(t *testing.T) {
 
 func TestSetWithOptions(t *testing.T) {
 	conn := getLocalConnection()
-	expiryTime := strconv.FormatInt(time.Now().Add(1*time.Minute).UnixMilli(), 10)
 	defer conn.Close()
+	expiryTime := strconv.FormatInt(time.Now().Add(1*time.Minute).UnixMilli(), 10)
 
 	testCases := []TestCase{
 		{
@@ -193,8 +193,8 @@ func TestSetWithExat(t *testing.T) {
 
 func TestWithKeepTTLFlag(t *testing.T) {
 	conn := getLocalConnection()
-	expiryTime := strconv.FormatInt(time.Now().Add(1*time.Minute).UnixMilli(), 10)
 	defer conn.Close()
+	expiryTime := strconv.FormatInt(time.Now().Add(1*time.Minute).UnixMilli(), 10)
 
 	for _, tcase := range []TestCase{
 		{

--- a/integration_tests/commands/resp/setup.go
+++ b/integration_tests/commands/resp/setup.go
@@ -40,7 +40,7 @@ func getLocalConnection() net.Conn {
 	return conn
 }
 
-func closePublisherSubscribers(publisher net.Conn, subscribers []net.Conn) error {
+func ClosePublisherSubscribers(publisher net.Conn, subscribers []net.Conn) error {
 	if err := publisher.Close(); err != nil {
 		return fmt.Errorf("error closing publisher connection: %v", err)
 	}
@@ -80,12 +80,12 @@ func getLocalSdk() *dicedb.Client {
 	})
 }
 
-type watchSubscriber struct {
+type WatchSubscriber struct {
 	client *dicedb.Client
 	watch  *dicedb.WatchConn
 }
 
-func closePublisherSubscribersSDK(publisher *dicedb.Client, subscribers []watchSubscriber) error {
+func ClosePublisherSubscribersSDK(publisher *dicedb.Client, subscribers []WatchSubscriber) error {
 	if err := publisher.Close(); err != nil {
 		return fmt.Errorf("error closing publisher connection: %v", err)
 	}

--- a/integration_tests/commands/resp/zrangewatch_test.go
+++ b/integration_tests/commands/resp/zrangewatch_test.go
@@ -3,12 +3,12 @@ package resp
 import (
 	"context"
 	"fmt"
-	"github.com/dicedb/dice/internal/clientio"
-	dicedb "github.com/dicedb/dicedb-go"
-	"gotest.tools/v3/assert"
 	"net"
 	"testing"
-	"time"
+
+	"github.com/dicedb/dice/internal/clientio"
+	dicedb "github.com/dicedb/dicedb-go"
+	"github.com/stretchr/testify/assert"
 )
 
 type zrangeWatchTestCase struct {
@@ -33,29 +33,21 @@ var zrangeWatchTestCases = []zrangeWatchTestCase{
 func TestZRANGEWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
+	defer func() {
+		err := closePublisherSubscribers(publisher, subscribers)
+		assert.Nil(t, err)
+	}()
 
 	FireCommand(publisher, fmt.Sprintf("DEL %s", zrangeWatchKey))
-
-	defer func() {
-		if err := publisher.Close(); err != nil {
-			t.Errorf("Error closing publisher connection: %v", err)
-		}
-		for _, sub := range subscribers {
-			time.Sleep(100 * time.Millisecond)
-			if err := sub.Close(); err != nil {
-				t.Errorf("Error closing subscriber connection: %v", err)
-			}
-		}
-	}()
 
 	respParsers := make([]*clientio.RESPParser, len(subscribers))
 	for i, subscriber := range subscribers {
 		rp := fireCommandAndGetRESPParser(subscriber, fmt.Sprintf(zrangeWatchQuery, zrangeWatchKey))
-		assert.Assert(t, rp != nil)
+		assert.NotNil(t, rp)
 		respParsers[i] = rp
 
 		v, err := rp.DecodeOne()
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 		castedValue, ok := v.([]interface{})
 		if !ok {
 			t.Errorf("Type assertion to []interface{} failed for value: %v", v)
@@ -69,7 +61,7 @@ func TestZRANGEWATCH(t *testing.T) {
 
 		for _, rp := range respParsers {
 			v, err := rp.DecodeOne()
-			assert.NilError(t, err)
+			assert.Nil(t, err)
 			castedValue, ok := v.([]interface{})
 			if !ok {
 				t.Errorf("Type assertion to []interface{} failed for value: %v", v)
@@ -77,9 +69,11 @@ func TestZRANGEWATCH(t *testing.T) {
 			assert.Equal(t, 3, len(castedValue))
 			assert.Equal(t, "ZRANGE", castedValue[0])
 			assert.Equal(t, "1178068413", castedValue[1])
-			assert.DeepEqual(t, tc.result, castedValue[2])
+			assert.Equal(t, tc.result, castedValue[2])
 		}
 	}
+
+	// TODO - unsubscribe from updates once ZRANGE.UNWATCH is implemented
 }
 
 type zrangeWatchSDKTestCase struct {
@@ -112,7 +106,11 @@ var zrangeWatchSDKTestCases = []zrangeWatchSDKTestCase{
 
 func TestZRANGEWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	defer func() {
+		err := closePublisherSubscribersSDK(publisher, subscribers)
+		assert.Nil(t, err)
+	}()
 
 	publisher.Del(context.Background(), zrangeWatchKey)
 
@@ -120,9 +118,9 @@ func TestZRANGEWATCHWithSDK(t *testing.T) {
 	for i, subscriber := range subscribers {
 		watch := subscriber.client.WatchConn(context.Background())
 		subscribers[i].watch = watch
-		assert.Assert(t, watch != nil)
+		assert.NotNil(t, watch)
 		firstMsg, err := watch.Watch(context.Background(), "ZRANGE", zrangeWatchKey, "0", "-1", "REV", "WITHSCORES")
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 		assert.Equal(t, firstMsg.Command, "ZRANGE")
 		assert.Equal(t, firstMsg.Fingerprint, "1178068413")
 		channels[i] = watch.Channel()
@@ -133,21 +131,27 @@ func TestZRANGEWATCHWithSDK(t *testing.T) {
 			Score:  tc.score,
 			Member: tc.val,
 		}).Err()
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 
 		for _, channel := range channels {
 			v := <-channel
 
 			assert.Equal(t, "ZRANGE", v.Command)         // command
 			assert.Equal(t, "1178068413", v.Fingerprint) // Fingerprint
-			assert.DeepEqual(t, tc.result, v.Data)       // data
+			assert.Equal(t, tc.result, v.Data)           // data
 		}
 	}
+
+	// TODO - unsubscribe from updates once ZRANGE.UNWATCH is implemented
 }
 
 func TestZRANGEWATCHWithSDK2(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	defer func() {
+		err := closePublisherSubscribersSDK(publisher, subscribers)
+		assert.Nil(t, err)
+	}()
 
 	publisher.Del(context.Background(), zrangeWatchKey)
 
@@ -156,7 +160,7 @@ func TestZRANGEWATCHWithSDK2(t *testing.T) {
 		conn := subscribers[i].client.WatchConn(context.Background())
 		subscribers[i].watch = conn
 		firstMsg, err := conn.ZRangeWatch(context.Background(), zrangeWatchKey, "0", "-1", "REV", "WITHSCORES")
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 		assert.Equal(t, firstMsg.Command, "ZRANGE")
 		assert.Equal(t, firstMsg.Fingerprint, "1178068413")
 		channels[i] = conn.Channel()
@@ -167,14 +171,16 @@ func TestZRANGEWATCHWithSDK2(t *testing.T) {
 			Score:  tc.score,
 			Member: tc.val,
 		}).Err()
-		assert.NilError(t, err)
+		assert.Nil(t, err)
 
 		for _, channel := range channels {
 			v := <-channel
 
 			assert.Equal(t, "ZRANGE", v.Command)
 			assert.Equal(t, "1178068413", v.Fingerprint)
-			assert.DeepEqual(t, tc.result, v.Data)
+			assert.Equal(t, tc.result, v.Data)
 		}
 	}
+
+	// TODO - unsubscribe from updates once ZRANGE.UNWATCH is implemented
 }

--- a/integration_tests/commands/resp/zrangewatch_test.go
+++ b/integration_tests/commands/resp/zrangewatch_test.go
@@ -34,7 +34,7 @@ func TestZRANGEWATCH(t *testing.T) {
 	publisher := getLocalConnection()
 	subscribers := []net.Conn{getLocalConnection(), getLocalConnection(), getLocalConnection()}
 	defer func() {
-		err := closePublisherSubscribers(publisher, subscribers)
+		err := ClosePublisherSubscribers(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 
@@ -106,9 +106,9 @@ var zrangeWatchSDKTestCases = []zrangeWatchSDKTestCase{
 
 func TestZRANGEWATCHWithSDK(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 	defer func() {
-		err := closePublisherSubscribersSDK(publisher, subscribers)
+		err := ClosePublisherSubscribersSDK(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 
@@ -147,9 +147,9 @@ func TestZRANGEWATCHWithSDK(t *testing.T) {
 
 func TestZRANGEWATCHWithSDK2(t *testing.T) {
 	publisher := getLocalSdk()
-	subscribers := []watchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
+	subscribers := []WatchSubscriber{{client: getLocalSdk()}, {client: getLocalSdk()}, {client: getLocalSdk()}}
 	defer func() {
-		err := closePublisherSubscribersSDK(publisher, subscribers)
+		err := ClosePublisherSubscribersSDK(publisher, subscribers)
 		assert.Nil(t, err)
 	}()
 

--- a/integration_tests/commands/resp/zset_test.go
+++ b/integration_tests/commands/resp/zset_test.go
@@ -597,8 +597,6 @@ func TestZRANGE(t *testing.T) {
 	conn := getLocalConnection()
 	defer conn.Close()
 
-	print("In zrange")
-
 	testCases := []TestCase{
 		{
 			name:     "ZRANGE with mixed indices",

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -85,7 +85,7 @@ func (w *BaseWorker) Start(ctx context.Context) error {
 	go func() {
 		for {
 			data, err := w.ioHandler.Read(ctx)
-			if err != nil || len(data) == 0 {
+			if err != nil {
 				select {
 				case readErrChan <- err:
 					return

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -85,7 +85,7 @@ func (w *BaseWorker) Start(ctx context.Context) error {
 	go func() {
 		for {
 			data, err := w.ioHandler.Read(ctx)
-			if err != nil || string(data) == "" {
+			if err != nil || len(data) == 0 {
 				select {
 				case readErrChan <- err:
 					return


### PR DESCRIPTION
This PR fixes a bunch of issues.

First, it fixes goroutine leaks in worker by adding a ctx ub child goroutine to exit if parent is exits. See #1297 for more details.

Second, there were additional goroutine leaks because of `initHealthCheck` goroutine (`watch_connection.go`) in SDK. This was because `WatchConn` was not closed in any of the tests, only `Clients` were closed. `WatchConn.Close()` sends closing signal to this goroutine. This is fixed by making helper functions `ClosePublisherSubscribers`  and `ClosePublisherSubscribersSDK` which close it properly and make is easier for other developers to not worry about it going forward.

Third, none of the tests unsubscribe as part of cleanup. Hence, watch manager keeps sending updates to buffered channel `AdhocChannel` which has a configured capacity of 20. At some point, it is filled and new watch tests keep on waiting on this channel. This is fixed for GET.WATCH and GET.UNWATCH tests by adding helper functions `unsubscribeFromUpdates` and `unsubscribeFromUpdatesSDK` which sets the right cleanup convention for other devs.

This is not fixed for PFCOUNT.WATCH and ZRANGE.WATCH tests as their unwatch functionality is still not implemented. TODO has been added in the respective places.

This PR also makes a few minor changes like acquiring connection in `TestMain` just before firing `ABORT` command, migrating testing library to testify/assert, etc.

Fixes #1297 