### PR TITLE
Fix: Ensure proper authentication when password is set against an user

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -72,7 +72,11 @@ func Start() {
 	// and new users in a much better way. Doing this using
 	// and empty password check is not a good solution.
 	if config.Config.Password != "" {
-		_, _ = auth.UserStore.Add(config.Config.Username)
+		user, _ := auth.UserStore.Add(config.Config.Username)
+		if err:= user.SetPassword(config.Config.Password); err != nil {
+			slog.Error("Could not set password", slog.String("password", config.Config.Password), slog.Any("error", err))
+			return
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/main.go
+++ b/server/main.go
@@ -73,10 +73,7 @@ func Start() {
 	// and empty password check is not a good solution.
 	if config.Config.Password != "" {
 		user, _ := auth.UserStore.Add(config.Config.Username)
-		if err:= user.SetPassword(config.Config.Password); err != nil {
-			slog.Error("Could not set password", slog.String("password", config.Config.Password), slog.Any("error", err))
-			return
-		}
+		_ = user.SetPassword(config.Config.Password)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
- Closes #1411 

**Description**
This PR sets password against an user when password is set with ```--password``` flag while starting the server with 
```go run main.go --password pass``` command.


<details>
<summary>Working Proof</summary>

- Starting the server with password flag
<img width="812" alt="Screenshot 2025-01-23 at 1 20 42 AM" src="https://github.com/user-attachments/assets/5259fea9-14c4-478d-ba1e-858b00266933" />

- Connecting cli and executing command without auth
<img width="633" alt="Screenshot 2025-01-23 at 1 21 09 AM" src="https://github.com/user-attachments/assets/05b1c23c-af43-4551-89f1-f97e6e132e6e" />

- Auth with wrong password
<img width="792" alt="Screenshot 2025-01-23 at 1 21 24 AM" src="https://github.com/user-attachments/assets/36251b14-3ca7-45b0-bf68-cb0072229a47" />

- Auth with correct password
<img width="745" alt="Screenshot 2025-01-23 at 1 21 36 AM" src="https://github.com/user-attachments/assets/60e553b4-f93e-469d-9018-eb28acad9a91" />

- Executing command with after successful auth
<img width="876" alt="Screenshot 2025-01-23 at 1 21 46 AM" src="https://github.com/user-attachments/assets/cc169cac-f317-42a9-a05f-05f210901bdf" />
</details>