### PR TITLE
Adding /docs for dicedb.io website

### DIFF
--- a/docs/src/pages/docs.astro
+++ b/docs/src/pages/docs.astro
@@ -1,0 +1,14 @@
+---
+// src/pages/docs.astro
+---
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=/get-started/installation" />
+    <link rel="canonical" href="/get-started/installation" />
+</head>
+<body>
+<p>
+    If you are not redirected automatically, follow this <a href="/get-started/installation">link for docs</a>.
+</p>
+</body>
+</html>


### PR DESCRIPTION
- Adds dicedb.io/docs link
- It's a redirect to dicedb.io/get-started/installation
![image](https://github.com/user-attachments/assets/55326c0c-bc56-468b-87ef-5df9b78a7d48)
