### PR TITLE
Fix for repeat messages when new client connects

### DIFF
--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -49,6 +49,8 @@ func (t *IOThread) StartSync(ctx context.Context, shardManager *ShardManager, wa
 		// TODO: Optimize this. We are doing this for all command execution
 		// Also, we are allowing people to override the client ID.
 		// Also, CLientID is duplicated in command and io-thread.
+		// Also, we shouldn't allow execution/registration incase of invalid commands
+		// like for B.WATCH cmd since it'll err out we shall return and not create subscription
 		t.ClientID = _c.ClientID
 
 		if c.Cmd == "HANDSHAKE" {

--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -73,7 +73,6 @@ func (t *IOThread) StartSync(ctx context.Context, shardManager *ShardManager, wa
 
 		// TODO: Streamline this because we need ordering of updates
 		// that are being sent to watchers.
-		_c.C.Cmd = strings.ReplaceAll(_c.C.Cmd, ".WATCH", "")
 		watchManager.NotifyWatchers(_c, shardManager, t)
 	}
 }

--- a/internal/server/ironhawk/watch_manager.go
+++ b/internal/server/ironhawk/watch_manager.go
@@ -139,6 +139,12 @@ func (w *WatchManager) NotifyWatchers(c *cmd.Cmd, shardManager *ShardManager, t 
 				continue
 			}
 
+			// If this is first time a client is connecting it'd be sending a GET.WATCH command
+			// in that case we don't need to notify all other clients subsribed to the key
+			if c.C.Cmd == "GET.WATCH" && t.ClientID != clientID {
+				continue
+			}
+
 			err := thread.IoHandler.WriteSync(context.Background(), r.R)
 			if err != nil {
 				slog.Error("failed to write response to thread",

--- a/internal/server/ironhawk/watch_manager.go
+++ b/internal/server/ironhawk/watch_manager.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	"github.com/dicedb/dice/internal/cmd"
 )
@@ -139,9 +140,9 @@ func (w *WatchManager) NotifyWatchers(c *cmd.Cmd, shardManager *ShardManager, t 
 				continue
 			}
 
-			// If this is first time a client is connecting it'd be sending a GET.WATCH command
-			// in that case we don't need to notify all other clients subsribed to the key
-			if c.C.Cmd == "GET.WATCH" && t.ClientID != clientID {
+			// If this is first time a client is connecting it'd be sending a .WATCH command
+			// in that case we don't need to notify all other clients subscribed to the key
+			if strings.HasSuffix(c.C.Cmd, ".WATCH") && t.ClientID != clientID {
 				continue
 			}
 


### PR DESCRIPTION
Closes #1478 

## Issue:
- When a new client connects it triggers message to all the connected/subscribed clients at that point of time.

## Cause:
- When a new client connects as part of `Subscribe()` when client sends `GET.WATCH` we're notifying all watchers.

## Solution:
- When a new client triggers `GET.WATCH` command we should just notify the client of the messages we've for that client if any pending don't need to trigger messages for all the subscribed clients, hence in notify watchers we're filtering the `GET.WATCH` command for given client if `GET.WATCH` subscribe.