### PR TITLE
fix: VERSION Parameter not getting picked in make build 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOARCH ?= $(shell go env GOARCH)
 
 build:
 	@echo "Building for $(GOOS)/$(GOARCH)"
-	CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-s -w -X config.DiceDBVersion=$VERSION" -o ./dicedb
+	CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-s -w -X config.DiceDBVersion=$(VERSION)" -o ./dicedb
 
 build-debug:
 	@echo "Building for $(GOOS)/$(GOARCH)"


### PR DESCRIPTION
before change
Building for darwin/amd64
CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X config.DiceDBVersion=ERSION" -o ./dicedb

after change
Building for darwin/amd64
CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X config.DiceDBVersion=v1.0.3" -o ./dicedb