### PR TITLE
Fix devcontainer Go path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Start from a slim apline image
+# Start from a slim alpine image
 FROM golang:1.24.1-alpine AS builder
 WORKDIR /src
 COPY . .
@@ -8,6 +8,12 @@ RUN apk add --no-cache gcc musl-dev libc6-compat make
 RUN make build
 
 FROM alpine
+WORKDIR /src
+
+# Copy the Go binary from the builder stage
+COPY --from=builder /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 COPY --from=builder /src/dicedb /src/VERSION /src/
 
 EXPOSE 7379


### PR DESCRIPTION
Fixes: [ #1644](https://github.com/DiceDB/dice/issues/1644)

## Changes Made:

- Updated the Dockerfile to include:
   - `COPY --from=builder /usr/local/go /usr/local/go`
   - `ENV PATH="/usr/local/go/bin:${PATH}"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the container image build process to ensure the runtime environment is correctly configured for a smoother and more reliable application experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->