### PR TITLE
[FEAT|NEW]: GETSET & KEYS command

### DIFF
--- a/internal/cmd/cmd_getset.go
+++ b/internal/cmd/cmd_getset.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"strconv"
+
+	"github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/object"
+	"github.com/dicedb/dice/internal/shardmanager"
+	dstore "github.com/dicedb/dice/internal/store"
+)
+
+var cGETSET = &CommandMeta{
+	Name:      "GETSET",
+	Syntax:    "GETSET key value",
+	HelpShort: "GETSET sets the value for the key and returns the old value",
+	HelpLong: `
+GETSET sets the value for the key and returns the old value.
+
+The command returns (nil) if the key does not exist.
+	`,
+	Examples: `
+localhost:7379> SET k1 v1
+OK OK
+localhost:7379> GETSET k1 v2
+OK v1
+localhost:7379> GET k1
+OK v2
+	`,
+	Eval:    evalGETSET,
+	Execute: executeGETSET,
+}
+
+func init() {
+	CommandRegistry.AddCommand(cGETSET)
+}
+
+func evalGETSET(c *Cmd, s *dstore.Store) (*CmdRes, error) {
+	if len(c.C.Args) != 2 {
+		return cmdResNil, errors.ErrWrongArgumentCount("GETSET")
+	}
+	key := c.C.Args[0]
+	value := c.C.Args[1]
+	obj := s.Get(key)
+	intValue, err := strconv.ParseInt(value, 10, 64)
+
+	if err == nil {
+		s.Put(key, s.NewObj(intValue, -1, object.ObjTypeInt))
+	} else {
+		floatValue, err := strconv.ParseFloat(value, 64)
+		if err == nil {
+			s.Put(key, s.NewObj(floatValue, -1, object.ObjTypeFloat))
+		} else {
+			s.Put(key, s.NewObj(value, -1, object.ObjTypeString))
+		}
+	}
+	if obj == nil {
+		return cmdResNil, nil
+	}
+	return cmdResFromObject(obj)
+}
+
+func executeGETSET(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 2 {
+		return cmdResNil, errors.ErrWrongArgumentCount("GETSET")
+	}
+	shard := sm.GetShardForKey(c.C.Args[0])
+	return evalGETSET(c, shard.Thread.Store())
+}

--- a/internal/cmd/cmd_getset.go
+++ b/internal/cmd/cmd_getset.go
@@ -4,10 +4,7 @@
 package cmd
 
 import (
-	"strconv"
-
 	"github.com/dicedb/dice/internal/errors"
-	"github.com/dicedb/dice/internal/object"
 	"github.com/dicedb/dice/internal/shardmanager"
 	dstore "github.com/dicedb/dice/internal/store"
 )
@@ -44,18 +41,9 @@ func evalGETSET(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 	key := c.C.Args[0]
 	value := c.C.Args[1]
 	obj := s.Get(key)
-	intValue, err := strconv.ParseInt(value, 10, 64)
+	newObj := CreateObjectFromValue(s, value, -1)
+	s.Put(key, newObj)
 
-	if err == nil {
-		s.Put(key, s.NewObj(intValue, -1, object.ObjTypeInt))
-	} else {
-		floatValue, err := strconv.ParseFloat(value, 64)
-		if err == nil {
-			s.Put(key, s.NewObj(floatValue, -1, object.ObjTypeFloat))
-		} else {
-			s.Put(key, s.NewObj(value, -1, object.ObjTypeString))
-		}
-	}
 	if obj == nil {
 		return cmdResNil, nil
 	}

--- a/internal/cmd/cmd_keys.go
+++ b/internal/cmd/cmd_keys.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/shardmanager"
+	dstore "github.com/dicedb/dice/internal/store"
+	"github.com/dicedb/dicedb-go/wire"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var cKEYS = &CommandMeta{
+	Name:      "KEYS",
+	Syntax:    "KEYS pattern",
+	HelpShort: "KEYS returns all keys matching the pattern",
+	HelpLong: `
+KEYS returns all keys matching the pattern.
+
+The pattern can contain the following special characters to match multiple keys.
+Supports glob-style patterns:
+- *: matches any sequence of characters
+- ?: matches any single character`,
+	Examples: `
+localhost:7379> SET k1 v1
+OK OK
+localhost:7379> SET k2 v2
+OK OK
+localhost:7379> KEYS k?
+OK k1 k2
+localhost:7379> KEYS k*
+OK k1 k2
+localhost:7379> KEYS *
+OK k1 k2
+	`,
+	Eval:    evalKEYS,
+	Execute: executeKEYS,
+}
+
+func init() {
+	CommandRegistry.AddCommand(cKEYS)
+}
+
+func evalKEYS(c *Cmd, s *dstore.Store) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("KEYS")
+	}
+	pattern := c.C.Args[0]
+	keys, err := s.Keys(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return createResponseFromArray(keys), nil
+}
+
+func executeKEYS(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) != 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("KEYS")
+	}
+	var keys []string
+	for _, shard := range sm.Shards() {
+		res, err := evalKEYS(c, shard.Thread.Store())
+		if err != nil {
+			return nil, err
+		}
+		for _, v := range res.R.GetVList() {
+			keys = append(keys, v.GetStringValue())
+		}
+	}
+	finalRes := createResponseFromArray(keys)
+	return finalRes, nil
+}
+
+func createResponseFromArray(arr []string) *CmdRes {
+	if len(arr) == 0 {
+		return cmdResNil
+	}
+	var res []*structpb.Value
+	for _, v := range arr {
+		val := structpb.NewStringValue(v)
+		res = append(res, val)
+	}
+	return &CmdRes{R: &wire.Response{
+		VList: res}}
+}

