### PR TITLE
Added hyperlink to dicedb-go repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ start the CLI and will try to connect to the DiceDB server.
 
 ### Pointing to local checked-out `dicedb-go`
 
-It is advised to checkout `dicedb-go` repository also because `dice` takes
+It is advised to checkout [dicedb-go](https://github.com/DiceDB/dicedb-go) repository also because `dice` takes
 a strong dependency on it. To point to the local copy add the following line
 at the end of the `go.mod` file.
 


### PR DESCRIPTION
Added a link to the dicedb-go repository in the README , I was confused at first about where to find it. As a new contributor, it wasn’t obvious, and others might run into the same issue. This change should make it easier for people to find the right repository without any confusion.