### PR TITLE
removing unnecessary build task from test-suite

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -24,7 +24,7 @@ on:
       - "LICENSE"
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -49,8 +49,6 @@ jobs:
               - '**/*.go'
       - name: Install dependencies
         run: go get -v . # Check if there is any version changes from the cache
-      - name: Build
-        run: make build
       - name: Run Unit tests
         if: steps.file_types.outputs.watch_file_changes == 'true'
         run: make unittest


### PR DESCRIPTION
As per my understanding we don't have to build binary in testing workflow and I believe .goreleaser.yaml is taking good care of building artifacts upon tag releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved our quality assurance process by streamlining the automated testing pipeline. An unnecessary intermediate build step was removed to simplify internal testing and enhance process efficiency. This change is part of our continuous improvement efforts and does not affect any customer-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->