--- a/internal/cmd/cmd_set.go
+++ b/internal/cmd/cmd_set.go
@@ -230,7 +230,6 @@ func CreateObjectFromValue(s *dstore.Store, value string, expiryMs int64) *objec
 	floatValue, err := strconv.ParseFloat(value, 64)
 	if err == nil {
 		return s.NewObj(floatValue, expiryMs, object.ObjTypeFloat)
-	} else {
-		return s.NewObj(value, expiryMs, object.ObjTypeString)
 	}
+	return s.NewObj(value, expiryMs, object.ObjTypeString)
 }

--- a/internal/cmd/cmd_set.go
+++ b/internal/cmd/cmd_set.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dicedb/dice/internal/object"
 	"github.com/dicedb/dice/internal/server/utils"
 	"github.com/dicedb/dice/internal/shardmanager"
+	"github.com/dicedb/dice/internal/store"
 	dstore "github.com/dicedb/dice/internal/store"
 )
 
@@ -194,17 +195,8 @@ func evalSET(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 		return cmdResNil, nil
 	}
 
-	intValue, err := strconv.ParseInt(value, 10, 64)
-	if err == nil {
-		s.Put(key, s.NewObj(intValue, exDurationMs, object.ObjTypeInt), dstore.WithKeepTTL(params[KEEPTTL] != ""))
-	} else {
-		floatValue, err := strconv.ParseFloat(value, 64)
-		if err == nil {
-			s.Put(key, s.NewObj(floatValue, exDurationMs, object.ObjTypeFloat), dstore.WithKeepTTL(params[KEEPTTL] != ""))
-		} else {
-			s.Put(key, s.NewObj(value, exDurationMs, object.ObjTypeString), dstore.WithKeepTTL(params[KEEPTTL] != ""))
-		}
-	}
+	newObj := CreateObjectFromValue(s, value, exDurationMs)
+	s.Put(key, newObj, dstore.WithKeepTTL(params[KEEPTTL] != ""))
 
 	if params[GET] != "" {
 		// TODO: Optimize this because we have alread fetched the
@@ -229,4 +221,18 @@ func executeSET(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
 	}
 	shard := sm.GetShardForKey(c.C.Args[0])
 	return evalSET(c, shard.Thread.Store())
+}
+
+func CreateObjectFromValue(s *store.Store, value string, expiryMs int64) *object.Obj {
+	intValue, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		return s.NewObj(intValue, expiryMs, object.ObjTypeInt)
+	} else {
+		floatValue, err := strconv.ParseFloat(value, 64)
+		if err == nil {
+			return s.NewObj(floatValue, expiryMs, object.ObjTypeFloat)
+		} else {
+			return s.NewObj(value, expiryMs, object.ObjTypeString)
+		}
+	}
 }

--- a/internal/cmd/cmd_set.go
+++ b/internal/cmd/cmd_set.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dicedb/dice/internal/object"
 	"github.com/dicedb/dice/internal/server/utils"
 	"github.com/dicedb/dice/internal/shardmanager"
-	"github.com/dicedb/dice/internal/store"
 	dstore "github.com/dicedb/dice/internal/store"
 )
 
@@ -223,16 +222,15 @@ func executeSET(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
 	return evalSET(c, shard.Thread.Store())
 }
 
