### PR TITLE
Adds support for `H*` command.

### DIFF
--- a/internal/cmd/cmd_hget.go
+++ b/internal/cmd/cmd_hget.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/shardmanager"
+	dstore "github.com/dicedb/dice/internal/store"
+	"github.com/dicedb/dicedb-go/wire"
+)
+
+var cHGET = &CommandMeta{
+	Name:      "HGET",
+	Syntax:    "HGET key field",
+	HelpShort: "HGET returns the value of field for the key",
+	HelpLong: `
+HGET returns the field value for the hash key in args.
+
+The command returns (nil) if the key or field does not exist.
+	`,
+	Examples: `
+localhost:7379> HSET k1 f1 v1
+OK OK
+localhost:7379> HGET k1 f1
+OK v1
+localhost:7379> HGET k2
+(nil)
+localhost:7379> HGET k1 f2
+(nil)
+	`,
+	Eval:    evalHGET,
+	Execute: executeHGET,
+}
+
+func init() {
+	CommandRegistry.AddCommand(cHGET)
+}
+
+func evalHGET(c *Cmd, s *dstore.Store) (*CmdRes, error) {
+	key := c.C.Args[0]
+	field := c.C.Args[1]
+	obj := s.Get(key)
+
+	if obj == nil {
+		return cmdResNil, nil
+	}
+
+	hashMap, ok := obj.Value.(HashMap)
+
+	if !ok {
+		return cmdResNil, errors.ErrWrongTypeOperation
+	}
+
+	val, present := hashMap.Get(field)
+	if !present {
+		return cmdResNil, nil
+	}
+
+	return &CmdRes{R: &wire.Response{
+		Value: &wire.Response_VStr{VStr: *val},
+	}}, nil
+}
+
+func executeHGET(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 2 {
+		return cmdResNil, errors.ErrWrongArgumentCount("HGET")
+	}
+	shard := sm.GetShardForKey(c.C.Args[0])
+	return evalHGET(c, shard.Thread.Store())
+}

--- a/internal/cmd/cmd_hgetall.go
+++ b/internal/cmd/cmd_hgetall.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/object"
+	"github.com/dicedb/dice/internal/shardmanager"
+	dstore "github.com/dicedb/dice/internal/store"
+	"github.com/dicedb/dicedb-go/wire"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var cHGETALL = &CommandMeta{
+	Name:      "HGETALL",
+	Syntax:    "HGETALL key",
+	HelpShort: "HGET returns all the field and value for the key",
+	HelpLong: `
+HGET returns all the field and value for the key.
+
+The command returns (nil) if the key does not exist.
+	`,
+	Examples: `
+localhost:7379> HSET k1 f1 v1
+OK OK
+localhost:7379> HGETALL k1
+OK f1
+v1
+localhost:7379> HGETALL k2
+(nil)
+	`,
+	Eval:    evalHGETALL,
+	Execute: executeHGETALL,
+}
+
+func init() {
+	CommandRegistry.AddCommand(cHGETALL)
+}
+
+func evalHGETALL(c *Cmd, s *dstore.Store) (*CmdRes, error) {
+	key := c.C.Args[0]
+	obj := s.Get(key)
+
+	var hashMap HashMap
+
+	if obj != nil {
+		if err := object.AssertType(obj.Type, object.ObjTypeHashMap); err != nil {
+			return cmdResNil, errors.ErrWrongTypeOperation
+		}
+		hashMap = obj.Value.(HashMap)
+	}
+
+	var vlist []*structpb.Value
+	for key, val := range hashMap {
+		field, err1 := structpb.NewValue(key)
+		value, err2 := structpb.NewValue(val)
+		if err1 != nil || err2 != nil {
+			return nil, errors.ErrUnknownObjectType
+		}
+		vlist = append(vlist, field, value)
+	}
+
+	return &CmdRes{R: &wire.Response{
+		VList: vlist,
+	}}, nil
+}
+
+func executeHGETALL(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("HGETALL")
+	}
+	shard := sm.GetShardForKey(c.C.Args[0])
+	return evalHGETALL(c, shard.Thread.Store())
+}

