### PR TITLE
Add default parent directory for storing logs and persistent data(WAL)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -269,7 +269,7 @@ func GetDefaultParentDirPath() string {
 }
 
 func expandHomeDirDarwin(path string) string {
-	if len(path) > 0 && path[0] == '~' {
+	if path != "" && path[0] == '~' {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return path // Fallback if home directory can't be resolved

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -123,7 +123,7 @@ func Execute() {
 		fmt.Println("  -enable-watch          Enable support for .WATCH commands and real-time reactivity (default: false)")
 		fmt.Println("  -enable-profiling      Enable profiling and capture critical metrics and traces in .prof files (default: false)")
 		fmt.Println("  -log-level             Log level, values: info, debug (default: \"info\")")
-		fmt.Println("  -log-dir               Log directory path (default: \"/tmp/dicedb\")")
+		fmt.Printf("  -log-dir               Log directory path (default: \"%s\")\n", config.GetDefaultParentDirPath())
 		fmt.Println("  -enable-persistence    Enable write-ahead logging (default: false)")
 		fmt.Println("  -restore-wal           Restore the database from the WAL files (default: false)")
 		fmt.Println("  -wal-engine            WAL engine to use, values: sqlite, aof (default: \"null\")")
@@ -137,6 +137,7 @@ func Execute() {
 	}
 
 	flag.Parse()
+	config.ConfigureParentDirPaths()
 
 	if len(os.Args) > 2 {
 		switch os.Args[1] {
@@ -224,8 +225,6 @@ func Execute() {
 			defaultConfig(&flagsConfig)
 		}
 	}
-
-	defaultConfig(&flagsConfig)
 }
 
 func defaultConfig(flags *config.Config) {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
@@ -54,8 +55,9 @@ func main() {
 
 	wl, _ = wal.NewNullWAL()
 	if config.DiceConfig.Persistence.Enabled {
+		WALDir := filepath.Join(config.DefaultParentDir, config.DiceConfig.Persistence.WALDir)
 		if config.DiceConfig.Persistence.WALEngine == "sqlite" {
-			_wl, err := wal.NewSQLiteWAL(config.DiceConfig.Persistence.WALDir)
+			_wl, err := wal.NewSQLiteWAL(WALDir)
 			if err != nil {
 				slog.Warn("could not create WAL with", slog.String("wal-engine", config.DiceConfig.Persistence.WALEngine), slog.Any("error", err))
 				sigs <- syscall.SIGKILL
@@ -63,7 +65,7 @@ func main() {
 			}
 			wl = _wl
 		} else if config.DiceConfig.Persistence.WALEngine == "aof" {
-			_wl, err := wal.NewAOFWAL(config.DiceConfig.Persistence.WALDir)
+			_wl, err := wal.NewAOFWAL(WALDir)
 			if err != nil {
 				slog.Warn("could not create WAL with", slog.String("wal-engine", config.DiceConfig.Persistence.WALEngine), slog.Any("error", err))
 				sigs <- syscall.SIGKILL


### PR DESCRIPTION
- Added default parent directory for storing logs and persistent data similar to Redis, PostgreSQL etc. which typically define parent directory paths to store logs/data related to app.
- Default paths will depend on OS
```
linuxPath   = "/var/lib/dicedb"
darwinPath  = "~/Library/Application Support/dicedb"
windowsPath = "C:\\ProgramData\\dicedb"
```

<img width="1720" alt="image" src="https://github.com/user-attachments/assets/daf0a0c1-a6c8-4340-aba9-e2ad0f56373a">

<img width="1719" alt="image" src="https://github.com/user-attachments/assets/e124745c-742c-41f4-a26b-409a68abdc86">