-func CreateObjectFromValue(s *store.Store, value string, expiryMs int64) *object.Obj {
+func CreateObjectFromValue(s *dstore.Store, value string, expiryMs int64) *object.Obj {
 	intValue, err := strconv.ParseInt(value, 10, 64)
 	if err == nil {
 		return s.NewObj(intValue, expiryMs, object.ObjTypeInt)
+	}
+	floatValue, err := strconv.ParseFloat(value, 64)
+	if err == nil {
+		return s.NewObj(floatValue, expiryMs, object.ObjTypeFloat)
 	} else {
-		floatValue, err := strconv.ParseFloat(value, 64)
-		if err == nil {
-			return s.NewObj(floatValue, expiryMs, object.ObjTypeFloat)
-		} else {
-			return s.NewObj(value, expiryMs, object.ObjTypeString)
-		}
+		return s.NewObj(value, expiryMs, object.ObjTypeString)
 	}
 }

--- a/tests/commands/ironhawk/getex_test.go
+++ b/tests/commands/ironhawk/getex_test.go
@@ -39,8 +39,8 @@ func TestGETEX(t *testing.T) {
 		},
 		{
 			name:     "GETEX with PERSIST option",
-			commands: []string{"SET foo bar EX 100", "TTL foo", "GETEX foo PERSIST", "TTL foo"},
-			expected: []interface{}{"OK", 100, "bar", -1},
+			commands: []string{"SET foo bar EX 100", "GETEX foo PERSIST", "TTL foo"},
+			expected: []interface{}{"OK", "bar", -1},
 		},
 
 		{

--- a/tests/commands/ironhawk/getset_test.go
+++ b/tests/commands/ironhawk/getset_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package ironhawk
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestGETSET(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "SET with expiration and GETSET",
+			commands: []string{"SET k v EX 2", "GETSET k v2", "TTL k"},
+			expected: []interface{}{"OK", "v", -1},
+			delay:    []time.Duration{0, 0, 3 * time.Second},
+		},
+		{
+			name:     "GETSET without expiration",
+			commands: []string{"SET k v", "GET k", "GETSET k v2", "GET k"},
+			expected: []interface{}{"OK", "v", "v", "v2"},
+		},
+		{
+			name:     "GETSET with non existent key",
+			commands: []string{"GETSET nek v", "GET nek"},
+			expected: []interface{}{nil, "v"},
+		},
+		{
+			name:     "GETSET with no keys or arguments",
+			commands: []string{"GETSET"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'GETSET' command"),
+			},
+		},
+	}
+
+	runTestcases(t, client, testCases)
+}

--- a/tests/commands/ironhawk/keys_test.go
+++ b/tests/commands/ironhawk/keys_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package ironhawk
+
+import (
+	"testing"
+)
+
+func TestKEYS(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "KEYS with more than one matching key",
+			commands: []string{"SET k v", "SET k1 v1", "KEYS k*"},
+			expected: []interface{}{"OK", "OK", []interface{}{"k", "k1"}},
+		},
+		{
+			name:     "KEYS with no matching keys",
+			commands: []string{"KEYS a*"},
+			expected: []interface{}{[]interface{}{}},
+		},
+	}
+
+	runTestcases(t, client, testCases)
+}

--- a/tests/commands/ironhawk/keys_test.go
+++ b/tests/commands/ironhawk/keys_test.go
@@ -22,6 +22,16 @@ func TestKEYS(t *testing.T) {
 			commands: []string{"KEYS a*"},
 			expected: []interface{}{[]interface{}{}},
 		},
+		{
+			name:     "KEYS with single character wildcard",
+			commands: []string{"SET k1 v1", "SET k2 v2", "SET ka va", "KEYS k?"},
+			expected: []interface{}{"OK", "OK", "OK", []interface{}{"k1", "k2", "ka"}},
+		},
+		{
+			name:     "KEYS with single matching key",
+			commands: []string{"SET unique_key value", "KEYS unique*"},
+			expected: []interface{}{"OK", []interface{}{"unique_key"}},
+		},
 	}
 
 	runTestcases(t, client, testCases)

--- a/tests/commands/ironhawk/main_test.go
+++ b/tests/commands/ironhawk/main_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dicedb/dicedb-go"
 	"github.com/dicedb/dicedb-go/wire"
 	assert "github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestMain(m *testing.M) {
@@ -41,6 +42,10 @@ func assertEqual(t *testing.T, expected interface{}, actual *wire.Response) {
 		assert.Nil(t, actual.GetVNil())
 	case error:
 		assert.Equal(t, v.Error(), actual.Err)
+	case []*structpb.Value:
+		if actual.VList != nil {
+			assert.ElementsMatch(t, v, actual.GetVList())
+		}
 	case []interface{}:
 		expected := expected.([]interface{})
 

--- a/tests/commands/ironhawk/main_test.go
+++ b/tests/commands/ironhawk/main_test.go
@@ -39,7 +39,7 @@ func assertEqual(t *testing.T, expected interface{}, actual *wire.Response) {
 	case int:
 		assert.Equal(t, int64(v), actual.GetVInt())
 	case nil:
-		assert.Nil(t, actual.GetVNil())
+		assert.Equal(t, true, actual.GetVNil())
 	case error:
 		assert.Equal(t, v.Error(), actual.Err)
 	case []*structpb.Value:


### PR DESCRIPTION
Hi,

This PR adds support for Keys, Getset and  array support for tests. Please merge this [PR](https://github.com/DiceDB/dicedb-cli/pull/31) before merging this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the **GETSET** command, allowing users to set a new value for a key while retrieving its previous value.
	- Added the **KEYS** command, enabling users to fetch keys that match a specified pattern with clear usage hints and examples.
- **Bug Fixes**
	- Updated test cases for **GETSET** and **KEYS** commands to ensure correct functionality and expected outcomes.
- **Refactor**
	- Enhanced the **SET** command logic by introducing a new helper function for value processing, improving code clarity and modularity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->