### PR TITLE
Fixed typo in HANDSHAKE.md and cmd_handshake.go

### DIFF
--- a/docs/src/content/docs/commands/HANDSHAKE.md
+++ b/docs/src/content/docs/commands/HANDSHAKE.md
@@ -14,7 +14,6 @@ description: HANDSHAKE tells the server the purpose of the connection
 HANDSHAKE client_id execution_mode
 ```
 
-
 HANDSHAKE is used to tell the DiceDB server the purpose of the connection. It
 registers the client_id and execution_mode.
 
@@ -24,11 +23,10 @@ a UUID.
 The execution_mode is the mode of the connection, it can be one of the following:
 
 1. "command" - The client will send commands to the server and receive responses.
-2. "watch" - The connection in the watch mode will be used to receoive the responses of query subscriptions.
+2. "watch" - The connection in the watch mode will be used to receive the responses of query subscriptions.
 
 If you use DiceDB SDK or CLI then this HANDSHAKE command is automatically sent when the connection is established
 or when you establish a subscription.
-	
 
 #### Examples
 
@@ -36,5 +34,5 @@ or when you establish a subscription.
 
 localhost:7379> HANDSHAKE 4c9d0411-6b28-4ee5-b78a-e7e258afa52f command
 OK OK
-	
+
 ```

--- a/internal/cmd/cmd_handshake.go
+++ b/internal/cmd/cmd_handshake.go
@@ -23,7 +23,7 @@ a UUID.
 The execution_mode is the mode of the connection, it can be one of the following:
 
 1. "command" - The client will send commands to the server and receive responses.
-2. "watch" - The connection in the watch mode will be used to receoive the responses of query subscriptions.
+2. "watch" - The connection in the watch mode will be used to receive the responses of query subscriptions.
 
 If you use DiceDB SDK or CLI then this HANDSHAKE command is automatically sent when the connection is established
 or when you establish a subscription.


### PR DESCRIPTION
In PRs https://github.com/DiceDB/dice/pull/1580 and https://github.com/DiceDB/dice/pull/1582 the typo has been fixed only in docs/src/content/docs/commands/HANDSHAKE.md file. 

This PR aims to fix the typo in below files
docs/src/content/docs/commands/HANDSHAKE.md
internal/cmd/cmd_handshake.go

