### PR TITLE
Updated KeyFeatures.astro

### DIFF
--- a/docs/src/components/KeyFeatures.astro
+++ b/docs/src/components/KeyFeatures.astro
@@ -34,7 +34,7 @@ import { ArrowDownLeft, Cpu, Waves } from "lucide-astro";
           <span style="margin-left: 0.5em;">For Modern Hardware</span>
         </h3>
         <p>
-          fully utilizes underlying core to get higher throughput and better hardware utilization.
+          fully utilizes underlying cores to get higher throughput and better hardware utilization.
         </p>
       </div>
     </div>

--- a/docs/src/components/KeyFeatures.astro
+++ b/docs/src/components/KeyFeatures.astro
@@ -34,7 +34,7 @@ import { ArrowDownLeft, Cpu, Waves } from "lucide-astro";
           <span style="margin-left: 0.5em;">For Modern Hardware</span>
         </h3>
         <p>
-          fully utilizes underlying core to get higgher throughput and better hardware utilization.
+          fully utilizes underlying core to get higher throughput and better hardware utilization.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Fixed spelling mistake from "higgher" to "higher" section of "For Modern Hardware section" in KeyFeatures.astro file

![image](https://github.com/user-attachments/assets/3e016c47-4b01-419b-97fc-dc161898e705)
