### PR TITLE
HGETALL WATCH Support

### DIFF
--- a/internal/commandhandler/cmd_meta.go
+++ b/internal/commandhandler/cmd_meta.go
@@ -111,6 +111,7 @@ const (
 	CmdCMSIncrBy           = "CMS.INCRBY"
 	CmdHSet                = "HSET"
 	CmdHGet                = "HGET"
+	CmdHGetAll			   = "HGETALL"
 	CmdHSetnx              = "HSETNX"
 	CmdHDel                = "HDEL"
 	CmdHMSet               = "HMSET"
@@ -211,6 +212,8 @@ const (
 	CmdZRangeUnWatch  = "ZRANGE.UNWATCH"
 	CmdPFCountWatch   = "PFCOUNT.WATCH"
 	CmdPFCountUnWatch = "PFCOUNT.UNWATCH"
+	CmdHGetAllWatch   = "HGETALL.WATCH"
+	CmdHGetAllUnWatch = "HGETALL.UNWATCH"
 )
 
 type CmdMeta struct {
@@ -676,6 +679,9 @@ var CommandsMeta = map[string]CmdMeta{
 	CmdPFCountWatch: {
 		CmdType: Watch,
 	},
+	CmdHGetAllWatch: {
+		CmdType: Watch,
+	},
 
 	// Unwatch commands
 	CmdGetUnWatch: {
@@ -685,6 +691,9 @@ var CommandsMeta = map[string]CmdMeta{
 		CmdType: Unwatch,
 	},
 	CmdPFCountUnWatch: {
+		CmdType: Unwatch,
+	},
+	CmdHGetAllUnWatch: {
 		CmdType: Unwatch,
 	},
 }

--- a/internal/store/constants.go
+++ b/internal/store/constants.go
@@ -35,4 +35,5 @@ const (
 	SingleShardTouch string = "SINGLETOUCH"
 	SingleShardKeys  string = "SINGLEKEYS"
 	FlushDB          string = "FLUSHDB"
+	HGetAll			 string = "HGETALL"
 )

--- a/internal/watchmanager/watch_manager.go
+++ b/internal/watchmanager/watch_manager.go
@@ -50,6 +50,7 @@ var (
 		dstore.ZAdd:    {dstore.ZRange: struct{}{}},
 		dstore.PFADD:   {dstore.PFCOUNT: struct{}{}},
 		dstore.PFMERGE: {dstore.PFCOUNT: struct{}{}},
+		dstore.HSET: 	{dstore.HGETALL: struct{}{}},
 	}
 )
 


### PR DESCRIPTION
This PR adds support for the HGETALL.WATCH command, allowing clients to watch whenever the data inside the respective hash set changes. 

HGETALL Command doc - https://redis.io/docs/latest/commands/hgetall/
