### PR TITLE
fix result for multiple keys in exists command

### DIFF
--- a/internal/cmd/utils/list.go
+++ b/internal/cmd/utils/list.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package utils
+
+func GetUniqueList[T comparable](arr []T) []T {
+	seen := make(map[T]struct{})
+	var result []T
+
+	for _, v := range arr {
+		if _, exists := seen[v]; !exists {
+			seen[v] = struct{}{}
+			result = append(result, v)
+		}
+	}
+
+	return result
+}

--- a/tests/commands/ironhawk/exists_test.go
+++ b/tests/commands/ironhawk/exists_test.go
@@ -40,6 +40,16 @@ func TestExists(t *testing.T) {
 			commands: []string{"EXISTS"},
 			expected: []interface{}{0},
 		},
+		{
+			name:     "EXISTS with duplicate keys",
+			commands: []string{"SET key value", "EXISTS key key"},
+			expected: []interface{}{"OK", 1},
+		},
+		{
+			name:     "EXISTS with duplicate keys multiple keys",
+			commands: []string{"SET key value", "SET key1 value", "EXISTS key key key1"},
+			expected: []interface{}{"OK", "OK", 2},
+		},
 	}
 
 	runTestcases(t, client, testCases)


### PR DESCRIPTION
fixes #1597 

change:
1. get distinct shard to query
2. for each shard query for distinct keys

```/mnt/c/code/dice$ TEST_FUNC="^TestExists$" make test-one
go clean -testcache
CGO_ENABLED=1 go test -v -race -count=1 --run ^TestExists$ ./tests/...
=== RUN   TestExists
=== RUN   TestExists/Test_EXISTS_command
=== RUN   TestExists/Test_EXISTS_command_with_multiple_keys
=== RUN   TestExists/Test_EXISTS_an_expired_key
=== RUN   TestExists/Test_EXISTS_with_multiple_keys_and_expired_key
=== RUN   TestExists/EXISTS_with_no_keys_or_arguments
=== RUN   TestExists/EXISTS_with_duplicate_keys
=== RUN   TestExists/EXISTS_with_duplicate_keys_multiple_keys
--- PASS: TestExists (4.01s)
    --- PASS: TestExists/Test_EXISTS_command (0.00s)
    --- PASS: TestExists/Test_EXISTS_command_with_multiple_keys (0.00s)
    --- PASS: TestExists/Test_EXISTS_an_expired_key (2.00s)
    --- PASS: TestExists/Test_EXISTS_with_multiple_keys_and_expired_key (2.00s)
    --- PASS: TestExists/EXISTS_with_no_keys_or_arguments (0.00s)
    --- PASS: TestExists/EXISTS_with_duplicate_keys (0.00s)
    --- PASS: TestExists/EXISTS_with_duplicate_keys_multiple_keys (0.00s)
PASS
ok      github.com/dicedb/dice/tests/commands/ironhawk  5.074s
testing: warning: no tests to run
PASS
ok      github.com/dicedb/dice/tests/server     1.014s [no tests to run]