### PR TITLE
fixed makefile and removed outdated content from readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# Adapted from https://www.thapaliya.com/en/writings/well-documented-makefiles/
+
 THREADS ?= 4 #number of threads
 CLIENTS ?= 50 #number of clients per thread
 REQUESTS ?= 10000 #number of requests per client

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,6 @@ unittest: ## run the unit tests
 unittest-one: ## run a single unit test function by name (e.g. make unittest-one TEST_FUNC=TestSetGet)
 	go test -v -race -count=1 --run $(TEST_FUNC) ./internal/...
 
-release: ## build and push the Docker image to Docker Hub with the latest tag and the version tag
-	git tag $(VERSION)
-	git push origin --tags
-	docker build --tag dicedb/dicedb:latest --tag dicedb/dicedb:$(VERSION) .
-	docker push dicedb/dicedb:$(VERSION)
-	docker push dicedb/dicedb:latest
-
 ##@ Benchmarking
 
 run_benchmark: ## run the memtier benchmark with the specified parameters
@@ -97,3 +90,12 @@ clean: ## clean the dicedb binary
 	@echo "Cleaning build artifacts..."
 	rm -f dicedb
 	@echo "Clean complete."
+
+##@ Deployment
+
+release: ## build and push the Docker image to Docker Hub with the latest tag and the version tag
+	git tag $(VERSION)
+	git push origin --tags
+	docker build --tag dicedb/dicedb:latest --tag dicedb/dicedb:$(VERSION) .
+	docker push dicedb/dicedb:$(VERSION)
+	docker push dicedb/dicedb:latest

--- a/README.md
+++ b/README.md
@@ -105,19 +105,6 @@ By default, DiceDB will look for the configuration file at `./dicedb.conf`. (Lin
 
 > [!TIP]
 > If you want to use a custom configuration file, you can specify the path using the `-c` flag. and to output the configuration file to a specific location, you can specify the output dir path using the `-o` flag.
-#### Additional Configuration Options:
-
-If you'd like to use a different location, you can specify a custom configuration file path with the `-c flag`:
-
-```bash
-go run main.go -c /path/to/config.toml
-```
-If you'd like to output the configuration file to a specific location, you can specify a custom output path with the `-o flag`:
-
-```bash
-go run main.go -o /path/of/output/dir
-```
-
 
 ### Setting up CLI
 


### PR DESCRIPTION
- Added a reference guide on well-documented Makefiles.
- Moved the `release` target to a new `Deployment` section for better organization.
- removed outdated readme content