### PR TITLE
Add error message for using JSON.OBJLEN on non-existant key

### DIFF
--- a/integration_tests/commands/http/json_test.go
+++ b/integration_tests/commands/http/json_test.go
@@ -1230,7 +1230,7 @@ func TestJsonObjLen(t *testing.T) {
 			commands: []HTTPCommand{
 				{Command: "JSON.OBJLEN", Body: map[string]interface{}{"key": "non_existing_key", "path": "$"}},
 			},
-			expected: []interface{}{nil},
+			expected: []interface{}{"ERR could not perform this operation on a key that doesn't exist"},
 		},
 		{
 			name: "JSON.OBJLEN with empty path",

--- a/integration_tests/commands/resp/json_test.go
+++ b/integration_tests/commands/resp/json_test.go
@@ -1186,7 +1186,7 @@ func TestJsonObjLen(t *testing.T) {
 		{
 			name:     "JSON.OBJLEN with non-existent key",
 			commands: []string{"json.set obj $ " + b, "json.objlen non_existing_key $"},
-			expected: []interface{}{"OK", "(nil)"},
+			expected: []interface{}{"OK", "ERR could not perform this operation on a key that doesn't exist"},
 		},
 		{
 			name:     "JSON.OBJLEN with empty path",

--- a/integration_tests/commands/websocket/json_test.go
+++ b/integration_tests/commands/websocket/json_test.go
@@ -303,7 +303,7 @@ func TestJsonObjLen(t *testing.T) {
 		{
 			name:     "JSON.OBJLEN with non-existent key",
 			commands: []string{"json.set obj $ " + b, "json.objlen non_existing_key $"},
-			expected: []interface{}{"OK", nil},
+			expected: []interface{}{"OK", "ERR could not perform this operation on a key that doesn't exist"},
 		},
 		{
 			name:     "JSON.OBJLEN with empty path",

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1409,7 +1409,7 @@ func testEvalJSONOBJLEN(t *testing.T, store *dstore.Store) {
 			input: []string{"NONEXISTENT_KEY"},
 			migratedOutput: EvalResponse{
 				Result: nil,
-				Error:  nil,
+				Error:  diceerrors.ErrKeyDoesNotExist,
 			},
 		},
 		"jsonobjlen root not object": {

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -1902,7 +1902,7 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) *EvalResponse {
 	if obj == nil {
 		return &EvalResponse{
 			Result: nil,
-			Error:  nil,
+			Error:  diceerrors.ErrKeyDoesNotExist,
 		}
 	}
 


### PR DESCRIPTION
This fixes the missing error message that happens when you run the `JSON.OBJLEN` command on a key that doesn't exist. (Presently, it returns a blank message.)

I discovered this inconsistency while [writing the `JSON.OBJLEN` page](https://github.com/DiceDB/dice/issues/1282).

Ref: #1353 