--- a/internal/cmd/cmd_hgetall_watch.go
+++ b/internal/cmd/cmd_hgetall_watch.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"strconv"
+
+	"github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/shardmanager"
+	dstore "github.com/dicedb/dice/internal/store"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var cHGETALLWATCH = &CommandMeta{
+	Name:      "HGETALL.WATCH",
+	Syntax:    "HGETALL.WATCH key",
+	HelpShort: "HGETALL.WATCH creates a query subscription over the HGETALL command",
+	HelpLong: `
+HGETALL.WATCH creates a query subscription over the HGETALL command. The client invoking the command
+will receive the output of the HGETALL command (not just the notification) whenever the value against
+the key is updated.
+
+> This is part of the [Reactivity](https://dicedb.io/reactivity) paradigm offered by DiceDB.
+
+You can update the key in any other client. The HGETALL.WATCH client will receive the updated value.
+	`,
+	Examples: `
+client1:7379> HSET k f1 v1
+OK 1
+client1:7379> HGETALL.WATCH k
+entered the watch mode for HGETALL.WATCH k
+
+
+client2:7379> HSET k f2 v2
+OK 1
+
+
+client1:7379> ...
+entered the watch mode for HGETALL.WATCH k
+OK [fingerprint=2356444921] f2 v2
+	`,
+	Eval:    evalHGETALLWATCH,
+	Execute: executeHGETALLWATCH,
+}
+
+func init() {
+	CommandRegistry.AddCommand(cHGETALLWATCH)
+}
+
+func evalHGETALLWATCH(c *Cmd, s *dstore.Store) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("HGETALL.WATCH")
+	}
+
+	r, err := evalHGETALL(c, s)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.R.Attrs == nil {
+		r.R.Attrs = &structpb.Struct{
+			Fields: make(map[string]*structpb.Value),
+		}
+	}
+
+	r.R.Attrs.Fields["fingerprint"] = structpb.NewStringValue(strconv.FormatUint(uint64(c.Fingerprint()), 10))
+	return r, nil
+}
+
+func executeHGETALLWATCH(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("HGETALL.WATCH")
+	}
+	shard := sm.GetShardForKey(c.C.Args[0])
+	return evalHGETALLWATCH(c, shard.Thread.Store())
+}

--- a/internal/cmd/cmd_hset.go
+++ b/internal/cmd/cmd_hset.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/object"
+	"github.com/dicedb/dice/internal/shardmanager"
+	dstore "github.com/dicedb/dice/internal/store"
+	"github.com/dicedb/dicedb-go/wire"
+)
+
+type HashMap map[string]string
+
+var cHSET = &CommandMeta{
+	Name:      "HSET",
+	Syntax:    "HSET key field value [field value ...]",
+	HelpShort: "HSET sets field value in the hash stored at key",
+	HelpLong: `
+HSET sets the field and value for the key in args.
+
+Returns "OK" if the field value was set or updated to hash key. Returns (nil) if the field value was not set or updated to hash key.
+	`,
+	Examples: `
+localhost:7379> HSET k1 f1 v1
+OK OK
+localhost:7379> HGET k1 f1
+OK v1
+localhost:7379> HGET k2 f1
+OK (nil)
+	`,
+	Eval:    evalHSET,
+	Execute: executeHSET,
+}
+
+func init() {
+	CommandRegistry.AddCommand(cHSET)
+}
+
+func (h HashMap) Get(k string) (*string, bool) {
+	value, ok := h[k]
+	if !ok {
+		return nil, false
+	}
+	return &value, true
+}
+
+func (h HashMap) Set(k, v string) (*string, bool) {
+	value, ok := h[k]
+	if ok {
+		oldValue := value
+		h[k] = v
+		return &oldValue, true
+	}
+
+	h[k] = v
+	return nil, false
+}
+
+func hashMapBuilder(keyValuePairs []string, currentHashMap HashMap) (HashMap, int64, error) {
+	var hmap HashMap
+	var numKeysNewlySet int64
+
+	if currentHashMap == nil {
+		hmap = make(HashMap)
+	} else {
+		hmap = currentHashMap
+	}
+
+	iter := 0
+	argLength := len(keyValuePairs)
+
+	for iter <= argLength-1 {
+		if iter >= argLength-1 || iter+1 > argLength-1 {
+			return hmap, -1, errors.ErrWrongArgumentCount("HSET")
+		}
+
+		k := keyValuePairs[iter]
+		v := keyValuePairs[iter+1]
+
+		_, present := hmap.Set(k, v)
+		if !present {
+			numKeysNewlySet++
+		}
+		iter += 2
+	}
+
+	return hmap, numKeysNewlySet, nil
+}
+
+func evalHSET(c *Cmd, s *dstore.Store) (*CmdRes, error) {
+	key := c.C.Args[0]
+	obj := s.Get(key)
+
+	var hashMap HashMap
+
+	if obj != nil {
+		if err := object.AssertType(obj.Type, object.ObjTypeHashMap); err != nil {
+			return cmdResNil, errors.ErrWrongTypeOperation
+		}
+		hashMap = obj.Value.(HashMap)
+	}
+
+	keyValuePairs := c.C.Args[1:]
+
+	hashMap, numKeys, err := hashMapBuilder(keyValuePairs, hashMap)
+	if err != nil {
+		return cmdResNil, err
+	}
+
+	obj = s.NewObj(hashMap, -1, object.ObjTypeHashMap)
+	s.Put(key, obj)
+
+	return &CmdRes{R: &wire.Response{
+		Value: &wire.Response_VInt{VInt: numKeys},
+	}}, nil
+}
+
+func executeHSET(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) < 3 {
+		return cmdResNil, errors.ErrWrongArgumentCount("HSET")
+	}
+	shard := sm.GetShardForKey(c.C.Args[0])
+	return evalHSET(c, shard.Thread.Store())
+}

