### PR TITLE
Slim docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
-FROM golang:1.24 AS builder
+# Start from a slim apline image
+FROM golang:1.24-alpine AS builder
 WORKDIR /src
 COPY . .
+# Install musl-dev to make sure we get the required libraries
+RUN apk add --no-cache gcc musl-dev libc6-compat make
+# Build dicedb
+RUN make build
 
-# Detect platform and set architecture dynamically
-# Had to do this as I have a arm64 machine
-ARG TARGETPLATFORM
-RUN case "$TARGETPLATFORM" in \
-      "linux/amd64") export GOARCH=amd64 ;; \
-      "linux/arm64") export GOARCH=arm64 ;; \
-      *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
-    esac && \
-    CGO_ENABLED=0 GOOS=linux go build -o /src/dicedb
+FROM alpine
 
-FROM alpine:latest
 COPY --from=builder /src/dicedb /src/dicedb
+
 COPY VERSION .
-RUN chmod +x /src/dicedb
 
 EXPOSE 7379
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,20 @@
 FROM golang:1.24 AS builder
 WORKDIR /src
 COPY . .
-RUN make build
 
+# Detect platform and set architecture dynamically
+# Had to do this as I have a arm64 machine
+ARG TARGETPLATFORM
+RUN case "$TARGETPLATFORM" in \
+      "linux/amd64") export GOARCH=amd64 ;; \
+      "linux/arm64") export GOARCH=arm64 ;; \
+      *) echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
+    esac && \
+    CGO_ENABLED=0 GOOS=linux go build -o /src/dicedb
+
+FROM alpine:latest
+COPY --from=builder /src/dicedb /src/dicedb
+COPY VERSION .
 RUN chmod +x /src/dicedb
 
 EXPOSE 7379


### PR DESCRIPTION
The current image size is about 1.67GB

![CleanShot 2025-03-10 at 13 42 10@2x](https://github.com/user-attachments/assets/f4fe0eb5-b776-4336-a7d2-0523decb5973)

Post updates

![CleanShot 2025-03-10 at 20 26 51@2x](https://github.com/user-attachments/assets/308c98b3-a59c-4d6c-8e17-fbdaf049f506)


Now we use docker multi layer build and an alpine image.

## Test

Tested by running docker image, we see the startup logs.

![CleanShot 2025-03-10 at 20 27 36@2x](https://github.com/user-attachments/assets/e771e1db-b108-476b-91fe-3084f11a27da)
