### PR TITLE
Update `PFMERGE` to be supported as multishard command

### DIFF
--- a/integration_tests/commands/http/hyperloglog_test.go
+++ b/integration_tests/commands/http/hyperloglog_test.go
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//go:build ignore
+// +build ignore
+
+// Ignored as multishard commands not supported by HTTP
 package http
 
 import (

--- a/integration_tests/commands/websocket/hyperloglog_test.go
+++ b/integration_tests/commands/websocket/hyperloglog_test.go
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//go:build ignore
+// +build ignore
+
+// Ignored as multishard commands not supported by WS
 package websocket
 
 import (

--- a/internal/cmd/cmds.go
+++ b/internal/cmd/cmds.go
@@ -45,12 +45,12 @@ type DiceDBCmd struct {
 	// This slice allows flexible support for commands with variable arguments.
 	Args []string
 
-	// InternalObj is a pointer to an InternalObj, representing an optional data structure
+	// InternalObjs is a pointer to list of InternalObjs, representing an optional data structure
 	// associated with the command. This contains pointer to the underlying simple
 	// types such as int, string or even complex types
 	// like hashes, sets, or sorted sets, which are stored and manipulated as objects.
 	// WARN: This parameter should be used with caution
-	InternalObj *object.InternalObj
+	InternalObjs []*object.InternalObj
 }
 
 type RedisCmds struct {

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -127,13 +127,21 @@ var (
 // their implementation for HTTP and WebSocket protocols is still pending.
 // As a result, their Eval functions remained intact.
 var (
-	//TODO: supports only http protocol, needs to be removed once http is migrated to multishard
 	objectCopyCmdMeta = DiceCmdMeta{
 		Name:            "OBJECTCOPY",
 		Info:            `COPY command copies the value stored at the source key to the destination key.`,
 		StoreObjectEval: evalCOPYObject,
 		IsMigrated:      true,
 		Arity:           -2,
+	}
+	pfMergeCmdMeta = DiceCmdMeta{
+		Name: "PFMERGE",
+		Info: `PFMERGE destkey [sourcekey [sourcekey ...]]
+		Merges one or more HyperLogLog values into a single key.`,
+		IsMigrated:      true,
+		Arity:           -2,
+		KeySpecs:        KeySpecs{BeginIndex: 1},
+		StoreObjectEval: evalPFMERGE,
 	}
 )
 
@@ -967,15 +975,6 @@ var (
 		Arity:      -2,
 		KeySpecs:   KeySpecs{BeginIndex: 1},
 	}
-	pfMergeCmdMeta = DiceCmdMeta{
-		Name: "PFMERGE",
-		Info: `PFMERGE destkey [sourcekey [sourcekey ...]]
-		Merges one or more HyperLogLog values into a single key.`,
-		NewEval:    evalPFMERGE,
-		IsMigrated: true,
-		Arity:      -2,
-		KeySpecs:   KeySpecs{BeginIndex: 1},
-	}
 	jsonStrlenCmdMeta = DiceCmdMeta{
 		Name: "JSON.STRLEN",
 		Info: `JSON.STRLEN key [path]
@@ -1344,6 +1343,7 @@ var (
 func init() {
 	PreProcessing["COPY"] = evalGetObject
 	PreProcessing["RENAME"] = evalGET
+	PreProcessing["GETOBJECT"] = evalGetObject
 
 	DiceCmds["ABORT"] = abortCmdMeta
 	DiceCmds["APPEND"] = appendCmdMeta

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/dicedb/dice/internal/cmd"
 	"math"
 	"reflect"
 	"strconv"
@@ -49,6 +50,14 @@ type evalTestCase struct {
 	validator      func(output []byte)
 	newValidator   func(output interface{})
 	migratedOutput EvalResponse
+}
+
+type evalMultiShardTestCase struct {
+	name      string
+	setup     func()
+	input     *cmd.DiceDBCmd
+	validator func(output interface{})
+	output    EvalResponse
 }
 
 func setupTest(store *dstore.Store) *dstore.Store {
@@ -101,7 +110,6 @@ func TestEval(t *testing.T) {
 	testEvalHEXISTS(t, store)
 	testEvalHDEL(t, store)
 	testEvalHSCAN(t, store)
-	testEvalPFMERGE(t, store)
 	testEvalJSONSTRLEN(t, store)
 	testEvalJSONOBJLEN(t, store)
 	testEvalHLEN(t, store)
@@ -3010,12 +3018,14 @@ func testEvalPFCOUNT(t *testing.T, store *dstore.Store) {
 }
 
 func testEvalPFMERGE(t *testing.T, store *dstore.Store) {
-	tests := map[string]evalTestCase{
+	tests := map[string]evalMultiShardTestCase{
 		"PFMERGE nil value": {
 			name:  "PFMERGE nil value",
 			setup: func() {},
-			input: nil,
-			migratedOutput: EvalResponse{
+			input: &cmd.DiceDBCmd{
+				Cmd: "PFMERGE",
+			},
+			output: EvalResponse{
 				Result: nil,
 				Error:  diceerrors.ErrWrongArgumentCount("PFMERGE"),
 			},
@@ -3023,8 +3033,11 @@ func testEvalPFMERGE(t *testing.T, store *dstore.Store) {
 		"PFMERGE empty array": {
 			name:  "PFMERGE empty array",
 			setup: func() {},
-			input: []string{},
-			migratedOutput: EvalResponse{
+			input: &cmd.DiceDBCmd{
+				Cmd:  "PFMERGE",
+				Args: []string{},
+			},
+			output: EvalResponse{
 				Result: nil,
 				Error:  diceerrors.ErrWrongArgumentCount("PFMERGE"),
 			},
@@ -3040,8 +3053,11 @@ func testEvalPFMERGE(t *testing.T, store *dstore.Store) {
 				}
 				store.Put(key, obj)
 			},
-			input: []string{"INVALID_OBJ_DEST_KEY"},
-			migratedOutput: EvalResponse{
+			input: &cmd.DiceDBCmd{
+				Cmd:  "PFMERGE",
+				Args: []string{"INVALID_OBJ_DEST_KEY"},
+			},
+			output: EvalResponse{
 				Result: nil,
 				Error:  diceerrors.ErrInvalidHyperLogLogKey,
 			},
@@ -3049,17 +3065,32 @@ func testEvalPFMERGE(t *testing.T, store *dstore.Store) {
 		"PFMERGE destKey doesn't exist": {
 			name:  "PFMERGE destKey doesn't exist",
 			setup: func() {},
-			input: []string{"NON_EXISTING_DEST_KEY"},
-			migratedOutput: EvalResponse{
+			input: &cmd.DiceDBCmd{
+				Cmd:  "PFMERGE",
+				Args: []string{"NON_EXISTING_DEST_KEY"},
+			},
+			output: EvalResponse{
 				Result: clientio.OK,
 				Error:  nil,
 			},
 		},
 		"PFMERGE destKey exist": {
-			name:  "PFMERGE destKey exist",
-			setup: func() {},
-			input: []string{"NON_EXISTING_DEST_KEY"},
-			migratedOutput: EvalResponse{
+			name: "PFMERGE destKey exist",
+			setup: func() {
+				key := "EXISTING_DEST_KEY"
+				value := hyperloglog.New()
+				value.Insert([]byte("VALUE"))
+				obj := &object.Obj{
+					Value:          value,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store.Put(key, obj)
+			},
+			input: &cmd.DiceDBCmd{
+				Cmd:  "PFMERGE",
+				Args: []string{"EXISTING_DEST_KEY"},
+			},
+			output: EvalResponse{
 				Result: clientio.OK,
 				Error:  nil,
 			},
@@ -3076,8 +3107,11 @@ func testEvalPFMERGE(t *testing.T, store *dstore.Store) {
 				}
 				store.Put(key, obj)
 			},
-			input: []string{"EXISTING_DEST_KEY", "NON_EXISTING_SRC_KEY"},
-			migratedOutput: EvalResponse{
+			input: &cmd.DiceDBCmd{
+				Cmd:  "PFMERGE",
+				Args: []string{"EXISTING_DEST_KEY", "NON_EXISTING_SRC_KEY"},
+			},
+			output: EvalResponse{
 				Result: clientio.OK,
 				Error:  nil,
 			},
@@ -3094,8 +3128,19 @@ func testEvalPFMERGE(t *testing.T, store *dstore.Store) {
 				}
 				store.Put(key, obj)
 			},
-			input: []string{"EXISTING_DEST_KEY", "NON_EXISTING_SRC_KEY"},
-			migratedOutput: EvalResponse{
+			input: &cmd.DiceDBCmd{
+				Cmd:  "PFMERGE",
+				Args: []string{"EXISTING_DEST_KEY", "EXISTING_SRC_KEY"},
+				InternalObjs: []*object.InternalObj{
+					{
+						Obj: &object.Obj{
+							Value: hyperloglog.New(),
+							Type:  object.ObjTypeHLL,
+						},
+					},
+				},
+			},
+			output: EvalResponse{
 				Result: clientio.OK,
 				Error:  nil,
 			},
@@ -3111,7 +3156,7 @@ func testEvalPFMERGE(t *testing.T, store *dstore.Store) {
 					LastAccessedAt: uint32(time.Now().Unix()),
 				}
 				store.Put(key, obj)
-				srcKey := "EXISTING_SRC_KEY"
+				srcKey := "EXISTING_SRC_KEY1"
 				srcValue := hyperloglog.New()
 				value.Insert([]byte("SRC_VALUE"))
 				srcKeyObj := &object.Obj{
@@ -3119,16 +3164,41 @@ func testEvalPFMERGE(t *testing.T, store *dstore.Store) {
 					LastAccessedAt: uint32(time.Now().Unix()),
 				}
 				store.Put(srcKey, srcKeyObj)
+				srcKey2 := "EXISTING_SRC_KEY2"
+				srcValue2 := hyperloglog.New()
+				value.Insert([]byte("SRC_VALUE"))
+				srcKeyObj2 := &object.Obj{
+					Value:          srcValue2,
+					LastAccessedAt: uint32(time.Now().Unix()),
+				}
+				store.Put(srcKey2, srcKeyObj2)
 			},
-			input: []string{"EXISTING_DEST_KEY", "EXISTING_SRC_KEY"},
-			migratedOutput: EvalResponse{
+			input: &cmd.DiceDBCmd{
+				Cmd:  "PFMERGE",
+				Args: []string{"EXISTING_DEST_KEY", "EXISTING_SRC_KEY1", "EXISTING_SRC_KEY2"},
+				InternalObjs: []*object.InternalObj{
+					{
+						Obj: &object.Obj{
+							Value: hyperloglog.New(),
+							Type:  object.ObjTypeHLL,
+						},
+					},
+					{
+						Obj: &object.Obj{
+							Value: hyperloglog.New(),
+							Type:  object.ObjTypeHLL,
+						},
+					},
+				},
+			},
+			output: EvalResponse{
 				Result: clientio.OK,
 				Error:  nil,
 			},
 		},
 	}
 
-	runMigratedEvalTests(t, tests, evalPFMERGE, store)
+	runEvalTestsMultiShard(t, tests, evalPFMERGE, store)
 }
 
 func testEvalHGET(t *testing.T, store *dstore.Store) {
@@ -4346,6 +4416,26 @@ func runMigratedEvalTests(t *testing.T, tests map[string]evalTestCase, evalFunc 
 			}
 
 			assert.NoError(t, output.Error)
+		})
+	}
+}
+
+func runEvalTestsMultiShard(t *testing.T, tests map[string]evalMultiShardTestCase, evalFunc func(*cmd.DiceDBCmd, *dstore.Store) *EvalResponse, store *dstore.Store) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store = setupTest(store)
+			if tc.setup != nil {
+				tc.setup()
+			}
+
+			output := evalFunc(tc.input, store)
+			if tc.output.Error != nil {
+				assert.Equal(t, tc.output.Error, output.Error)
+			}
+
+			if tc.output.Result != nil {
+				assert.Equal(t, tc.output.Result, output.Result)
+			}
 		})
 	}
 }
@@ -8339,13 +8429,13 @@ func testEvalGEOPOS(t *testing.T, store *dstore.Store) {
 				Error:  diceerrors.ErrWrongArgumentCount("GEOPOS"),
 			},
 		},
-        "GEOPOS for a key not used for setting geospatial values": {
+		"GEOPOS for a key not used for setting geospatial values": {
 			setup: func() {
 				evalSET([]string{"k", "v"}, store)
 			},
 			input: []string{"k", "v"},
-            migratedOutput: EvalResponse{
-				Result: nil, 
+			migratedOutput: EvalResponse{
+				Result: nil,
 				Error:  errors.New("WRONGTYPE Operation against a key holding the wrong kind of value"),
 			},
 		},

--- a/internal/eval/execute.go
+++ b/internal/eval/execute.go
@@ -69,9 +69,9 @@ func (e *Eval) ExecuteCommand() *EvalResponse {
 		// ===============================================================================
 		// dealing with store object is not recommended for all commands
 		// These operations are specialised for the commands which requires
-		// transferring data across multiple shards. e.g COPY, RENAME
+		// transferring data across multiple shards. e.g. COPY, RENAME, PFMERGE
 		// ===============================================================================
-		if e.cmd.InternalObj != nil {
+		if e.cmd.InternalObjs != nil {
 			// This involves handling object at store level, evaluating it, modifying it, and then storing it back.
 			return diceCmd.StoreObjectEval(e.cmd, e.store)
 		}

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -400,6 +400,20 @@ func evalGET(args []string, store *dstore.Store) *EvalResponse {
 			Error:  diceerrors.ErrWrongTypeOperation,
 		}
 
+	case object.ObjTypeHLL:
+		// Value is stored as a hyperloglog, use type assertion
+		if val, ok := obj.Value.(*hyperloglog.Sketch); ok {
+			return &EvalResponse{
+				Result: val,
+				Error:  nil,
+			}
+		}
+
+		return &EvalResponse{
+			Result: nil,
+			Error:  diceerrors.ErrWrongTypeOperation,
+		}
+
 	default:
 		return &EvalResponse{
 			Result: nil,
@@ -1704,7 +1718,7 @@ func evalPFADD(args []string, store *dstore.Store) *EvalResponse {
 			hll.Insert([]byte(arg))
 		}
 
-		obj = store.NewObj(hll, -1, object.ObjTypeString)
+		obj = store.NewObj(hll, -1, object.ObjTypeHLL)
 
 		store.Put(key, obj, dstore.WithPutCmd(dstore.PFADD))
 		return &EvalResponse{
@@ -1725,7 +1739,7 @@ func evalPFADD(args []string, store *dstore.Store) *EvalResponse {
 		existingHll.Insert([]byte(arg))
 	}
 
-	obj = store.NewObj(existingHll, -1, object.ObjTypeString)
+	obj = store.NewObj(existingHll, -1, object.ObjTypeHLL)
 	store.Put(key, obj, dstore.WithPutCmd(dstore.PFADD))
 
 	if newCardinality := existingHll.Estimate(); initialCardinality != newCardinality {
@@ -1992,63 +2006,6 @@ func evalJSONOBJLEN(args []string, store *dstore.Store) *EvalResponse {
 
 	return &EvalResponse{
 		Result: objectLen,
-		Error:  nil,
-	}
-}
-
-func evalPFMERGE(args []string, store *dstore.Store) *EvalResponse {
-	if len(args) < 1 {
-		return &EvalResponse{
-			Result: nil,
-			Error:  diceerrors.ErrWrongArgumentCount("PFMERGE"),
-		}
-	}
-
-	var mergedHll *hyperloglog.Sketch
-	destKey := args[0]
-	obj := store.Get(destKey)
-
-	// If destKey doesn't exist, create a new HLL, else fetch the existing
-	if obj == nil {
-		mergedHll = hyperloglog.New()
-	} else {
-		var ok bool
-		mergedHll, ok = obj.Value.(*hyperloglog.Sketch)
-		if !ok {
-			return &EvalResponse{
-				Result: nil,
-				Error:  diceerrors.ErrInvalidHyperLogLogKey,
-			}
-		}
-	}
-
-	for _, arg := range args {
-		obj := store.Get(arg)
-		if obj != nil {
-			currKeyHll, ok := obj.Value.(*hyperloglog.Sketch)
-			if !ok {
-				return &EvalResponse{
-					Result: nil,
-					Error:  diceerrors.ErrInvalidHyperLogLogKey,
-				}
-			}
-
-			err := mergedHll.Merge(currKeyHll)
-			if err != nil {
-				return &EvalResponse{
-					Result: nil,
-					Error:  diceerrors.ErrCorruptedHyperLogLogObject,
-				}
-			}
-		}
-	}
-
-	// Save the mergedHll
-	obj = store.NewObj(mergedHll, -1, object.ObjTypeString)
-	store.Put(destKey, obj, dstore.WithPutCmd(dstore.PFMERGE))
-
-	return &EvalResponse{
-		Result: clientio.OK,
 		Error:  nil,
 	}
 }
@@ -5918,7 +5875,7 @@ func evalCOPYObject(cd *cmd.DiceDBCmd, store *dstore.Store) *EvalResponse {
 
 	store.Del(key)
 
-	copyObj := cd.InternalObj.Obj.DeepCopy()
+	copyObj := cd.InternalObjs[0].Obj.DeepCopy()
 	if copyObj == nil {
 		return &EvalResponse{
 			Result: clientio.IntegerZero,
@@ -5926,7 +5883,7 @@ func evalCOPYObject(cd *cmd.DiceDBCmd, store *dstore.Store) *EvalResponse {
 		}
 	}
 
-	exDurationMs := cd.InternalObj.ExDuration
+	exDurationMs := cd.InternalObjs[0].ExDuration
 
 	store.Put(key, copyObj)
 
@@ -5936,6 +5893,62 @@ func evalCOPYObject(cd *cmd.DiceDBCmd, store *dstore.Store) *EvalResponse {
 
 	return &EvalResponse{
 		Result: clientio.IntegerOne,
+		Error:  nil,
+	}
+}
+
+func evalPFMERGE(cd *cmd.DiceDBCmd, store *dstore.Store) *EvalResponse {
+	if len(cd.Args) < 1 {
+		return &EvalResponse{
+			Result: nil,
+			Error:  diceerrors.ErrWrongArgumentCount("PFMERGE"),
+		}
+	}
+
+	var mergedHll *hyperloglog.Sketch
+	destKey := cd.Args[0]
+	obj := store.Get(destKey)
+
+	// If destKey doesn't exist, create a new HLL, else fetch the existing
+	if obj == nil {
+		mergedHll = hyperloglog.New()
+	} else {
+		var ok bool
+		mergedHll, ok = obj.Value.(*hyperloglog.Sketch)
+		if !ok {
+			return &EvalResponse{
+				Result: nil,
+				Error:  diceerrors.ErrInvalidHyperLogLogKey,
+			}
+		}
+	}
+
+	for _, obj := range cd.InternalObjs {
+		if obj != nil {
+			currKeyHll, ok := obj.Obj.Value.(*hyperloglog.Sketch)
+			if !ok {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrInvalidHyperLogLogKey,
+				}
+			}
+
+			err := mergedHll.Merge(currKeyHll)
+			if err != nil {
+				return &EvalResponse{
+					Result: nil,
+					Error:  diceerrors.ErrCorruptedHyperLogLogObject,
+				}
+			}
+		}
+	}
+
+	// Save the mergedHll
+	obj = store.NewObj(mergedHll, -1, object.ObjTypeHLL)
+	store.Put(destKey, obj, dstore.WithPutCmd(dstore.PFMERGE))
+
+	return &EvalResponse{
+		Result: clientio.OK,
 		Error:  nil,
 	}
 }

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -5875,6 +5875,13 @@ func evalCOPYObject(cd *cmd.DiceDBCmd, store *dstore.Store) *EvalResponse {
 
 	store.Del(key)
 
+	if len(cd.InternalObjs) < 1 {
+		return &EvalResponse{
+			Result: nil,
+			Error:  diceerrors.ErrGeneral("ERR dest key not present"),
+		}
+	}
+
 	copyObj := cd.InternalObjs[0].Obj.DeepCopy()
 	if copyObj == nil {
 		return &EvalResponse{

--- a/internal/iothread/cmd_compose.go
+++ b/internal/iothread/cmd_compose.go
@@ -263,10 +263,10 @@ func composeFlushDB(responses ...ops.StoreResponse) interface{} {
 	return clientio.OK
 }
 
-// composeMSet processes responses from multiple shards for an "MSet" operation
-// (Multi-set operation). It loops through the responses to check if any shard returned an error.
+// composePFMerge processes responses from multiple shards for an "PFMerge" operation.
+// It loops through the responses to check if any shard returned an error.
 // If an error is detected, it immediately returns that error. Otherwise, it returns "OK"
-// to indicate that all "MSet" operations across shards were successful.
+// to indicate that all merged HyperLogLog is set to the destination variable successfully.
 func composePFMerge(responses ...ops.StoreResponse) interface{} {
 	for idx := range responses {
 		if responses[idx].EvalResponse.Error != nil {

--- a/internal/iothread/cmd_compose.go
+++ b/internal/iothread/cmd_compose.go
@@ -262,3 +262,17 @@ func composeFlushDB(responses ...ops.StoreResponse) interface{} {
 
 	return clientio.OK
 }
+
+// composeMSet processes responses from multiple shards for an "MSet" operation
+// (Multi-set operation). It loops through the responses to check if any shard returned an error.
+// If an error is detected, it immediately returns that error. Otherwise, it returns "OK"
+// to indicate that all "MSet" operations across shards were successful.
+func composePFMerge(responses ...ops.StoreResponse) interface{} {
+	for idx := range responses {
+		if responses[idx].EvalResponse.Error != nil {
+			return responses[idx].EvalResponse.Error
+		}
+	}
+
+	return clientio.OK
+}

--- a/internal/iothread/cmd_decompose.go
+++ b/internal/iothread/cmd_decompose.go
@@ -121,8 +121,9 @@ func decomposeCopy(ctx context.Context, thread *BaseIOThread, cd *cmd.DiceDBCmd)
 	return decomposedCmds, nil
 }
 
-// decomposeMSet decomposes the PFMERGE command into individual GET commands for each HLL.
-// For each key it creates a separate GET command to get the value at the given key.
+// decomposePFMerge decomposes the PFMERGE command into individual GET commands for each HLL.
+// For each key it creates a separate GET command to get the value at the given key, and waits for all responses to be
+// returned before proceeding.
 func decomposePFMerge(ctx context.Context, thread *BaseIOThread, cd *cmd.DiceDBCmd) ([]*cmd.DiceDBCmd, error) {
 	// Waiting for GET command response for all the keys to be merged
 	resp := make([]*object.InternalObj, 0, len(cd.Args)-1)

--- a/internal/iothread/cmd_meta.go
+++ b/internal/iothread/cmd_meta.go
@@ -363,9 +363,6 @@ var CommandsMeta = map[string]CmdMeta{
 	CmdPFCount: {
 		CmdType: SingleShard,
 	},
-	CmdPFMerge: {
-		CmdType: SingleShard,
-	},
 	CmdTTL: {
 		CmdType: SingleShard,
 	},
@@ -586,6 +583,14 @@ var CommandsMeta = map[string]CmdMeta{
 		preProcessResponse: customProcessCopy,
 		decomposeCommand:   decomposeCopy,
 		composeResponse:    composeCopy,
+	},
+
+	CmdPFMerge: {
+		CmdType:            MultiShard,
+		preProcessing:      true,
+		preProcessResponse: preProcessPFMerge,
+		decomposeCommand:   decomposePFMerge,
+		composeResponse:    composePFMerge,
 	},
 
 	CmdMset: {

--- a/internal/iothread/cmd_preprocess.go
+++ b/internal/iothread/cmd_preprocess.go
@@ -80,7 +80,7 @@ func customProcessCopy(thread *BaseIOThread, diceDBCmd *cmd.DiceDBCmd) error {
 	return nil
 }
 
-// preProcessPFMerge prepares the PFMERGE command for preprocessing by sending GET commands
+// preProcessPFMerge prepares the PFMERGE command for preprocessing by sending GETOBJECT commands
 // to retrieve the value of all the keys to be merged with. The retrieved value is used later in the
 // decomposePFMERGE function to merge the hll keys to the new key.
 func preProcessPFMerge(thread *BaseIOThread, diceDBCmd *cmd.DiceDBCmd) error {
@@ -88,6 +88,8 @@ func preProcessPFMerge(thread *BaseIOThread, diceDBCmd *cmd.DiceDBCmd) error {
 		return diceerrors.ErrWrongArgumentCount("PFMERGE")
 	}
 
+	// Sending GETOBJECT commands for the keys to be merged, which would be used in
+	// later stages to merge with destination key in PFMERGE command.
 	for i := 1; i < len(diceDBCmd.Args); i++ {
 		sid, rc := thread.shardManager.GetShardInfo(diceDBCmd.Args[i])
 		preCmd := cmd.DiceDBCmd{

--- a/internal/iothread/cmd_preprocess.go
+++ b/internal/iothread/cmd_preprocess.go
@@ -79,3 +79,32 @@ func customProcessCopy(thread *BaseIOThread, diceDBCmd *cmd.DiceDBCmd) error {
 
 	return nil
 }
+
+// preProcessPFMerge prepares the PFMERGE command for preprocessing by sending GET commands
+// to retrieve the value of all the keys to be merged with. The retrieved value is used later in the
+// decomposePFMERGE function to merge the hll keys to the new key.
+func preProcessPFMerge(thread *BaseIOThread, diceDBCmd *cmd.DiceDBCmd) error {
+	if len(diceDBCmd.Args) < 1 {
+		return diceerrors.ErrWrongArgumentCount("PFMERGE")
+	}
+
+	for i := 1; i < len(diceDBCmd.Args); i++ {
+		sid, rc := thread.shardManager.GetShardInfo(diceDBCmd.Args[i])
+		preCmd := cmd.DiceDBCmd{
+			Cmd:  "GETOBJECT",
+			Args: []string{diceDBCmd.Args[i]},
+		}
+
+		rc <- &ops.StoreOp{
+			SeqID:         0,
+			RequestID:     GenerateUniqueRequestID(),
+			Cmd:           &preCmd,
+			IOThreadID:    thread.id,
+			ShardID:       sid,
+			Client:        nil,
+			PreProcessing: true,
+		}
+	}
+
+	return nil
+}

--- a/internal/iothread/iothread.go
+++ b/internal/iothread/iothread.go
@@ -43,7 +43,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const defaultRequestTimeout = 600 * time.Second
+const defaultRequestTimeout = 6 * time.Second
 
 var requestCounter uint32
 

--- a/internal/iothread/iothread.go
+++ b/internal/iothread/iothread.go
@@ -43,7 +43,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const defaultRequestTimeout = 6 * time.Second
+const defaultRequestTimeout = 600 * time.Second
 
 var requestCounter uint32
 

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -105,4 +105,5 @@ const (
 	ObjTypeCountMinSketch
 	ObjTypeBF
 	ObjTypeDequeue
+	ObjTypeHLL
 )


### PR DESCRIPTION
- Updated `PFMERGE` command to support as multishard command
- Added `preprocess`, `decompose`, `compose` implementation for `PFMERGE`
- Added unit tests
- Update integration tests (Disabled HTTP/WS tests as multishard command not supported for those)

<img width="919" alt="image" src="https://github.com/user-attachments/assets/bb6bbe5b-09e9-4161-aea5-86718dcfe384" />
