### PR TITLE
Fix dice exit process on `GET.WATCH` with no arg.

### DIFF
--- a/internal/cmd/cmd_get_watch.go
+++ b/internal/cmd/cmd_get_watch.go
@@ -49,10 +49,6 @@ func init() {
 }
 
 func evalGETWATCH(c *Cmd, s *dstore.Store) (*CmdRes, error) {
-	if len(c.C.Args) != 1 {
-		return cmdResNil, errors.ErrWrongArgumentCount("GET.WATCH")
-	}
-
 	r, err := evalGET(c, s)
 	if err != nil {
 		return nil, err
@@ -69,6 +65,9 @@ func evalGETWATCH(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 }
 
 func executeGETWATCH(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("GET.WATCH")
+	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalGETWATCH(c, shard.Thread.Store())
 }

--- a/tests/commands/ironhawk/get_watch_test.go
+++ b/tests/commands/ironhawk/get_watch_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package ironhawk
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGETWATCH(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "Get watch subscription without key arg",
+			commands: []string{"GET.WATCH"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'GET.WATCH' command"),
+			},
+		},
+	}
+
+	runTestcases(t, client, testCases)
+}


### PR DESCRIPTION
Fixes: #1595 