### PR TITLE
Fix to adhere enable persistence flag when passed as program args

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -256,7 +256,7 @@ func MergeFlags(flags *Config) {
 			DiceConfig.Logging.LogLevel = flags.Logging.LogLevel
 		case "log-dir":
 			DiceConfig.Logging.LogDir = flags.Logging.LogDir
-		case "persistence-enable":
+		case "enable-persistence":
 			DiceConfig.Persistence.Enabled = flags.Persistence.Enabled
 		case "restore-from-wal":
 			DiceConfig.Persistence.RestoreFromWAL = flags.Persistence.RestoreFromWAL

--- a/integration_tests/config/parser_test.go
+++ b/integration_tests/config/parser_test.go
@@ -73,7 +73,6 @@ type persistence struct {
 	AOFFile            string `config:"aof_file" default:"./dice-master.aof" validate:"filepath"`
 	PersistenceEnabled bool   `config:"persistence_enabled" default:"true"`
 	WriteAOFOnCleanup  bool   `config:"write_aof_on_cleanup" default:"false"`
-	EnableWAL          bool   `config:"enable-wal" default:"false"`
 	WALDir             string `config:"wal-dir" default:"./" validate:"dirpath"`
 	RestoreFromWAL     bool   `config:"restore-wal" default:"false"`
 	WALEngine          string `config:"wal-engine" default:"aof" validate:"oneof=sqlite aof"`

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -87,7 +87,7 @@ func Execute() {
 	flag.StringVar(&flagsConfig.Logging.LogLevel, "log-level", "info", "log level, values: info, debug")
 	flag.StringVar(&config.DiceConfig.Logging.LogDir, "log-dir", "/tmp/dicedb", "log directory path")
 
-	flag.BoolVar(&flagsConfig.Persistence.Enabled, "persistence-enable", false, "enable write-ahead logging")
+	flag.BoolVar(&flagsConfig.Persistence.Enabled, "enable-persistence", false, "enable write-ahead logging")
 	flag.BoolVar(&flagsConfig.Persistence.RestoreFromWAL, "restore-wal", false, "restore the database from the WAL files")
 	flag.StringVar(&flagsConfig.Persistence.WALEngine, "wal-engine", "null", "wal engine to use, values: sqlite, aof")
 
@@ -124,7 +124,7 @@ func Execute() {
 		fmt.Println("  -enable-profiling      Enable profiling and capture critical metrics and traces in .prof files (default: false)")
 		fmt.Println("  -log-level             Log level, values: info, debug (default: \"info\")")
 		fmt.Println("  -log-dir               Log directory path (default: \"/tmp/dicedb\")")
-		fmt.Println("  -enable-wal            Enable write-ahead logging (default: false)")
+		fmt.Println("  -enable-persistence    Enable write-ahead logging (default: false)")
 		fmt.Println("  -restore-wal           Restore the database from the WAL files (default: false)")
 		fmt.Println("  -wal-engine            WAL engine to use, values: sqlite, aof (default: \"null\")")
 		fmt.Println("  -requirepass           Enable authentication for the default user (default: \"\")")


### PR DESCRIPTION
Issue:
- `enable-wal` flag is not adhered/used anywhere hence passing that doesn't affect persistence config.

Fix:
- Replaced `enable-wal` with `enable-persistence`(already present config)

Output:
```
❯ go run main.go  --enable-persistence=false
2024-11-22T11:41:17+05:30 INF Field Logging.LogDir failed validation: dirpath
2024-11-22T11:41:17+05:30 INF Setting default value for Logging.LogDir to: /tmp/dicedb

        ██████╗ ██╗ ██████╗███████╗██████╗ ██████╗ 
        ██╔══██╗██║██╔════╝██╔════╝██╔══██╗██╔══██╗
        ██║  ██║██║██║     █████╗  ██║  ██║██████╔╝
        ██║  ██║██║██║     ██╔══╝  ██║  ██║██╔══██╗
        ██████╔╝██║╚██████╗███████╗██████╔╝██████╔╝
        ╚═════╝ ╚═╝ ╚═════╝╚══════╝╚═════╝ ╚═════╝
                        
2024-11-22T11:41:17+05:30 INF starting DiceDB version=0.1.0
2024-11-22T11:41:17+05:30 INF running with port=7379
2024-11-22T11:41:17+05:30 INF running with cores=12
2024-11-22T11:41:17+05:30 INF running with shards=12
2024-11-22T11:41:17+05:30 INF running with watch=false
2024-11-22T11:41:17+05:30 INF running with profiling=false
2024-11-22T11:41:17+05:30 INF running with persistence=false
```