### PR TITLE
update to create a dicedb.yaml file if not present

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ func Load(flags *pflag.FlagSet) {
 
 	err := viper.ReadInConfig()
 	if _, ok := err.(viper.ConfigFileNotFoundError); !ok && err != nil {
-		panic(err)
+		viper.WriteConfigAs(filepath.Join(MetadataDir, "dicedb.yaml"))
 	}
 
 	flags.VisitAll(func(flag *pflag.Flag) {


### PR DESCRIPTION
fixes #1500 

after cloning and running
make build &&  go run main.go it throws below error
reason is configureMetadataDir sets MetadataDir to '.' and if file isn't present it throws error
instead of throwing error it should create file


panic: While parsing config: yaml: control characters are not allowed

goroutine 1 [running]:
github.com/dicedb/dice/config.Load(0xc0002fee00)
        /mnt/c/code/dice/config/config.go:62 +0x130
github.com/dicedb/dice/cmd.init.func2(0xc0002fee00?, {0x13c8017?, 0x4?, 0x13c7fff?})
        /mnt/c/code/dice/cmd/root.go:47 +0x18
github.com/spf13/cobra.(*Command).execute(0x1ea1d00, {0xc000024090, 0x0, 0x0})
        /home/abhijeet/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x1ea1d00)
        /home/abhijeet/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/abhijeet/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/dicedb/dice/cmd.Execute()
        /mnt/c/code/dice/cmd/root.go:54 +0x1a
main.main()
        /mnt/c/code/dice/main.go:9 +0xf
exit status 2

