### PR TITLE
Fix float values retrieval in GET command

### DIFF
--- a/internal/cmd/cmd_get.go
+++ b/internal/cmd/cmd_get.go
@@ -74,6 +74,10 @@ func cmdResFromObject(obj *object.Obj) (*CmdRes, error) {
 		return &CmdRes{R: &wire.Response{
 			Value: &wire.Response_VBytes{VBytes: obj.Value.([]byte)},
 		}}, nil
+	case object.ObjTypeFloat:
+		return &CmdRes{R: &wire.Response{
+			Value: &wire.Response_VFloat{VFloat: obj.Value.(float64)},
+		}}, nil
 	default:
 		slog.Error("unknown object type", "type", obj.Type)
 		return cmdResNil, errors.ErrUnknownObjectType


### PR DESCRIPTION
```
localhost:7379> get k1
OK (nil)
localhost:7379> set k1 3.1
OK OK
localhost:7379> get k1
OK 3.100000
localhost:7379> set k1 3.1234566
OK OK
localhost:7379> get k1
OK 3.123457
localhost:7379> set k1 3.1234566123124234234
OK OK
localhost:7379> get k1
OK 3.123457
```