### PR TITLE
ISSUE 1536 : Add support for space quoted string in ECHO command and CLI

### DIFF
--- a/internal/cmd/cmd_echo.go
+++ b/internal/cmd/cmd_echo.go
@@ -27,12 +27,9 @@ func init() {
 }
 
 func evalECHO(c *Cmd, s *dstore.Store) (*CmdRes, error) {
-	if len(c.C.Args) != 1 {
-		return cmdResNil, errors.ErrWrongArgumentCount("ECHO")
-	}
-
+	message := strings.Join(c.C.Args, " ")
 	return &CmdRes{R: &wire.Response{
-		Value: &wire.Response_VStr{VStr: c.C.Args[0]},
+		Value: &wire.Response_VStr{VStr: message},
 	}}, nil
 }
 


### PR DESCRIPTION
**Previously**
```
localhost:7379> echo "rohan"
OK "rohan"
```
```
localhost:7379> ECHO "Hello, World!"
ERR wrong number of arguments for 'ECHO' command
```

**After Fix**
```
localhost:7379> echo "rohan"
OK "rohan"
```
```
localhost:7379> ECHO "Hello, World!"
OK "Hello, World!"
```
```
localhost:7379> ECHO Rohan Sharma
OK Rohan Sharma
```
```
localhost:7379> ECHO Rohan Sharma               Apple
OK Rohan Sharma Apple
```
