### PR TITLE
#1250: Add support for GEORADIUS

### DIFF
--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -1321,6 +1321,14 @@ var (
 		NewEval:    evalGEODIST,
 		KeySpecs:   KeySpecs{BeginIndex: 1},
 	}
+	geoRadiusCmdMeta = DiceCmdMeta{
+		Name:       "GEORADIUS",
+		Info:       `Returns members of a sorted set with geospatial data that lie within a specified radius from a given center location.`,
+		Arity:      -5,
+		IsMigrated: true,
+		NewEval:    evalGEORADIUS,
+		KeySpecs:   KeySpecs{BeginIndex: 1},
+	}
 	jsonstrappendCmdMeta = DiceCmdMeta{
 		Name: "JSON.STRAPPEND",
 		Info: `JSON.STRAPPEND key [path] value

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -6366,7 +6366,7 @@ func evalGEORADIUS(args []string, store *dstore.Store) *EvalResponse {
 		}
 	}
 	unit := strings.ToUpper(args[4])
-	if unit != "M" || unit != "KM" || unit != "MI" || unit != "FT" {
+	if unit != "M" && unit != "KM" && unit != "MI" && unit != "FT" {
 		return &EvalResponse{
 			Result: nil,
 			Error:  diceerrors.ErrGeneral("unsupported unit provided. please use M, KM, FT, MI"),


### PR DESCRIPTION
Adds support for [GEORADIUS](https://redis.io/docs/latest/commands/georadius/)

PR Checklist
- [ ] Command parser
- [ ] Eval Implementation
- [ ] Unit Test
- [ ] Integration Test
- [ ] Documentation

Closes #1250 
