### PR TITLE
HTTP unmarshal a number into an interface{} as json.Number instead of float64

### DIFF
--- a/internal/server/httpws/redisCmdAdapter_test.go
+++ b/internal/server/httpws/redisCmdAdapter_test.go
@@ -17,6 +17,7 @@
 package httpws
 
 import (
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -81,6 +82,14 @@ func TestParseHTTPRequest(t *testing.T) {
 			body:         `{"key": "k1", "value": [{"subKey1": "value1"}, {"subKey2": "value2"}], "nx": "true"}`,
 			expectedCmd:  "SET",
 			expectedArgs: []string{"k1", `[{"subKey1":"value1"},{"subKey2":"value2"}]`, "nx"},
+		},
+		{
+			name:         "Test SET command with int64",
+			method:       "POST",
+			url:          "/set",
+			body:         `{"key": "k1", "value": -9223372036854775808}`,
+			expectedCmd:  "SET",
+			expectedArgs: []string{"k1", "-9223372036854775808"},
 		},
 		{
 			name:         "Test GET command",
@@ -226,6 +235,14 @@ func TestParseHTTPRequest(t *testing.T) {
 			expectedCmd:  "JSON.ARRPOP",
 			expectedArgs: []string{"k1", "$", "1"},
 		},
+		{
+			name:         "Test ABORT command",
+			method:       "POST",
+			url:          "/abort",
+			body:         `{}`,
+			expectedCmd:  "ABORT",
+			expectedArgs: []string{},
+		},
 	}
 
 	for _, tc := range commands {
@@ -247,6 +264,48 @@ func TestParseHTTPRequest(t *testing.T) {
 			// Check arguments match, regardless of order
 			assert.ElementsMatch(t, expectedCmd.Args, diceDBCmd.Args, "The parsed arguments should match the expected arguments, ignoring order")
 
+		})
+	}
+}
+
+func TestParseHTTPRequestError(t *testing.T) {
+	commands := []struct {
+		name        string
+		method      string
+		url         string
+		body        string
+		expectedErr string
+	}{
+		{
+			name:        "Unexpected EOF",
+			method:      "POST",
+			url:         "/set",
+			body:        `{"key": "malformed json}"`,
+			expectedErr: io.ErrUnexpectedEOF.Error(),
+		},
+		{
+			name:        "Empty body",
+			method:      "POST",
+			url:         "/set",
+			body:        `{}`,
+			expectedErr: "empty JSON object",
+		},
+		{
+			name:        "Syntax error",
+			method:      "POST",
+			url:         "/set",
+			body:        `{'key': "k1"}`,
+			expectedErr: "invalid character '\\'' looking for beginning of object key string",
+		},
+	}
+	for _, tc := range commands {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.url, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			_, err := ParseHTTPRequest(req)
+			assert.Error(t, err)
+			assert.EqualError(t, err, tc.expectedErr)
 		})
 	}
 }


### PR DESCRIPTION
fixes #1163

reference: https://pkg.go.dev/encoding/json#Decoder.UseNumber
> UseNumber causes the Decoder to unmarshal a number into an interface{} as a [Number](https://pkg.go.dev/encoding/json#Number) instead of as a float64.

## Changes
- Use `json.Decoder` with `UseNumber` option to unmarshal the JSON object received from http handler.
- Added a testcase for `math.MinInt64`.
- Added testcases for errors.

## Output
SET
```
curl --location --request GET 'localhost:8082/set' \
--header 'Content-Type: application/json' \
--data '{
    "key" : "a",
    "value" : -9223372036854775808
}'
{"status":"success","data":"OK"}
```

GET
```
curl --location --request GET 'localhost:8082/get' \
--header 'Content-Type: application/json' \
--data '{
    "key" : "a"
}'
{"status":"success","data":-9223372036854775808}
```