### PR TITLE
ci: #1346 Add support for building on multiple architectures

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -41,6 +41,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha # This tells Buildx to attempt to use the GitHub Actions cache
           cache-to: type=gha,mode=max # This stores the generated cache in the GitHub Actions cache
 


### PR DESCRIPTION
This commit updates the workflow to build and push Docker images for both linux/amd64 and linux/arm64 architectures. This enables users to choose the appropriate image based on their needs.

Closes: #1346