### PR TITLE
Fix typo in KeyFeatures.astro

### DIFF
--- a/docs/src/components/KeyFeatures.astro
+++ b/docs/src/components/KeyFeatures.astro
@@ -41,7 +41,7 @@ import { ArrowDownLeft, Cpu, Waves } from "lucide-astro";
           <span style="margin-left: 0.5em;">For Modern Hardware</span>
         </h3>
         <p>
-          fully utilizes underlying core to get higgher throughput and better
+          fully utilizes underlying core to get higher throughput and better
           hardware utilization.
         </p>
       </div>


### PR DESCRIPTION
Fixes a typo: `higgher` -> `higher`.