--- a/tests/commands/ironhawk/hget_test.go
+++ b/tests/commands/ironhawk/hget_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package ironhawk
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestHGET(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "Get Value for Field stored at Hash Key",
+			commands: []string{"HSET k f 1", "HGET k f"},
+			expected: []interface{}{1, "1"},
+		},
+		{
+			name:     "Get Hash Field on non-hash Key",
+			commands: []string{"SET key f", "HGET key f"},
+			expected: []interface{}{"OK",
+				errors.New("wrongtype operation against a key holding the wrong kind of value"),
+			},
+		},
+		{
+			name:     "Get Hash Key with no Field argument",
+			commands: []string{"HGET k"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'HGET' command"),
+			},
+		},
+	}
+	runTestcases(t, client, testCases)
+}

--- a/tests/commands/ironhawk/hgetall_test.go
+++ b/tests/commands/ironhawk/hgetall_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package ironhawk
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestHGETALL(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "Get Value for Field stored at Hash Key",
+			commands: []string{"HSET k f1 v1 f2 v2", "HGETALL k"},
+			expected: []interface{}{2,
+				[]*structpb.Value{
+					structpb.NewStringValue("f1"),
+					structpb.NewStringValue("v1"),
+					structpb.NewStringValue("f2"),
+					structpb.NewStringValue("v2"),
+				},
+			},
+		},
+		{
+			name:     "HGETALL with no key argument",
+			commands: []string{"HGETALL"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'HGETALL' command"),
+			},
+		},
+		{
+			name:     "HGETALL with non hash key",
+			commands: []string{"SET key 5", "HGETALL key"},
+			expected: []interface{}{"OK",
+				errors.New("wrongtype operation against a key holding the wrong kind of value"),
+			},
+		},
+	}
+	runTestcases(t, client, testCases)
+}

--- a/tests/commands/ironhawk/hset_test.go
+++ b/tests/commands/ironhawk/hset_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package ironhawk
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestHSET(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "Set Field Value at Key stored in Hash",
+			commands: []string{"HSET k f v"},
+			expected: []interface{}{1},
+		},
+		{
+			name:     "Set Hash on non-hash Key",
+			commands: []string{"SET key f", "HSET key f v"},
+			expected: []interface{}{"OK",
+				errors.New("wrongtype operation against a key holding the wrong kind of value"),
+			},
+		},
+		{
+			name:     "Set Hash with no Field and Value",
+			commands: []string{"HSET k"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'HSET' command"),
+			},
+		},
+	}
+	runTestcases(t, client, testCases)
+}

--- a/tests/commands/ironhawk/main_test.go
+++ b/tests/commands/ironhawk/main_test.go
@@ -5,6 +5,7 @@ package ironhawk
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/dicedb/dice/config"
 	"github.com/dicedb/dicedb-go"
 	"github.com/dicedb/dicedb-go/wire"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestMain(m *testing.M) {
@@ -39,6 +41,10 @@ func assertEqual(t *testing.T, expected interface{}, actual *wire.Response) bool
 		areEqual = actual.GetVNil()
 	case error:
 		areEqual = v.Error() == actual.Err
+	case []*structpb.Value:
+		if actual.VList != nil {
+			areEqual = reflect.DeepEqual(v, actual.GetVList())
+		}
 	}
 	if !areEqual {
 		t.Errorf("expected %v, got %v", expected, actual)


### PR DESCRIPTION
Implements `HSET`, `HGET`, `HGETALL` commands on IronHawk and also adds support for watch subscription on `HGETALL`
Fixes: #1124 


![Screenshot from 2025-03-19 16-25-18](https://github.com/user-attachments/assets/f712c7b1-9bba-42fe-892c-2dd59b994adf)
