### PR TITLE
[DRAFT] Fix concurrency issue #1591

### DIFF
--- a/internal/cmd/cmds.go
+++ b/internal/cmd/cmds.go
@@ -45,6 +45,7 @@ func (c *Cmd) Key() string {
 
 func (c *Cmd) Execute(sm *shardmanager.ShardManager) (*CmdRes, error) {
 	res := cmdResNil
+	res.R.CorrId = c.C.GetCorrId()
 	err := errors.ErrUnknownCmd(c.C.Cmd)
 	start := time.Now()
 	if c.Meta == nil {
@@ -55,6 +56,7 @@ func (c *Cmd) Execute(sm *shardmanager.ShardManager) (*CmdRes, error) {
 		c.Meta = meta
 	}
 	res, err = c.Meta.Execute(c, sm)
+	res.R.CorrId = c.C.GetCorrId()
 	slog.Debug("command executed",
 		slog.Any("cmd", c.String()),
 		slog.String("client_id", c.ClientID),

--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -48,7 +48,7 @@ func (t *IOThread) StartSync(ctx context.Context, shardManager *shardmanager.Sha
 
 		res, err := _c.Execute(shardManager)
 		if err != nil {
-			res = &cmd.CmdRes{R: &wire.Response{Err: err.Error()}}
+			res = &cmd.CmdRes{R: &wire.Response{CorrId: c.GetCorrId(), Err: err.Error()}}
 		}
 
 		// TODO: Optimize this. We are doing this for all command execution

--- a/tests/commands/ironhawk/concurrent_cmds_test.go
+++ b/tests/commands/ironhawk/concurrent_cmds_test.go
@@ -1,0 +1,41 @@
+package ironhawk
+
+import (
+	"github.com/dicedb/dicedb-go/wire"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestConcurrentCommands(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	const numCommands = 10
+
+	var wg sync.WaitGroup
+
+	wg.Add(numCommands)
+
+	for i := 0; i < numCommands; i++ {
+		go func() {
+			defer wg.Done()
+
+			id := strconv.Itoa(i)
+
+			// small delay to ensure commands overlap
+			time.Sleep(time.Millisecond * 10)
+
+			resp := client.Fire(&wire.Command{Cmd: "ECHO", Args: []string{id}})
+			if resp.GetErr() != "" {
+				t.Errorf("Expected no error, got %v", resp.GetErr())
+			}
+			if resp.GetVStr() != id {
+				t.Errorf("Expected %s, got %v", id, resp.GetVStr())
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes https://github.com/DiceDB/dice/issues/1591

The source of the issue is absence of synchronization when Client is writing to and reading from TCP connection.

Need your feedback, to make sure you are ok with the approach I took:
- Use fixed 4 byte header for each message (`wire.Command`/`wire.Response`)
- Add correlation_id to each command/response to match them
- On `Client` side, read responses from `net.Conn` in a loop
- Put responses in corresponding channel (map[corr_id] = chan *Response)
- Each `Client.Fire()` reads from a corresponding channel

Here are the links to all of the PRs (this fix requires changes to multiple repositories):
[dicedb-go PR](https://github.com/DiceDB/dicedb-go/pull/4)
[dice PR](https://github.com/DiceDB/dice/pull/1628)
[dicedb-protos PR](https://github.com/DiceDB/dicedb-protos/pull/1)

- [x] Communicate with maintainers on the overall approach
- [ ] Make code production-ready (error handling etc)

Before this change:
![before](https://github.com/user-attachments/assets/1cabf2d9-d1a9-4245-b221-4b961580ca3d)
After this change:
![after](https://github.com/user-attachments/assets/56827420-caab-4c58-88f6-c4598cf50882)
