### PR TITLE
Integrated wal with ironhawk server

### DIFF
--- a/internal/cmd/cmds.go
+++ b/internal/cmd/cmds.go
@@ -55,6 +55,11 @@ func (c *Cmd) Execute(sm *shardmanager.ShardManager) (*CmdRes, error) {
 		}
 		c.Meta = meta
 	}
+	if !c.IsReplay && sm.Wal != nil {
+		if err := sm.Wal.LogCommand([]byte(fmt.Sprintf("%s %s", c.C.Cmd, strings.Join(c.C.Args, " ")))); err != nil {
+			return res, err
+		}
+	}
 	res, err = c.Meta.Execute(c, sm)
 	slog.Debug("command executed",
 		slog.Any("cmd", c.String()),

--- a/internal/shardmanager/main.go
+++ b/internal/shardmanager/main.go
@@ -15,15 +15,17 @@ import (
 	"github.com/dicedb/dice/internal/shard"
 	"github.com/dicedb/dice/internal/shardthread"
 	"github.com/dicedb/dice/internal/store"
+	"github.com/dicedb/dice/internal/wal"
 )
 
 type ShardManager struct {
 	shards  []*shard.Shard
 	sigChan chan os.Signal // sigChan is the signal channel for the shard manager
+	Wal     wal.AbstractWAL
 }
 
 // NewShardManager creates a new ShardManager instance with the given number of Shards and a parent context.
-func NewShardManager(shardCount int, globalErrorChan chan error) *ShardManager {
+func NewShardManager(shardCount int, globalErrorChan chan error, wal wal.AbstractWAL) *ShardManager {
 	shards := make([]*shard.Shard, shardCount)
 	maxKeysPerShard := config.DefaultKeysLimit / shardCount
 	for i := 0; i < shardCount; i++ {
@@ -36,6 +38,7 @@ func NewShardManager(shardCount int, globalErrorChan chan error) *ShardManager {
 	return &ShardManager{
 		shards:  shards,
 		sigChan: make(chan os.Signal, 1),
+		Wal:     wal,
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -121,7 +121,7 @@ func Start() {
 	// improving concurrency performance across multiple goroutines.
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	shardManager := shardmanager.NewShardManager(numShards, serverErrCh)
+	shardManager := shardmanager.NewShardManager(numShards, serverErrCh, wl)
 	watchManager := ironhawk.NewWatchManager()
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Integrated WAL with ironhawk engine by putting the initialized WAL in ShardManager struct and consuming it from there to Log the commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal tracking and diagnostics, boosting overall system stability and reliability while maintaining a seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->