### PR TITLE
fix: modify the config default value keep consistency

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -49,7 +49,7 @@ func printConfiguration() {
 	// Add whether the watch feature is enabled
 	slog.Info("running with", slog.Bool("profiling", config.DiceConfig.Performance.EnableProfiling))
 
-	// Add whether the watch feature is enabled
+	// Add whether the persistence feature is enabled
 	slog.Info("running with", slog.Bool("persistence", config.DiceConfig.Persistence.Enabled))
 }
 
@@ -73,10 +73,10 @@ func Execute() {
 
 	flag.IntVar(&flagsConfig.RespServer.Port, "port", 7379, "port for the DiceDB server")
 
-	flag.IntVar(&flagsConfig.HTTP.Port, "http-port", 7380, "port for accepting requets over HTTP")
+	flag.IntVar(&flagsConfig.HTTP.Port, "http-port", 8082, "port for accepting requets over HTTP")
 	flag.BoolVar(&flagsConfig.HTTP.Enabled, "enable-http", false, "enable DiceDB to listen, accept, and process HTTP")
 
-	flag.IntVar(&flagsConfig.WebSocket.Port, "websocket-port", 7381, "port for accepting requets over WebSocket")
+	flag.IntVar(&flagsConfig.WebSocket.Port, "websocket-port", 8379, "port for accepting requets over WebSocket")
 	flag.BoolVar(&flagsConfig.WebSocket.Enabled, "enable-websocket", false, "enable DiceDB to listen, accept, and process WebSocket")
 
 	flag.IntVar(&flagsConfig.Performance.NumShards, "num-shards", -1, "number shards to create. defaults to number of cores")
@@ -98,7 +98,7 @@ func Execute() {
 	flag.IntVar(&flagsConfig.Memory.KeysLimit, "keys-limit", config.DefaultKeysLimit, "keys limit for the DiceDB server. "+
 		"This flag controls the number of keys each shard holds at startup. You can multiply this number with the "+
 		"total number of shard threads to estimate how much memory will be required at system start up.")
-	flag.Float64Var(&flagsConfig.Memory.EvictionRatio, "eviction-ratio", 0.1, "ratio of keys to evict when the "+
+	flag.Float64Var(&flagsConfig.Memory.EvictionRatio, "eviction-ratio", 0.9, "ratio of keys to evict when the "+
 		"keys limit is reached")
 
 	flag.Usage = func() {
@@ -115,9 +115,9 @@ func Execute() {
 		fmt.Println("  -h, --help             Show this help message")
 		fmt.Println("  -host                  Host for the DiceDB server (default: \"0.0.0.0\")")
 		fmt.Println("  -port                  Port for the DiceDB server (default: 7379)")
-		fmt.Println("  -http-port             Port for accepting requests over HTTP (default: 7380)")
+		fmt.Println("  -http-port             Port for accepting requests over HTTP (default: 8082)")
 		fmt.Println("  -enable-http           Enable DiceDB to listen, accept, and process HTTP (default: false)")
-		fmt.Println("  -websocket-port        Port for accepting requests over WebSocket (default: 7381)")
+		fmt.Println("  -websocket-port        Port for accepting requests over WebSocket (default: 8379)")
 		fmt.Println("  -enable-websocket      Enable DiceDB to listen, accept, and process WebSocket (default: false)")
 		fmt.Println("  -num-shards            Number of shards to create. Defaults to number of cores (default: -1)")
 		fmt.Println("  -enable-watch          Enable support for .WATCH commands and real-time reactivity (default: false)")
@@ -130,8 +130,8 @@ func Execute() {
 		fmt.Println("  -requirepass           Enable authentication for the default user (default: \"\")")
 		fmt.Println("  -o                     Directory path to create the config file (default: \"\")")
 		fmt.Println("  -c                     File path of the config file (default: \"\")")
-		fmt.Println("  -keys-limit            Keys limit for the DiceDB server (default: 0)")
-		fmt.Println("  -eviction-ratio        Ratio of keys to evict when the keys limit is reached (default: 0.1)")
+		fmt.Println("  -keys-limit            Keys limit for the DiceDB server (default: 200000000)")
+		fmt.Println("  -eviction-ratio        Ratio of keys to evict when the keys limit is reached (default: 0.9)")
 		color.Unset()
 		os.Exit(0)
 	}


### PR DESCRIPTION
this is a config style optimize, nothing to do with core logic.
In config.go
there are some configs have  default value, such as  the following port **8082** and **8379**
`

          type http struct {
	      Enabled bool `config:"enabled" default:"true"`
	      Port    int  `config:"port" default:"8082" validate:"number,gte=0,lte=65535"`
      }
      
      type websocket struct {
	      Enabled                 bool          `config:"enabled" default:"true"`
	      Port                    int           `config:"port" default:"8379" validate:"number,gte=0,lte=65535"`
	      MaxWriteResponseRetries int           `config:"max_write_response_retries" default:"3" validate:"min=0"`
	      WriteResponseTimeout    time.Duration `config:"write_response_timeout" default:"10s"`
      }


`

but in cli.go the default value is not the same, such as  the following port **7380** and **7381**
`


        flag.IntVar(&flagsConfig.HTTP.Port, "http-port", 7380, "port for accepting requets over HTTP")
	    flag.BoolVar(&flagsConfig.HTTP.Enabled, "enable-http", false, "enable DiceDB to listen, accept, and process HTTP")

	    flag.IntVar(&flagsConfig.WebSocket.Port, "websocket-port", 7381, "port for accepting requets over WebSocket")

`

this pr only keep them the same so that default config value keep consistency.