### PR TITLE
Remove --enable-multithreading flag usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Although DiceDB is a drop-in replacement of Redis, which means almost no learnin
 The easiest way to get started with DiceDB is using [Docker](https://www.docker.com/) by running the following command.
 
 ```bash
-docker run -p 7379:7379 dicedb/dicedb --enable-multithreading --enable-watch
+docker run -p 7379:7379 dicedb/dicedb --enable-watch
 ```
 
 The above command will start the DiceDB server running locally on the port `7379` and you can connect
@@ -60,10 +60,10 @@ To run DiceDB for local development or running from source, you will need
 ```bash
 git clone https://github.com/dicedb/dice
 cd dice
-go run main.go --enable-multithreading --enable-watch
+go run main.go --enable-watch
 ```
 
-You can skip passing the two flags if you are not working with multi-threading or `.WATCH` features.
+You can skip passing the flag if you are not working with `.WATCH` feature.
 
 1. Install GoLangCI
 

--- a/docs/src/content/docs/get-started/installation.mdx
+++ b/docs/src/content/docs/get-started/installation.mdx
@@ -16,7 +16,7 @@ We are looking for Early Design Partners, so, if you want to evaluate DiceDB, [b
 The easiest way to get started with DiceDB is using [Docker](https://www.docker.com/) by running the following command.
 
 ```bash
-docker run -p 7379:7379 dicedb/dicedb --enable-multithreading --enable-watch
+docker run -p 7379:7379 dicedb/dicedb --enable-watch
 ```
 
 The above command will start the DiceDB server running locally on the port `7379` and you can connect

--- a/docs/src/content/docs/get-started/reactive-hello-world.mdx
+++ b/docs/src/content/docs/get-started/reactive-hello-world.mdx
@@ -15,12 +15,12 @@ But, before we start, make sure you have
 
 ### Starting DiceDB
 
-Start the DiceDB server with the two flags `--enable-multithreading` and `--enable-watch`
-to enable multi-threading and watch mode, respectively. Your command would look something
+Start the DiceDB server with the flag `--enable-watch`
+to enable watch mode. Your command would look something
 like this
 
 ```bash
-docker run -p 7379:7379 dicedb/dicedb --enable-multithreading --enable-watch
+docker run -p 7379:7379 dicedb/dicedb --enable-watch
 ```
 
 Also, connect to the database using the CLI as mentioned in the above installation steps or


### PR DESCRIPTION
Issue
```
$ go run main.go --enable-multithreading --enable-watch
flag provided but not defined: -enable-multithreading
```

-enable-multithreading flag is removed.
https://github.com/DiceDB/dice/pull/1318/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17
`Multithreading is enabled by default`