### PR TITLE
#1578 Make ping write a PONG prefix when one arg is passed, as per documentation

### DIFF
--- a/internal/cmd/cmd_ping.go
+++ b/internal/cmd/cmd_ping.go
@@ -41,7 +41,7 @@ func evalPING(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 		}}, nil
 	}
 	return &CmdRes{R: &wire.Response{
-		Value: &wire.Response_VStr{VStr: c.C.Args[0]},
+		Value: &wire.Response_VStr{VStr: "PONG " + c.C.Args[0]},
 	}}, nil
 }
 

--- a/tests/commands/ironhawk/ping_test.go
+++ b/tests/commands/ironhawk/ping_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package ironhawk
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPing(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "PING no arguments",
+			commands: []string{"PING"},
+			expected: []interface{}{"PONG"},
+		},
+		{
+			name:     "PING with one argument",
+			commands: []string{"PING hello"},
+			expected: []interface{}{"PONG hello"},
+		},
+		{
+			name:     "PING with two arguments",
+			commands: []string{"PING hello world"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'PING' command"),
+			},
+		},
+	}
+	runTestcases(t, client, testCases)
+}


### PR DESCRIPTION
This is to address https://github.com/DiceDB/dice/issues/1578

I noticed an inconsistency between the docs and dicedb behavior when running through the commands locally.

I've gone ahead and made the code consistent with the docsite and command docs. Also added a test file for this command which covers the general use cases.

Ran tests and linters and everything looks good.