### PR TITLE
Typo correction in Documentation - EXPIRE command page

### DIFF
--- a/docs/src/content/docs/commands/EXPIRE.md
+++ b/docs/src/content/docs/commands/EXPIRE.md
@@ -17,7 +17,7 @@ EXPIRE key seconds [NX | XX]
 
 EXPIRE sets an expiry (in seconds) on a specified key. After the expiry time has elapsed, the key will be automatically deleted.
 
-> If you want to delete the expirtation time on the key, you can use the PERSIST command.
+> If you want to delete the expiration time on the key, you can use the PERSIST command.
 
 The command returns 1 if the expiry was set, and 0 if the key already had an expiry set. The command supports the following options:
 


### PR DESCRIPTION
There is a typographical error in the documentation page for EXPIRE command. 

The word expiration is misspelled. This commit corrects the typographical error. 

Attached is the screenshot of the error located at https://dicedb.io/commands/expire/

![image](https://github.com/user-attachments/assets/b6b65630-b946-41b1-a6b7-e2853989f478)




