### PR TITLE
Fixed issue of invalid commands in Ironhawk

### DIFF
--- a/internal/cmd/cmds.go
+++ b/internal/cmd/cmds.go
@@ -16,7 +16,7 @@ import (
 	"github.com/dicedb/dicedb-go/wire"
 )
 
-//nolint: stylecheck
+// nolint: stylecheck
 const INFINITE_EXPIRATION = int64(-1)
 
 type Cmd struct {
@@ -45,14 +45,10 @@ func (c *Cmd) Key() string {
 func (c *Cmd) Execute(sm *shardmanager.ShardManager) (*CmdRes, error) {
 	start := time.Now()
 	if c.Meta == nil {
-		for _, meta := range CommandRegistry.CommandMetas {
-			if meta.Name == c.C.Cmd {
-				c.Meta = meta
-				break
-			}
-		}
+		c.Meta = CommandRegistry.CommandMetas[c.C.Cmd]
 	}
 	res, err := c.Meta.Execute(c, sm)
+
 	slog.Debug("command executed",
 		slog.Any("cmd", c.String()),
 		slog.String("client_id", c.ClientID),
@@ -77,7 +73,7 @@ type CommandMeta struct {
 }
 
 type CmdRegistry struct {
-	CommandMetas []*CommandMeta
+	CommandMetas map[string]*CommandMeta
 }
 
 func Total() int {
@@ -85,11 +81,11 @@ func Total() int {
 }
 
 func (r *CmdRegistry) AddCommand(cmd *CommandMeta) {
-	r.CommandMetas = append(r.CommandMetas, cmd)
+	r.CommandMetas[cmd.Name] = cmd
 }
 
 var CommandRegistry CmdRegistry = CmdRegistry{
-	CommandMetas: []*CommandMeta{},
+	CommandMetas: map[string]*CommandMeta{},
 }
 
 // DiceDBCmd represents a command structure to be executed

--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -40,25 +40,19 @@ func (t *IOThread) StartSync(ctx context.Context, shardManager *shardmanager.Sha
 		if err != nil {
 			return err
 		}
-
-		// TODO: Replace this iteration with a HashTable lookup.
-		var _meta *cmd.CommandMeta
-		for _, _meta = range cmd.CommandRegistry.CommandMetas {
-			if _meta.Name == c.Cmd {
-				break
-			}
-		}
-		if _meta == nil {
-			return fmt.Errorf("command '%s' not found", c.Cmd)
-		}
-
 		_c := &cmd.Cmd{C: c}
 		_c.ClientID = t.ClientID
 		_c.Mode = t.Mode
 
-		res, err := _c.Execute(shardManager)
-		if err != nil {
-			res = &cmd.CmdRes{R: &wire.Response{Err: err.Error()}}
+		var _meta *cmd.CommandMeta = cmd.CommandRegistry.CommandMetas[c.Cmd]
+		var res *cmd.CmdRes
+		if _meta == nil {
+			res = &cmd.CmdRes{R: &wire.Response{Err: fmt.Errorf("command %s not found", c.Cmd).Error()}}
+		} else {
+			res, err = _c.Execute(shardManager)
+			if err != nil {
+				res = &cmd.CmdRes{R: &wire.Response{Err: err.Error()}}
+			}
 		}
 
 		// TODO: Optimize this. We are doing this for all command execution


### PR DESCRIPTION
Fixed issue of not handling invalid commands in IronHawk engine. Also changed CommandMetas to a map for O(1) lookup.

Issue [#1541 ](https://github.com/DiceDB/dice/issues/1541)