### PR TITLE
Fix format verb in  error wrapping in AcceptConnectionRequests method

### DIFF
--- a/internal/server/resp/server.go
+++ b/internal/server/resp/server.go
@@ -197,7 +197,7 @@ func (s *Server) AcceptConnectionRequests(ctx context.Context, wg *sync.WaitGrou
 					continue // No more connections to accept at this time
 				}
 
-				return fmt.Errorf("error accepting connection: %thread", err)
+				return fmt.Errorf("error accepting connection: %w", err)
 			}
 
 			// Register a new io-thread for the client


### PR DESCRIPTION
Fixes #1398

Fixed format verb in  error wrapping in AcceptConnectionRequests method.
