### PR TITLE
Fixed initial setup error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,4 +71,3 @@ require (
 	google.golang.org/protobuf v1.36.4
 )
 
-replace github.com/dicedb/dicedb-go => ../dicedb-go


### PR DESCRIPTION
While running the `make build` command, it was throwing the following error.
`internal/cmd/cmd_decr.go:9:2: github.com/dicedb/dicedb-go@v1.0.1: replacement directory ../dicedb-go does not exist
make: *** [build] Error 1`

Reason of failure-
- We introduced replace directive for `dicedb-go` in go.mod file