### PR TITLE
Fix: Makefile Build Error in DiceDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOARCH ?= $(shell go env GOARCH)
 
 build:
 	@echo "Building for $(GOOS)/$(GOARCH)"
-	CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-s -w -X config.DiceDBVersion=$VERSION" -o ./dicedb
+	CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-s -w -X config.DiceDBVersion=$(VERSION)" -o ./dicedb
 
 build-debug:
 	@echo "Building for $(GOOS)/$(GOARCH)"


### PR DESCRIPTION
Resolved an error in the Makefile that affected the build process. Updated the build step to ensure proper handling of the `$VERSION `variable


fixes https://github.com/DiceDB/dice/issues/1622