### PR TITLE
Replace all references of 2024 with 2025

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/config/parser.go
+++ b/config/parser.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/config/parser.go
+++ b/config/parser.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/config/validator.go
+++ b/config/validator.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/config/validator.go
+++ b/config/validator.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/docs/src/content/updates/2024-08-01.md
+++ b/docs/src/content/updates/2024-08-01.md
@@ -10,7 +10,7 @@ Agenda:
 - JSON-to-JSON comparisons in WHERE clause?
 - Research from Cockroach labs on Json libs \- [https://www.cockroachlabs.com/blog/high-performance-json-parsing/](https://www.cockroachlabs.com/blog/high-performance-json-parsing/)
 
-## Jul 25, 2024 | [DiceDB Weekly Community Call](https://www.google.com/calendar/event?eid=M2Judmhnb2E0YnFsY2d0NWUwMDBhdnZjbmUgYXJwaXQubWFzdGVyY2xhc3NAbQ)
+## Jul 25, 2025| [DiceDB Weekly Community Call](https://www.google.com/calendar/event?eid=M2Judmhnb2E0YnFsY2d0NWUwMDBhdnZjbmUgYXJwaXQubWFzdGVyY2xhc3NAbQ)
 
 Agenda:
 

--- a/docs/src/content/updates/2024-08-01.md
+++ b/docs/src/content/updates/2024-08-01.md
@@ -10,7 +10,7 @@ Agenda:
 - JSON-to-JSON comparisons in WHERE clause?
 - Research from Cockroach labs on Json libs \- [https://www.cockroachlabs.com/blog/high-performance-json-parsing/](https://www.cockroachlabs.com/blog/high-performance-json-parsing/)
 
-## Jul 25, 2025| [DiceDB Weekly Community Call](https://www.google.com/calendar/event?eid=M2Judmhnb2E0YnFsY2d0NWUwMDBhdnZjbmUgYXJwaXQubWFzdGVyY2xhc3NAbQ)
+## Jul 25, 2025  | [DiceDB Weekly Community Call](https://www.google.com/calendar/event?eid=M2Judmhnb2E0YnFsY2d0NWUwMDBhdnZjbmUgYXJwaXQubWFzdGVyY2xhc3NAbQ)
 
 Agenda:
 

--- a/docs/src/content/updates/2024-10-10.md
+++ b/docs/src/content/updates/2024-10-10.md
@@ -44,7 +44,7 @@ Performance and Optimization:
 
 Other:
 
-1. Updated benchmark numbers as of 10th Oct 2025(Arpit Bhayani)
+1. Updated benchmark numbers as of 10th Oct 2025  (Arpit Bhayani)
 2. Upgraded vulnerable packages (Progyan)
 3. Added support for getting adhocReqChan buffer from config (Rohan Chavan)
 4. Changed Github workflow to not run actions for docs related PRs (suryavirkapur)

--- a/docs/src/content/updates/2024-10-10.md
+++ b/docs/src/content/updates/2024-10-10.md
@@ -44,7 +44,7 @@ Performance and Optimization:
 
 Other:
 
-1. Updated benchmark numbers as of 10th Oct 2024 (Arpit Bhayani)
+1. Updated benchmark numbers as of 10th Oct 2025(Arpit Bhayani)
 2. Upgraded vulnerable packages (Progyan)
 3. Added support for getting adhocReqChan buffer from config (Rohan Chavan)
 4. Changed Github workflow to not run actions for docs related PRs (suryavirkapur)

--- a/examples/leaderboard-go/main.go
+++ b/examples/leaderboard-go/main.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/examples/leaderboard-go/main.go
+++ b/examples/leaderboard-go/main.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/examples/url-shortener/main.go
+++ b/examples/url-shortener/main.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/examples/url-shortener/main.go
+++ b/examples/url-shortener/main.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/append_test.go
+++ b/integration_tests/commands/http/append_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/append_test.go
+++ b/integration_tests/commands/http/append_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/bit_test.go
+++ b/integration_tests/commands/http/bit_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/bit_test.go
+++ b/integration_tests/commands/http/bit_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/bloom_test.go
+++ b/integration_tests/commands/http/bloom_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/bloom_test.go
+++ b/integration_tests/commands/http/bloom_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/check_type_test.go
+++ b/integration_tests/commands/http/check_type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/check_type_test.go
+++ b/integration_tests/commands/http/check_type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_count_test.go
+++ b/integration_tests/commands/http/command_count_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_count_test.go
+++ b/integration_tests/commands/http/command_count_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_default_test.go
+++ b/integration_tests/commands/http/command_default_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_default_test.go
+++ b/integration_tests/commands/http/command_default_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_docs_test.go
+++ b/integration_tests/commands/http/command_docs_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_docs_test.go
+++ b/integration_tests/commands/http/command_docs_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_getkeys_test.go
+++ b/integration_tests/commands/http/command_getkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_getkeys_test.go
+++ b/integration_tests/commands/http/command_getkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_help_test.go
+++ b/integration_tests/commands/http/command_help_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_help_test.go
+++ b/integration_tests/commands/http/command_help_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_info_test.go
+++ b/integration_tests/commands/http/command_info_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_info_test.go
+++ b/integration_tests/commands/http/command_info_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_list_test.go
+++ b/integration_tests/commands/http/command_list_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_list_test.go
+++ b/integration_tests/commands/http/command_list_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_rename_test.go
+++ b/integration_tests/commands/http/command_rename_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/command_rename_test.go
+++ b/integration_tests/commands/http/command_rename_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/copy_test.go
+++ b/integration_tests/commands/http/copy_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/copy_test.go
+++ b/integration_tests/commands/http/copy_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/countminsketch_test.go
+++ b/integration_tests/commands/http/countminsketch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/countminsketch_test.go
+++ b/integration_tests/commands/http/countminsketch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/dbsize_test.go
+++ b/integration_tests/commands/http/dbsize_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/dbsize_test.go
+++ b/integration_tests/commands/http/dbsize_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/decr_test.go
+++ b/integration_tests/commands/http/decr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/decr_test.go
+++ b/integration_tests/commands/http/decr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/del_test.go
+++ b/integration_tests/commands/http/del_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/del_test.go
+++ b/integration_tests/commands/http/del_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/deque_test.go
+++ b/integration_tests/commands/http/deque_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/deque_test.go
+++ b/integration_tests/commands/http/deque_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/echo_test.go
+++ b/integration_tests/commands/http/echo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/echo_test.go
+++ b/integration_tests/commands/http/echo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/exists_test.go
+++ b/integration_tests/commands/http/exists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/exists_test.go
+++ b/integration_tests/commands/http/exists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/expire_test.go
+++ b/integration_tests/commands/http/expire_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/expire_test.go
+++ b/integration_tests/commands/http/expire_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/expireat_test.go
+++ b/integration_tests/commands/http/expireat_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/expireat_test.go
+++ b/integration_tests/commands/http/expireat_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/expiretime_test.go
+++ b/integration_tests/commands/http/expiretime_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/expiretime_test.go
+++ b/integration_tests/commands/http/expiretime_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/geo_test.go
+++ b/integration_tests/commands/http/geo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/geo_test.go
+++ b/integration_tests/commands/http/geo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/get_test.go
+++ b/integration_tests/commands/http/get_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/get_test.go
+++ b/integration_tests/commands/http/get_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/getdel_test.go
+++ b/integration_tests/commands/http/getdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/getdel_test.go
+++ b/integration_tests/commands/http/getdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/getex_test.go
+++ b/integration_tests/commands/http/getex_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/getex_test.go
+++ b/integration_tests/commands/http/getex_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/getrange_test.go
+++ b/integration_tests/commands/http/getrange_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/getrange_test.go
+++ b/integration_tests/commands/http/getrange_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/getset_test.go
+++ b/integration_tests/commands/http/getset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/getset_test.go
+++ b/integration_tests/commands/http/getset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hdel_test.go
+++ b/integration_tests/commands/http/hdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hdel_test.go
+++ b/integration_tests/commands/http/hdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hexists_test.go
+++ b/integration_tests/commands/http/hexists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hexists_test.go
+++ b/integration_tests/commands/http/hexists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hget_test.go
+++ b/integration_tests/commands/http/hget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hget_test.go
+++ b/integration_tests/commands/http/hget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hincrby_test.go
+++ b/integration_tests/commands/http/hincrby_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hincrby_test.go
+++ b/integration_tests/commands/http/hincrby_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hincrbyfloat_test.go
+++ b/integration_tests/commands/http/hincrbyfloat_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hincrbyfloat_test.go
+++ b/integration_tests/commands/http/hincrbyfloat_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hkeys_test.go
+++ b/integration_tests/commands/http/hkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hkeys_test.go
+++ b/integration_tests/commands/http/hkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hlen_test.go
+++ b/integration_tests/commands/http/hlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hlen_test.go
+++ b/integration_tests/commands/http/hlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hrandfield_test.go
+++ b/integration_tests/commands/http/hrandfield_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hrandfield_test.go
+++ b/integration_tests/commands/http/hrandfield_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hscan_test.go
+++ b/integration_tests/commands/http/hscan_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hscan_test.go
+++ b/integration_tests/commands/http/hscan_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hset_test.go
+++ b/integration_tests/commands/http/hset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hset_test.go
+++ b/integration_tests/commands/http/hset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hsetnx_test.go
+++ b/integration_tests/commands/http/hsetnx_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hsetnx_test.go
+++ b/integration_tests/commands/http/hsetnx_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hstrlen_test.go
+++ b/integration_tests/commands/http/hstrlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hstrlen_test.go
+++ b/integration_tests/commands/http/hstrlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hvals_test.go
+++ b/integration_tests/commands/http/hvals_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hvals_test.go
+++ b/integration_tests/commands/http/hvals_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hyperloglog_test.go
+++ b/integration_tests/commands/http/hyperloglog_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/hyperloglog_test.go
+++ b/integration_tests/commands/http/hyperloglog_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/incr_by_float_test.go
+++ b/integration_tests/commands/http/incr_by_float_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/incr_by_float_test.go
+++ b/integration_tests/commands/http/incr_by_float_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/incr_test.go
+++ b/integration_tests/commands/http/incr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/incr_test.go
+++ b/integration_tests/commands/http/incr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/json_arrpop_test.go
+++ b/integration_tests/commands/http/json_arrpop_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/json_arrpop_test.go
+++ b/integration_tests/commands/http/json_arrpop_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/json_test.go
+++ b/integration_tests/commands/http/json_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/json_test.go
+++ b/integration_tests/commands/http/json_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/jsondebug_test.go
+++ b/integration_tests/commands/http/jsondebug_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/jsondebug_test.go
+++ b/integration_tests/commands/http/jsondebug_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/jsonresp_test.go
+++ b/integration_tests/commands/http/jsonresp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/jsonresp_test.go
+++ b/integration_tests/commands/http/jsonresp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/keys_test.go
+++ b/integration_tests/commands/http/keys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/keys_test.go
+++ b/integration_tests/commands/http/keys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/main_test.go
+++ b/integration_tests/commands/http/main_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/main_test.go
+++ b/integration_tests/commands/http/main_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/mget_test.go
+++ b/integration_tests/commands/http/mget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/mget_test.go
+++ b/integration_tests/commands/http/mget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/mset_test.go
+++ b/integration_tests/commands/http/mset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/mset_test.go
+++ b/integration_tests/commands/http/mset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/object_test.go
+++ b/integration_tests/commands/http/object_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/object_test.go
+++ b/integration_tests/commands/http/object_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/set_data_cmd_test.go
+++ b/integration_tests/commands/http/set_data_cmd_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/set_data_cmd_test.go
+++ b/integration_tests/commands/http/set_data_cmd_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/set_test.go
+++ b/integration_tests/commands/http/set_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/set_test.go
+++ b/integration_tests/commands/http/set_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/setup.go
+++ b/integration_tests/commands/http/setup.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/setup.go
+++ b/integration_tests/commands/http/setup.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/touch_test.go
+++ b/integration_tests/commands/http/touch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/touch_test.go
+++ b/integration_tests/commands/http/touch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/ttl_pttl_test.go
+++ b/integration_tests/commands/http/ttl_pttl_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/ttl_pttl_test.go
+++ b/integration_tests/commands/http/ttl_pttl_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/type_test.go
+++ b/integration_tests/commands/http/type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/type_test.go
+++ b/integration_tests/commands/http/type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zcard_test.go
+++ b/integration_tests/commands/http/zcard_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zcard_test.go
+++ b/integration_tests/commands/http/zcard_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zpopmax_test.go
+++ b/integration_tests/commands/http/zpopmax_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zpopmax_test.go
+++ b/integration_tests/commands/http/zpopmax_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zrank_test.go
+++ b/integration_tests/commands/http/zrank_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zrank_test.go
+++ b/integration_tests/commands/http/zrank_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zrem_test.go
+++ b/integration_tests/commands/http/zrem_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zrem_test.go
+++ b/integration_tests/commands/http/zrem_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zset_test.go
+++ b/integration_tests/commands/http/zset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/http/zset_test.go
+++ b/integration_tests/commands/http/zset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/abort/server_abort_test.go
+++ b/integration_tests/commands/resp/abort/server_abort_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/abort/server_abort_test.go
+++ b/integration_tests/commands/resp/abort/server_abort_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/append_test.go
+++ b/integration_tests/commands/resp/append_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/append_test.go
+++ b/integration_tests/commands/resp/append_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/bit_test.go
+++ b/integration_tests/commands/resp/bit_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/bit_test.go
+++ b/integration_tests/commands/resp/bit_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/bloom_test.go
+++ b/integration_tests/commands/resp/bloom_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/bloom_test.go
+++ b/integration_tests/commands/resp/bloom_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/check_type_test.go
+++ b/integration_tests/commands/resp/check_type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/check_type_test.go
+++ b/integration_tests/commands/resp/check_type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_count_test.go
+++ b/integration_tests/commands/resp/command_count_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_count_test.go
+++ b/integration_tests/commands/resp/command_count_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_default_test.go
+++ b/integration_tests/commands/resp/command_default_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_default_test.go
+++ b/integration_tests/commands/resp/command_default_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_docs_test.go
+++ b/integration_tests/commands/resp/command_docs_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_docs_test.go
+++ b/integration_tests/commands/resp/command_docs_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_getkeys_test.go
+++ b/integration_tests/commands/resp/command_getkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_getkeys_test.go
+++ b/integration_tests/commands/resp/command_getkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_info_test.go
+++ b/integration_tests/commands/resp/command_info_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_info_test.go
+++ b/integration_tests/commands/resp/command_info_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_list_test.go
+++ b/integration_tests/commands/resp/command_list_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_list_test.go
+++ b/integration_tests/commands/resp/command_list_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_rename_test.go
+++ b/integration_tests/commands/resp/command_rename_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/command_rename_test.go
+++ b/integration_tests/commands/resp/command_rename_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/copy_test.go
+++ b/integration_tests/commands/resp/copy_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/copy_test.go
+++ b/integration_tests/commands/resp/copy_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/countminsketch_test.go
+++ b/integration_tests/commands/resp/countminsketch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/countminsketch_test.go
+++ b/integration_tests/commands/resp/countminsketch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/dbsize_test.go
+++ b/integration_tests/commands/resp/dbsize_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/dbsize_test.go
+++ b/integration_tests/commands/resp/dbsize_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/decr_test.go
+++ b/integration_tests/commands/resp/decr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/decr_test.go
+++ b/integration_tests/commands/resp/decr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/del_test.go
+++ b/integration_tests/commands/resp/del_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/del_test.go
+++ b/integration_tests/commands/resp/del_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/deque_test.go
+++ b/integration_tests/commands/resp/deque_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/deque_test.go
+++ b/integration_tests/commands/resp/deque_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/dump_test.go
+++ b/integration_tests/commands/resp/dump_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/dump_test.go
+++ b/integration_tests/commands/resp/dump_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/echo_test.go
+++ b/integration_tests/commands/resp/echo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/echo_test.go
+++ b/integration_tests/commands/resp/echo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/exists_test.go
+++ b/integration_tests/commands/resp/exists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/exists_test.go
+++ b/integration_tests/commands/resp/exists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/expire_test.go
+++ b/integration_tests/commands/resp/expire_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/expire_test.go
+++ b/integration_tests/commands/resp/expire_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/flushdb_test.go
+++ b/integration_tests/commands/resp/flushdb_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/flushdb_test.go
+++ b/integration_tests/commands/resp/flushdb_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/geo_test.go
+++ b/integration_tests/commands/resp/geo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/geo_test.go
+++ b/integration_tests/commands/resp/geo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/get_test.go
+++ b/integration_tests/commands/resp/get_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/get_test.go
+++ b/integration_tests/commands/resp/get_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getdel_test.go
+++ b/integration_tests/commands/resp/getdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getdel_test.go
+++ b/integration_tests/commands/resp/getdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getex_test.go
+++ b/integration_tests/commands/resp/getex_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getex_test.go
+++ b/integration_tests/commands/resp/getex_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getrange_test.go
+++ b/integration_tests/commands/resp/getrange_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getrange_test.go
+++ b/integration_tests/commands/resp/getrange_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getset_test.go
+++ b/integration_tests/commands/resp/getset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getset_test.go
+++ b/integration_tests/commands/resp/getset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getunwatch_test.go
+++ b/integration_tests/commands/resp/getunwatch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getunwatch_test.go
+++ b/integration_tests/commands/resp/getunwatch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getwatch_test.go
+++ b/integration_tests/commands/resp/getwatch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/getwatch_test.go
+++ b/integration_tests/commands/resp/getwatch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hdel_test.go
+++ b/integration_tests/commands/resp/hdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hdel_test.go
+++ b/integration_tests/commands/resp/hdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hello_test.go
+++ b/integration_tests/commands/resp/hello_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hello_test.go
+++ b/integration_tests/commands/resp/hello_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hexists_test.go
+++ b/integration_tests/commands/resp/hexists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hexists_test.go
+++ b/integration_tests/commands/resp/hexists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hget_test.go
+++ b/integration_tests/commands/resp/hget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hget_test.go
+++ b/integration_tests/commands/resp/hget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hgetall_test.go
+++ b/integration_tests/commands/resp/hgetall_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hgetall_test.go
+++ b/integration_tests/commands/resp/hgetall_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hincrby_test.go
+++ b/integration_tests/commands/resp/hincrby_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hincrby_test.go
+++ b/integration_tests/commands/resp/hincrby_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hincrbyfloat_test.go
+++ b/integration_tests/commands/resp/hincrbyfloat_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hincrbyfloat_test.go
+++ b/integration_tests/commands/resp/hincrbyfloat_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hkeys_test.go
+++ b/integration_tests/commands/resp/hkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hkeys_test.go
+++ b/integration_tests/commands/resp/hkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hlen_test.go
+++ b/integration_tests/commands/resp/hlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hlen_test.go
+++ b/integration_tests/commands/resp/hlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hmget_test.go
+++ b/integration_tests/commands/resp/hmget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hmget_test.go
+++ b/integration_tests/commands/resp/hmget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hmset_test.go
+++ b/integration_tests/commands/resp/hmset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hmset_test.go
+++ b/integration_tests/commands/resp/hmset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hrandfield_test.go
+++ b/integration_tests/commands/resp/hrandfield_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hrandfield_test.go
+++ b/integration_tests/commands/resp/hrandfield_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hscan_test.go
+++ b/integration_tests/commands/resp/hscan_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hscan_test.go
+++ b/integration_tests/commands/resp/hscan_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hset_test.go
+++ b/integration_tests/commands/resp/hset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hset_test.go
+++ b/integration_tests/commands/resp/hset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hsetnx_test.go
+++ b/integration_tests/commands/resp/hsetnx_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hsetnx_test.go
+++ b/integration_tests/commands/resp/hsetnx_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hstrlen_test.go
+++ b/integration_tests/commands/resp/hstrlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hstrlen_test.go
+++ b/integration_tests/commands/resp/hstrlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hvals_test.go
+++ b/integration_tests/commands/resp/hvals_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hvals_test.go
+++ b/integration_tests/commands/resp/hvals_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hyperloglog_test.go
+++ b/integration_tests/commands/resp/hyperloglog_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/hyperloglog_test.go
+++ b/integration_tests/commands/resp/hyperloglog_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/incr_by_float_test.go
+++ b/integration_tests/commands/resp/incr_by_float_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/incr_by_float_test.go
+++ b/integration_tests/commands/resp/incr_by_float_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/incr_test.go
+++ b/integration_tests/commands/resp/incr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/incr_test.go
+++ b/integration_tests/commands/resp/incr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/json_test.go
+++ b/integration_tests/commands/resp/json_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/json_test.go
+++ b/integration_tests/commands/resp/json_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/jsondebug_test.go
+++ b/integration_tests/commands/resp/jsondebug_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/jsondebug_test.go
+++ b/integration_tests/commands/resp/jsondebug_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/jsonresp_test.go
+++ b/integration_tests/commands/resp/jsonresp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/jsonresp_test.go
+++ b/integration_tests/commands/resp/jsonresp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/keys_test.go
+++ b/integration_tests/commands/resp/keys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/keys_test.go
+++ b/integration_tests/commands/resp/keys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/main_test.go
+++ b/integration_tests/commands/resp/main_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/main_test.go
+++ b/integration_tests/commands/resp/main_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/mget_test.go
+++ b/integration_tests/commands/resp/mget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/mget_test.go
+++ b/integration_tests/commands/resp/mget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/mset_test.go
+++ b/integration_tests/commands/resp/mset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/mset_test.go
+++ b/integration_tests/commands/resp/mset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/object_test.go
+++ b/integration_tests/commands/resp/object_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/object_test.go
+++ b/integration_tests/commands/resp/object_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/pfcountwatch_test.go
+++ b/integration_tests/commands/resp/pfcountwatch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/pfcountwatch_test.go
+++ b/integration_tests/commands/resp/pfcountwatch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/set_data_cmd_test.go
+++ b/integration_tests/commands/resp/set_data_cmd_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/set_data_cmd_test.go
+++ b/integration_tests/commands/resp/set_data_cmd_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/set_test.go
+++ b/integration_tests/commands/resp/set_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/set_test.go
+++ b/integration_tests/commands/resp/set_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/setup.go
+++ b/integration_tests/commands/resp/setup.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/setup.go
+++ b/integration_tests/commands/resp/setup.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/touch_test.go
+++ b/integration_tests/commands/resp/touch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/touch_test.go
+++ b/integration_tests/commands/resp/touch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/ttl_pttl_test.go
+++ b/integration_tests/commands/resp/ttl_pttl_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/ttl_pttl_test.go
+++ b/integration_tests/commands/resp/ttl_pttl_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/type_test.go
+++ b/integration_tests/commands/resp/type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/type_test.go
+++ b/integration_tests/commands/resp/type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zcard_test.go
+++ b/integration_tests/commands/resp/zcard_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zcard_test.go
+++ b/integration_tests/commands/resp/zcard_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zpopmax_test.go
+++ b/integration_tests/commands/resp/zpopmax_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zpopmax_test.go
+++ b/integration_tests/commands/resp/zpopmax_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zrangewatch_test.go
+++ b/integration_tests/commands/resp/zrangewatch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zrangewatch_test.go
+++ b/integration_tests/commands/resp/zrangewatch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zrank_test.go
+++ b/integration_tests/commands/resp/zrank_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zrank_test.go
+++ b/integration_tests/commands/resp/zrank_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zrem_test.go
+++ b/integration_tests/commands/resp/zrem_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zrem_test.go
+++ b/integration_tests/commands/resp/zrem_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zset_test.go
+++ b/integration_tests/commands/resp/zset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/resp/zset_test.go
+++ b/integration_tests/commands/resp/zset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/append_test.go
+++ b/integration_tests/commands/websocket/append_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/append_test.go
+++ b/integration_tests/commands/websocket/append_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/bit_test.go
+++ b/integration_tests/commands/websocket/bit_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/bit_test.go
+++ b/integration_tests/commands/websocket/bit_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/bloom_test.go
+++ b/integration_tests/commands/websocket/bloom_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/bloom_test.go
+++ b/integration_tests/commands/websocket/bloom_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/command_docs_test.go
+++ b/integration_tests/commands/websocket/command_docs_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/command_docs_test.go
+++ b/integration_tests/commands/websocket/command_docs_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/countminsketch_test.go
+++ b/integration_tests/commands/websocket/countminsketch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/countminsketch_test.go
+++ b/integration_tests/commands/websocket/countminsketch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/decr_test.go
+++ b/integration_tests/commands/websocket/decr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/decr_test.go
+++ b/integration_tests/commands/websocket/decr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/del_test.go
+++ b/integration_tests/commands/websocket/del_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/del_test.go
+++ b/integration_tests/commands/websocket/del_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/deque_test.go
+++ b/integration_tests/commands/websocket/deque_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/deque_test.go
+++ b/integration_tests/commands/websocket/deque_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/exists_test.go
+++ b/integration_tests/commands/websocket/exists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/exists_test.go
+++ b/integration_tests/commands/websocket/exists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/expire_test.go
+++ b/integration_tests/commands/websocket/expire_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/expire_test.go
+++ b/integration_tests/commands/websocket/expire_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/geo_test.go
+++ b/integration_tests/commands/websocket/geo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/geo_test.go
+++ b/integration_tests/commands/websocket/geo_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/get_test.go
+++ b/integration_tests/commands/websocket/get_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/get_test.go
+++ b/integration_tests/commands/websocket/get_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/getrange_test.go
+++ b/integration_tests/commands/websocket/getrange_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/getrange_test.go
+++ b/integration_tests/commands/websocket/getrange_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hdel_test.go
+++ b/integration_tests/commands/websocket/hdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hdel_test.go
+++ b/integration_tests/commands/websocket/hdel_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/helper.go
+++ b/integration_tests/commands/websocket/helper.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/helper.go
+++ b/integration_tests/commands/websocket/helper.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hexists_test.go
+++ b/integration_tests/commands/websocket/hexists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hexists_test.go
+++ b/integration_tests/commands/websocket/hexists_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hget_test.go
+++ b/integration_tests/commands/websocket/hget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hget_test.go
+++ b/integration_tests/commands/websocket/hget_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hincrby_test.go
+++ b/integration_tests/commands/websocket/hincrby_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hincrby_test.go
+++ b/integration_tests/commands/websocket/hincrby_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hincrbyfloat_test.go
+++ b/integration_tests/commands/websocket/hincrbyfloat_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hincrbyfloat_test.go
+++ b/integration_tests/commands/websocket/hincrbyfloat_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hkeys_test.go
+++ b/integration_tests/commands/websocket/hkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hkeys_test.go
+++ b/integration_tests/commands/websocket/hkeys_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hlen_test.go
+++ b/integration_tests/commands/websocket/hlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hlen_test.go
+++ b/integration_tests/commands/websocket/hlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hrandfield_test.go
+++ b/integration_tests/commands/websocket/hrandfield_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hrandfield_test.go
+++ b/integration_tests/commands/websocket/hrandfield_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hscan_test.go
+++ b/integration_tests/commands/websocket/hscan_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hscan_test.go
+++ b/integration_tests/commands/websocket/hscan_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hset_test.go
+++ b/integration_tests/commands/websocket/hset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hset_test.go
+++ b/integration_tests/commands/websocket/hset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hstrlen_test.go
+++ b/integration_tests/commands/websocket/hstrlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hstrlen_test.go
+++ b/integration_tests/commands/websocket/hstrlen_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hvals_test.go
+++ b/integration_tests/commands/websocket/hvals_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hvals_test.go
+++ b/integration_tests/commands/websocket/hvals_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hyperloglog_test.go
+++ b/integration_tests/commands/websocket/hyperloglog_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/hyperloglog_test.go
+++ b/integration_tests/commands/websocket/hyperloglog_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/incr_by_float_test.go
+++ b/integration_tests/commands/websocket/incr_by_float_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/incr_by_float_test.go
+++ b/integration_tests/commands/websocket/incr_by_float_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/incr_test.go
+++ b/integration_tests/commands/websocket/incr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/incr_test.go
+++ b/integration_tests/commands/websocket/incr_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/json_test.go
+++ b/integration_tests/commands/websocket/json_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/json_test.go
+++ b/integration_tests/commands/websocket/json_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/jsondebug_test.go
+++ b/integration_tests/commands/websocket/jsondebug_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/jsondebug_test.go
+++ b/integration_tests/commands/websocket/jsondebug_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/jsonresp_test.go
+++ b/integration_tests/commands/websocket/jsonresp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/jsonresp_test.go
+++ b/integration_tests/commands/websocket/jsonresp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/main_test.go
+++ b/integration_tests/commands/websocket/main_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/main_test.go
+++ b/integration_tests/commands/websocket/main_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/set_test.go
+++ b/integration_tests/commands/websocket/set_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/set_test.go
+++ b/integration_tests/commands/websocket/set_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/setup.go
+++ b/integration_tests/commands/websocket/setup.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/setup.go
+++ b/integration_tests/commands/websocket/setup.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/ttl_pttl_test.go
+++ b/integration_tests/commands/websocket/ttl_pttl_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/ttl_pttl_test.go
+++ b/integration_tests/commands/websocket/ttl_pttl_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/type_test.go
+++ b/integration_tests/commands/websocket/type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/type_test.go
+++ b/integration_tests/commands/websocket/type_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/writeretry_test.go
+++ b/integration_tests/commands/websocket/writeretry_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/writeretry_test.go
+++ b/integration_tests/commands/websocket/writeretry_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zcard_test.go
+++ b/integration_tests/commands/websocket/zcard_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zcard_test.go
+++ b/integration_tests/commands/websocket/zcard_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zpopmax_test.go
+++ b/integration_tests/commands/websocket/zpopmax_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zpopmax_test.go
+++ b/integration_tests/commands/websocket/zpopmax_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zrank_test.go
+++ b/integration_tests/commands/websocket/zrank_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zrank_test.go
+++ b/integration_tests/commands/websocket/zrank_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zrem_test.go
+++ b/integration_tests/commands/websocket/zrem_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zrem_test.go
+++ b/integration_tests/commands/websocket/zrem_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zset_test.go
+++ b/integration_tests/commands/websocket/zset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/commands/websocket/zset_test.go
+++ b/integration_tests/commands/websocket/zset_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/config/config_test.go
+++ b/integration_tests/config/config_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/config/config_test.go
+++ b/integration_tests/config/config_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/config/parser_test.go
+++ b/integration_tests/config/parser_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/config/parser_test.go
+++ b/integration_tests/config/parser_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/server/max_conn_test.go
+++ b/integration_tests/server/max_conn_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/server/max_conn_test.go
+++ b/integration_tests/server/max_conn_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/server/server_abort_test.go
+++ b/integration_tests/server/server_abort_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/server/server_abort_test.go
+++ b/integration_tests/server/server_abort_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/server/setup.go
+++ b/integration_tests/server/setup.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/integration_tests/server/setup.go
+++ b/integration_tests/server/setup.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/io.go
+++ b/internal/clientio/io.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/io.go
+++ b/internal/clientio/io.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/io_test.go
+++ b/internal/clientio/io_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/io_test.go
+++ b/internal/clientio/io_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/iohandler/iohandler.go
+++ b/internal/clientio/iohandler/iohandler.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/iohandler/iohandler.go
+++ b/internal/clientio/iohandler/iohandler.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/iohandler/netconn/netconn.go
+++ b/internal/clientio/iohandler/netconn/netconn.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/iohandler/netconn/netconn.go
+++ b/internal/clientio/iohandler/netconn/netconn.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/iohandler/netconn/netconn_resp_test.go
+++ b/internal/clientio/iohandler/netconn/netconn_resp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/iohandler/netconn/netconn_resp_test.go
+++ b/internal/clientio/iohandler/netconn/netconn_resp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/iohandler/netconn/netconn_test.go
+++ b/internal/clientio/iohandler/netconn/netconn_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/iohandler/netconn/netconn_test.go
+++ b/internal/clientio/iohandler/netconn/netconn_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/requestparser/parser.go
+++ b/internal/clientio/requestparser/parser.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/requestparser/parser.go
+++ b/internal/clientio/requestparser/parser.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/requestparser/resp/respparser.go
+++ b/internal/clientio/requestparser/resp/respparser.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/requestparser/resp/respparser.go
+++ b/internal/clientio/requestparser/resp/respparser.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/requestparser/resp/respparser_test.go
+++ b/internal/clientio/requestparser/resp/respparser_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/requestparser/resp/respparser_test.go
+++ b/internal/clientio/requestparser/resp/respparser_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/resp.go
+++ b/internal/clientio/resp.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/resp.go
+++ b/internal/clientio/resp.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/resp_test.go
+++ b/internal/clientio/resp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/clientio/resp_test.go
+++ b/internal/clientio/resp_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/cmd/cmds.go
+++ b/internal/cmd/cmds.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/cmd/cmds.go
+++ b/internal/cmd/cmds.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/comm/client.go
+++ b/internal/comm/client.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/comm/client.go
+++ b/internal/comm/client.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_compose.go
+++ b/internal/commandhandler/cmd_compose.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_compose.go
+++ b/internal/commandhandler/cmd_compose.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_custom.go
+++ b/internal/commandhandler/cmd_custom.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_custom.go
+++ b/internal/commandhandler/cmd_custom.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_decompose.go
+++ b/internal/commandhandler/cmd_decompose.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_decompose.go
+++ b/internal/commandhandler/cmd_decompose.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_meta.go
+++ b/internal/commandhandler/cmd_meta.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_meta.go
+++ b/internal/commandhandler/cmd_meta.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_preprocess.go
+++ b/internal/commandhandler/cmd_preprocess.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/commandhandler/cmd_preprocess.go
+++ b/internal/commandhandler/cmd_preprocess.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/common/map.go
+++ b/internal/common/map.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/common/map.go
+++ b/internal/common/map.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/common/regmap.go
+++ b/internal/common/regmap.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/common/regmap.go
+++ b/internal/common/regmap.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/common/swisstable.go
+++ b/internal/common/swisstable.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/common/swisstable.go
+++ b/internal/common/swisstable.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/dencoding/dencoding_benchmark_test.go
+++ b/internal/dencoding/dencoding_benchmark_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/dencoding/dencoding_benchmark_test.go
+++ b/internal/dencoding/dencoding_benchmark_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/dencoding/int.go
+++ b/internal/dencoding/int.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/dencoding/int.go
+++ b/internal/dencoding/int.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/dencoding/int_test.go
+++ b/internal/dencoding/int_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/dencoding/int_test.go
+++ b/internal/dencoding/int_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/errors/migrated_errors.go
+++ b/internal/errors/migrated_errors.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/errors/migrated_errors.go
+++ b/internal/errors/migrated_errors.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bitpos.go
+++ b/internal/eval/bitpos.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bitpos.go
+++ b/internal/eval/bitpos.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bloom_test.go
+++ b/internal/eval/bloom_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bloom_test.go
+++ b/internal/eval/bloom_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bloom_utils.go
+++ b/internal/eval/bloom_utils.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bloom_utils.go
+++ b/internal/eval/bloom_utils.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bytearray.go
+++ b/internal/eval/bytearray.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bytearray.go
+++ b/internal/eval/bytearray.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bytearray_test.go
+++ b/internal/eval/bytearray_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bytearray_test.go
+++ b/internal/eval/bytearray_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bytelist.go
+++ b/internal/eval/bytelist.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bytelist.go
+++ b/internal/eval/bytelist.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bytelist_test.go
+++ b/internal/eval/bytelist_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/bytelist_test.go
+++ b/internal/eval/bytelist_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/commands.go
+++ b/internal/eval/commands.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/constants.go
+++ b/internal/eval/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/constants.go
+++ b/internal/eval/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/countminsketch.go
+++ b/internal/eval/countminsketch.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/countminsketch.go
+++ b/internal/eval/countminsketch.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/countminsketch_test.go
+++ b/internal/eval/countminsketch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/countminsketch_test.go
+++ b/internal/eval/countminsketch_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/deque.go
+++ b/internal/eval/deque.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/deque.go
+++ b/internal/eval/deque.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/deque_test.go
+++ b/internal/eval/deque_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/deque_test.go
+++ b/internal/eval/deque_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/dump_restore.go
+++ b/internal/eval/dump_restore.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/dump_restore.go
+++ b/internal/eval/dump_restore.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/execute.go
+++ b/internal/eval/execute.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/execute.go
+++ b/internal/eval/execute.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/geo/geo.go
+++ b/internal/eval/geo/geo.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/geo/geo.go
+++ b/internal/eval/geo/geo.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/hmap.go
+++ b/internal/eval/hmap.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/hmap.go
+++ b/internal/eval/hmap.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/hmap_test.go
+++ b/internal/eval/hmap_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/hmap_test.go
+++ b/internal/eval/hmap_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/main_test.go
+++ b/internal/eval/main_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/main_test.go
+++ b/internal/eval/main_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/sortedset/sorted_set.go
+++ b/internal/eval/sortedset/sorted_set.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/sortedset/sorted_set.go
+++ b/internal/eval/sortedset/sorted_set.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/store_eval.go
+++ b/internal/eval/store_eval.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/type_asserts.go
+++ b/internal/eval/type_asserts.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/type_asserts.go
+++ b/internal/eval/type_asserts.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/type_bloomfilter.go
+++ b/internal/eval/type_bloomfilter.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/type_bloomfilter.go
+++ b/internal/eval/type_bloomfilter.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/type_string.go
+++ b/internal/eval/type_string.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/type_string.go
+++ b/internal/eval/type_string.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/type_string_test.go
+++ b/internal/eval/type_string_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/eval/type_string_test.go
+++ b/internal/eval/type_string_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/id/id.go
+++ b/internal/id/id.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/id/id.go
+++ b/internal/id/id.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/id/id_test.go
+++ b/internal/id/id_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/id/id_test.go
+++ b/internal/id/id_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/constants.go
+++ b/internal/iomultiplexer/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/constants.go
+++ b/internal/iomultiplexer/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/epoll_linux.go
+++ b/internal/iomultiplexer/epoll_linux.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/epoll_linux.go
+++ b/internal/iomultiplexer/epoll_linux.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/errors.go
+++ b/internal/iomultiplexer/errors.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/errors.go
+++ b/internal/iomultiplexer/errors.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/interface.go
+++ b/internal/iomultiplexer/interface.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/interface.go
+++ b/internal/iomultiplexer/interface.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/kqueue_darwin.go
+++ b/internal/iomultiplexer/kqueue_darwin.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/kqueue_darwin.go
+++ b/internal/iomultiplexer/kqueue_darwin.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/types.go
+++ b/internal/iomultiplexer/types.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/types.go
+++ b/internal/iomultiplexer/types.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/types_darwin.go
+++ b/internal/iomultiplexer/types_darwin.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/types_darwin.go
+++ b/internal/iomultiplexer/types_darwin.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/types_linux.go
+++ b/internal/iomultiplexer/types_linux.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iomultiplexer/types_linux.go
+++ b/internal/iomultiplexer/types_linux.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iothread/iothread.go
+++ b/internal/iothread/iothread.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iothread/iothread.go
+++ b/internal/iothread/iothread.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iothread/manager.go
+++ b/internal/iothread/manager.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/iothread/manager.go
+++ b/internal/iothread/manager.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/logger/zerolog.go
+++ b/internal/logger/zerolog.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/logger/zerolog.go
+++ b/internal/logger/zerolog.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/object/deep_copy.go
+++ b/internal/object/deep_copy.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/object/deep_copy.go
+++ b/internal/object/deep_copy.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/object/typeencoding.go
+++ b/internal/object/typeencoding.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/object/typeencoding.go
+++ b/internal/object/typeencoding.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/observability/constants.go
+++ b/internal/observability/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/observability/constants.go
+++ b/internal/observability/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/observability/hardware.go
+++ b/internal/observability/hardware.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/observability/hardware.go
+++ b/internal/observability/hardware.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/observability/instance.go
+++ b/internal/observability/instance.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/observability/instance.go
+++ b/internal/observability/instance.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/observability/ping.go
+++ b/internal/observability/ping.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/observability/ping.go
+++ b/internal/observability/ping.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/ops/store_op.go
+++ b/internal/ops/store_op.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/ops/store_op.go
+++ b/internal/ops/store_op.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/querymanager/watch_response.go
+++ b/internal/querymanager/watch_response.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/querymanager/watch_response.go
+++ b/internal/querymanager/watch_response.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/regex/regex_test.go
+++ b/internal/regex/regex_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/regex/regex_test.go
+++ b/internal/regex/regex_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/abstractserver/abstract_server.go
+++ b/internal/server/abstractserver/abstract_server.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/abstractserver/abstract_server.go
+++ b/internal/server/abstractserver/abstract_server.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/httpResp.go
+++ b/internal/server/httpws/httpResp.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/httpResp.go
+++ b/internal/server/httpws/httpResp.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/httpServer.go
+++ b/internal/server/httpws/httpServer.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/httpServer.go
+++ b/internal/server/httpws/httpServer.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/redisCmdAdapter.go
+++ b/internal/server/httpws/redisCmdAdapter.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/redisCmdAdapter.go
+++ b/internal/server/httpws/redisCmdAdapter.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/redisCmdAdapter_test.go
+++ b/internal/server/httpws/redisCmdAdapter_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/redisCmdAdapter_test.go
+++ b/internal/server/httpws/redisCmdAdapter_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/websocketServer.go
+++ b/internal/server/httpws/websocketServer.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/httpws/websocketServer.go
+++ b/internal/server/httpws/websocketServer.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/resp/server.go
+++ b/internal/server/resp/server.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/resp/server.go
+++ b/internal/server/resp/server.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/array.go
+++ b/internal/server/utils/array.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/array.go
+++ b/internal/server/utils/array.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/bitfield.go
+++ b/internal/server/utils/bitfield.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/bitfield.go
+++ b/internal/server/utils/bitfield.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/boolToInt.go
+++ b/internal/server/utils/boolToInt.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/boolToInt.go
+++ b/internal/server/utils/boolToInt.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/constants.go
+++ b/internal/server/utils/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/constants.go
+++ b/internal/server/utils/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/floatToInt.go
+++ b/internal/server/utils/floatToInt.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/floatToInt.go
+++ b/internal/server/utils/floatToInt.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/json.go
+++ b/internal/server/utils/json.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/json.go
+++ b/internal/server/utils/json.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/jsontype.go
+++ b/internal/server/utils/jsontype.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/jsontype.go
+++ b/internal/server/utils/jsontype.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/jsontype_test.go
+++ b/internal/server/utils/jsontype_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/jsontype_test.go
+++ b/internal/server/utils/jsontype_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/round.go
+++ b/internal/server/utils/round.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/round.go
+++ b/internal/server/utils/round.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/time.go
+++ b/internal/server/utils/time.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/server/utils/time.go
+++ b/internal/server/utils/time.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/shard/shard_manager.go
+++ b/internal/shard/shard_manager.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/shard/shard_manager.go
+++ b/internal/shard/shard_manager.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/shard/shard_thread.go
+++ b/internal/shard/shard_thread.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/shard/shard_thread.go
+++ b/internal/shard/shard_thread.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/aof.go
+++ b/internal/store/aof.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/aof.go
+++ b/internal/store/aof.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/aof_test.go
+++ b/internal/store/aof_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/aof_test.go
+++ b/internal/store/aof_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/batchevictionlru.go
+++ b/internal/store/batchevictionlru.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/batchevictionlru.go
+++ b/internal/store/batchevictionlru.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/batchevictionlru_test.go
+++ b/internal/store/batchevictionlru_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/batchevictionlru_test.go
+++ b/internal/store/batchevictionlru_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/constants.go
+++ b/internal/store/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/constants.go
+++ b/internal/store/constants.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/eviction.go
+++ b/internal/store/eviction.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/eviction.go
+++ b/internal/store/eviction.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/expire.go
+++ b/internal/store/expire.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/expire.go
+++ b/internal/store/expire.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/expire_test.go
+++ b/internal/store/expire_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/expire_test.go
+++ b/internal/store/expire_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/store_options.go
+++ b/internal/store/store_options.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/store/store_options.go
+++ b/internal/store/store_options.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal.pb.go
+++ b/internal/wal/wal.pb.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal.pb.go
+++ b/internal/wal/wal.pb.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal.proto
+++ b/internal/wal/wal.proto
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal.proto
+++ b/internal/wal/wal.proto
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal_aof.go
+++ b/internal/wal/wal_aof.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal_aof.go
+++ b/internal/wal/wal_aof.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal_null.go
+++ b/internal/wal/wal_null.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal_null.go
+++ b/internal/wal/wal_null.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal_sqlite.go
+++ b/internal/wal/wal_sqlite.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal_sqlite.go
+++ b/internal/wal/wal_sqlite.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/watchmanager/watch_manager.go
+++ b/internal/watchmanager/watch_manager.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/internal/watchmanager/watch_manager.go
+++ b/internal/watchmanager/watch_manager.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/mocks/slog_noop.go
+++ b/mocks/slog_noop.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/mocks/slog_noop.go
+++ b/mocks/slog_noop.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/testutils/json.go
+++ b/testutils/json.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/testutils/json.go
+++ b/testutils/json.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/testutils/parsecommand.go
+++ b/testutils/parsecommand.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/testutils/parsecommand.go
+++ b/testutils/parsecommand.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/testutils/slices.go
+++ b/testutils/slices.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2024 DiceDB (dicedb.io).
+// Copyright (C) 2025DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/testutils/slices.go
+++ b/testutils/slices.go
@@ -1,5 +1,5 @@
 // This file is part of DiceDB.
-// Copyright (C) 2025DiceDB (dicedb.io).
+// Copyright (C) 2025  DiceDB (dicedb.io).
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
### Description
Updated all occurrences of "2024" to "2025" across the repository to keep it aligned with the current year.

### Changes Made:
- Documentation updates in README.md, DOC.md
- Code comments and configuration file updates
- Ensured backward compatibility

### Tests
- Verified all changes manually.
- Ran `golangci-lint run` to ensure code quality.

### Notes
This is a non-breaking update to ensure the repository remains accurate for 2025.
