### PR TITLE
#1207 Fix redis-cli connect error

### DIFF
--- a/integration_tests/commands/resp/command_docs_test.go
+++ b/integration_tests/commands/resp/command_docs_test.go
@@ -7,10 +7,12 @@ import (
 )
 
 var getDocsTestCases = []struct {
-	name     string
-	inCmd    string
-	expected interface{}
+	name              string
+	inCmd             string
+	expected          interface{}
+	skipExpectedMatch bool
 }{
+	{"Without any commands", "", []any{}, true},
 	{"Set command", "SET", []interface{}{[]interface{}{
 		"set",
 		[]interface{}{
@@ -21,7 +23,7 @@ var getDocsTestCases = []struct {
 			"lastIndex", int64(0),
 			"step", int64(0),
 		},
-	}}},
+	}}, false},
 	{"Get command", "GET", []interface{}{[]interface{}{
 		"get",
 		[]interface{}{
@@ -32,7 +34,7 @@ var getDocsTestCases = []struct {
 			"lastIndex", int64(0),
 			"step", int64(0),
 		},
-	}}},
+	}}, false},
 	{"Ping command", "PING", []interface{}{[]interface{}{
 		"ping",
 		[]interface{}{
@@ -43,9 +45,10 @@ var getDocsTestCases = []struct {
 			"lastIndex", int64(0),
 			"step", int64(0),
 		},
-	}}},
+	}}, false},
 	{"Invalid command", "INVALID_CMD",
 		[]any{},
+		false,
 	},
 	{"Combination of valid and Invalid command", "SET INVALID_CMD", []interface{}{[]interface{}{
 		"set",
@@ -56,7 +59,7 @@ var getDocsTestCases = []struct {
 			"beginIndex", int64(1),
 			"lastIndex", int64(0),
 			"step", int64(0),
-		}}}},
+		}}}, false},
 	{"Combination of multiple valid commands", "SET GET", []interface{}{[]interface{}{
 		"set",
 		[]interface{}{
@@ -76,7 +79,7 @@ var getDocsTestCases = []struct {
 				"lastIndex", int64(0),
 				"step", int64(0),
 			},
-		}}},
+		}}, false},
 }
 
 func TestCommandDocs(t *testing.T) {
@@ -86,7 +89,14 @@ func TestCommandDocs(t *testing.T) {
 	for _, tc := range getDocsTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := FireCommand(conn, "COMMAND DOCS "+tc.inCmd)
-			assert.Equal(t, tc.expected, result)
+			if !tc.skipExpectedMatch {
+				assert.Equal(t, tc.expected, result)
+			} else {
+				assert.NotNil(t, result)
+				_, ok := result.([]interface{})
+				assert.True(t, ok)
+				assert.True(t, len(result.([]interface{})) > 0)
+			}
 		})
 	}
 }

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -1614,8 +1614,13 @@ func convertCmdMetaToDocs(cmdMeta *DiceCmdMeta) []interface{} {
 // Function to convert map[string]DiceCmdMeta{} to []interface{}
 func convertDiceCmdsMapToDocs() []interface{} {
 	var result []interface{}
+	// TODO: Add other keys supported as part of COMMAND DOCS, currently only
+	// command name and summary supported. This would required adding more metadata to supported commands
 	for _, cmdMeta := range DiceCmds {
-		result = append(result, convertCmdMetaToDocs(&cmdMeta))
+		result = append(result, strings.ToLower(cmdMeta.Name))
+		subResult := []interface{}{"summary", cmdMeta.Info}
+		result = append(result, subResult)
 	}
+
 	return result
 }


### PR DESCRIPTION
Issue:
- `redis-cli` expects `COMMAND DOCS` response to be in a particular [structure](https://redis.io/docs/latest/commands/command-docs/)

Fix:
- Modified `COMMAND DOCS` to be in sync with the expected format. We'd need to add more metadata to commands to support all the keys as part of commands mapped reply.

Output with redis-cli:
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/9a754a97-38e6-4b46-b4f7-7d22645b7f4e">
