### PR TITLE
Fix for ARGs length check

### DIFF
--- a/internal/cmd/cmd_decr.go
+++ b/internal/cmd/cmd_decr.go
@@ -42,6 +42,10 @@ func evalDECR(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeDECR(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("DECR")
+	}
+
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalDECR(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_decrby.go
+++ b/internal/cmd/cmd_decrby.go
@@ -36,6 +36,9 @@ func evalDECRBY(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeDECRBY(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 2 {
+		return cmdResNil, errors.ErrWrongArgumentCount("DECRBY")
+	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalDECRBY(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_del.go
+++ b/internal/cmd/cmd_del.go
@@ -51,6 +51,10 @@ func evalDEL(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeDEL(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) < 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("DEL")
+	}
+
 	var count int64
 	for _, key := range c.C.Args {
 		shard := sm.GetShardForKey(key)

--- a/internal/cmd/cmd_exists.go
+++ b/internal/cmd/cmd_exists.go
@@ -45,6 +45,9 @@ func evalEXISTS(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeEXISTS(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) < 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("EXISTS")
+	}
 	var count int64
 	for _, key := range c.C.Args {
 		shard := sm.GetShardForKey(key)

--- a/internal/cmd/cmd_expire.go
+++ b/internal/cmd/cmd_expire.go
@@ -62,6 +62,9 @@ func evalEXPIRE(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeEXPIRE(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) <= 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("EXPIRE")
+	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalEXPIRE(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_expireat.go
+++ b/internal/cmd/cmd_expireat.go
@@ -48,6 +48,10 @@ func evalEXPIREAT(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeEXPIREAT(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) < 2 {
+		return cmdResNil, errors.ErrWrongArgumentCount("EXPIREAT")
+	}
+
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalEXPIREAT(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_get.go
+++ b/internal/cmd/cmd_get.go
@@ -35,6 +35,9 @@ func evalGET(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeGET(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("GET")
+	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalGET(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_incr.go
+++ b/internal/cmd/cmd_incr.go
@@ -41,6 +41,9 @@ func evalINCR(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeINCR(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("INCR")
+	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalINCR(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_incrby.go
+++ b/internal/cmd/cmd_incrby.go
@@ -66,6 +66,9 @@ func doIncr(c *Cmd, s *dstore.Store, delta int64) (*CmdRes, error) {
 }
 
 func executeINCRBY(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 2 {
+		return cmdResNil, errors.ErrWrongArgumentCount("INCRBY")
+	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalINCRBY(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_set.go
+++ b/internal/cmd/cmd_set.go
@@ -185,6 +185,9 @@ func evalSET(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeSET(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) <= 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("SET")
+	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalSET(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_ttl.go
+++ b/internal/cmd/cmd_ttl.go
@@ -53,6 +53,9 @@ func evalTTL(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeTTL(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("TTL")
+	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalTTL(c, shard.Thread.Store())
 }

--- a/internal/cmd/cmd_unwatch.go
+++ b/internal/cmd/cmd_unwatch.go
@@ -29,6 +29,9 @@ func evalUNWATCH(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeUNWATCH(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("UNWATCH")
+	}
 	shard := sm.GetShardForKey("-")
 	return evalUNWATCH(c, shard.Thread.Store())
 }


### PR DESCRIPTION
Execute functions don't have length checks
DiceDB crashes if wrong number of args are given as it tries to get a shard for **args[0]**