### PR TITLE
docs: Update config file references from .conf to .yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bin/dice
 .vscode/
 dice-server
 dicedb
+dicedb.yaml
 venv
 __pycache__
 .idea/
@@ -28,12 +29,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-
 # environment variables
 .env
 .env.production
 
 # macOS-specific files
 .DS_Store
-dicedb.yaml
-dicedb.conf

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ air
 
 ### Local Setup with Custom Config
 
-By default, DiceDB will look for the configuration file at `./dicedb.conf`. (Linux, Darwin, and WSL)
+By default, DiceDB will look for the configuration file at `./dicedb.yaml`. (Linux, Darwin, and WSL)
 
 > [!TIP]
 > If you want to use a custom configuration file, you can specify the path using the `-c` flag. and to output the configuration file to a specific location, you can specify the output dir path using the `-o` flag.
@@ -210,4 +210,3 @@ This project is licensed under the BSD 3-Clause License. See the [LICENSE](LICEN
 ```
 $ sudo netstat -atlpn | grep :7379
 $ sudo kill -9 <process_id>
-```

--- a/docs/src/content/docs/commands/AUTH.md
+++ b/docs/src/content/docs/commands/AUTH.md
@@ -42,7 +42,7 @@ Once authenticated, the client can execute commands on the DiceDB server that re
 
 2. `(error) NOAUTH Authentication required`: This error occurs when a client attempts to execute a command without authenticating first. The client must use the `AUTH` command to authenticate before executing any other commands.
 
-3. `(error) ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?`: This error will be raised if the DiceDB server is not configured to use a password (i.e., the `requirepass` directive in the DiceDB.conf file is empty or commented out), and a client attempts to authenticate using the `AUTH` command.
+3. `(error) ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?`: This error will be raised if the DiceDB server is not configured to use a password (i.e., the `requirepass` directive in the `dicedb.yaml` file is empty or commented out), and a client attempts to authenticate using the `AUTH` command.
 
 ## Example Usage
 


### PR DESCRIPTION
Dice no longer looks for a conf so update the documentation to the yaml file.