### PR TITLE
Fix concurrent client connections watch mode

### DIFF
--- a/internal/cmd/cmd_get.go
+++ b/internal/cmd/cmd_get.go
@@ -58,7 +58,7 @@ func executeGET(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
 
 func cmdResFromObject(obj *object.Obj) (*CmdRes, error) {
 	if obj == nil {
-		return cmdResNil, nil
+		return GetNilRes(), nil
 	}
 
 	switch obj.Type {

--- a/internal/cmd/cmds.go
+++ b/internal/cmd/cmds.go
@@ -44,7 +44,8 @@ func (c *Cmd) Key() string {
 }
 
 func (c *Cmd) Execute(sm *shardmanager.ShardManager) (*CmdRes, error) {
-	res := cmdResNil
+	res := GetNilRes()
+
 	err := errors.ErrUnknownCmd(c.C.Cmd)
 	start := time.Now()
 	if c.Meta == nil {
@@ -149,6 +150,12 @@ func (cmd *DiceDBCmd) Key() string {
 		c = cmd.Args[0]
 	}
 	return c
+}
+
+func GetNilRes() *CmdRes {
+	return &CmdRes{R: &wire.Response{
+		Value: &wire.Response_VNil{VNil: true},
+	}}
 }
 
 var cmdResNil = &CmdRes{R: &wire.Response{


### PR DESCRIPTION
### Issues:
1. `watch_manager` map is not thread safe thus, when multiple go-routines for `watch` mode are triggered it causes race condition and errors out.
2. `cmdResNil` was a shared object used across `cmd` package. At time multiple go-routines were updating the same object as part of `r.R.Attrs.Fields["fingerprint"] = structpb.NewStringValue(strconv.FormatUint(uint64(c.Fingerprint()), 10))` or `proto.Marshal` which was causing concurrency error.

### Testing done:
- Validated with 900 concurrent watch connections with 10 updates for key/sec.
- Observed no issues with watch response across clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved command processing now provides a standardized response when no valid data is available.

- **Refactor**
  - Enhanced concurrent operations with robust synchronization in watch management, ensuring greater stability and data consistency during multi-threaded interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->