### PR TITLE
Added test cases for zset data type

### DIFF
--- a/integration_tests/commands/resp/type_test.go
+++ b/integration_tests/commands/resp/type_test.go
@@ -56,6 +56,14 @@ func TestType(t *testing.T) {
 		// 	commands: []string{"SET key1 \"foobar\"", "SET key2 \"abcdef\"", "TYPE dest"},
 		// 	expected: []interface{}{"OK", "OK", "string"},
 		// },
+		{
+			name: "TYPE for key with Zset value",
+			commands: []string{
+				"ZADD myzetset 1 'one' 2 'two'",
+				"TYPE myzetset",
+			},
+			expected:      []interface{}{int64(2), "zset"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/integration_tests/commands/websocket/type_test.go
+++ b/integration_tests/commands/websocket/type_test.go
@@ -51,6 +51,14 @@ func TestType(t *testing.T) {
 		// 	commands: []string{"SET key1 foobar", "SET key2 abcdef", "TYPE dest"},
 		// 	expected: []interface{}{"OK", "OK", "string"},
 		// },
+		{
+			name: "TYPE for key with Zset value",
+			commands: []string{
+				"ZADD myzetset 1 'one' 2 'two'",
+				"TYPE myzetset",
+			},
+			expected:      []interface{}{float64(2), "zset"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Issue Ticker Number
- Closes #1340 
## Description
This PR adds test cases to verify the support for zset data type in type command.
## Screenshots
For TEST_FUNC=TestType make test-one
<img width="771" alt="Screenshot 2024-12-06 at 7 04 35 PM" src="https://github.com/user-attachments/assets/6fea78e4-147f-45f9-8910-8e6ffed5fafc">
For make test
<img width="1315" alt="Screenshot 2024-12-06 at 9 09 24 PM" src="https://github.com/user-attachments/assets/39a763e9-baaa-4a78-b0f0-d51ac4dae7af">
