### PR TITLE
#446: Implement Dense representation for HLL once a threshold is reached

### DIFF
--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -4711,6 +4711,29 @@ func BenchmarkEvalHKEYS(b *testing.B) {
 	}
 }
 
+func BenchmarkEvalPFADD(b *testing.B) {
+	sizes := []int{0, 10, 100, 1000, 10000, 100000}
+	store := *dstore.NewStore(nil, nil, nil)
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("PFAddSize_%d", size), func(b *testing.B) {
+			key := fmt.Sprintf("benchmark_pfadd_%d", size)
+
+			args := []string{key}
+			for i := range size {
+				args = append(args, fmt.Sprintf("pf_item_%d", i))
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_ = evalPFADD(args, &store)
+			}
+		})
+	}
+}
+
 func BenchmarkEvalPFCOUNT(b *testing.B) {
 	store := *dstore.NewStore(nil, nil, nil)
 


### PR DESCRIPTION
Added Benchmarks for PFADD.

Benchmarks with the current Sparse Representation in PFADD
```
goos: darwin
goarch: arm64
pkg: github.com/dicedb/dice/internal/eval
cpu: Apple M1 Pro
BenchmarkEvalPFADD/PFAddSize_0-8         	 3737166	       317.1 ns/op	      80 B/op	       3 allocs/op
BenchmarkEvalPFADD/PFAddSize_10-8        	  628004	      1892 ns/op	     665 B/op	      22 allocs/op
BenchmarkEvalPFADD/PFAddSize_100-8       	   64923	     18592 ns/op	    4850 B/op	     125 allocs/op
BenchmarkEvalPFADD/PFAddSize_1000-8      	    3874	    303253 ns/op	   68278 B/op	    1177 allocs/op
BenchmarkEvalPFADD/PFAddSize_10000-8     	    1576	    757984 ns/op	  160080 B/op	   10003 allocs/op
BenchmarkEvalPFADD/PFAddSize_100000-8    	     306	   3911595 ns/op	 1600081 B/op	  100003 allocs/op
PASS
ok  	github.com/dicedb/dice/internal/eval	8.562s
```

Fixes: #446 