### PR TITLE
Icon alignment issue on Website

### DIFF
--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -21,7 +21,7 @@ import { Github } from "lucide-astro";
             Get Started →
           </a>
         </p>
-        <p style="margin-top: 0.5em;">
+        <p class="content-fit" style="margin-top: 0.5em;">
           <a
             class="button is-fullwidth"
             target="_blank"

--- a/docs/src/styles/main.scss
+++ b/docs/src/styles/main.scss
@@ -213,4 +213,8 @@ pre {
   line-height: 1.5em !important;
 }
 
+.content-fit{
+  width: fit-content;
+}
+
 @import "../../node_modules/bulma/bulma.sass";


### PR DESCRIPTION
This PR fixes he GitHub icon misalignment issue in the footer on medium and small screens
-  Applied fit-content css property
-  Followed existing coding pattern

Issue Reference:
Closes #1436

Testing & Verification:
✅Verified the fix on screen dimensions 1025px, <768px and all others.
✅Ran golangci-lint and confirmed no linting errors.

Screenshots:
![Screenshot 2025-02-05 175159](https://github.com/user-attachments/assets/0c46329b-5fbd-4c5e-9e54-979cf3b95b2e)
