### PR TITLE
Migrated ZPOPMIN Command

### DIFF
--- a/internal/cmd/cmd_zpopmin.go
+++ b/internal/cmd/cmd_zpopmin.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"strconv"
+
+	"github.com/dicedb/dice/internal/errors"
+	"github.com/dicedb/dice/internal/eval/sortedset"
+	"github.com/dicedb/dice/internal/shardmanager"
+	dstore "github.com/dicedb/dice/internal/store"
+)
+
+var cZPOPMIN = &CommandMeta{
+	Name:      "ZPOPMIN",
+	Syntax:    "ZPOPMIN key [count]",
+	HelpShort: "ZPOPMIN returns the lowest-scoring members from a sorted set after removing them. Deletes the sorted set if the last member was popped.",
+	HelpLong: `
+ZPOPMIN command is used to remove and return the member(s) with the lowest score(s) from a sorted set.
+The command supports the following options:
+- count: The number of members to remove and return.
+	`,
+	Examples: `
+localhost:7379> ZADD myzset 1 "one"
+(integer) 1
+localhost:7379> ZADD myzset 2 "two"
+(integer) 1
+localhost:7379> ZADD myzset 3 "three"
+(integer) 1
+localhost:7379> ZADD myzset 4 "four"
+(integer) 1
+localhost:7379> ZPOPMIN myzset 2
+1) "one"
+2) "1"
+3) "two"
+4) "2"
+	`,
+	Eval:    evalZPOPMIN,
+	Execute: executeZPOPMIN,
+}
+
+func init() {
+	CommandRegistry.AddCommand(cZPOPMIN)
+}
+
+func evalZPOPMIN(c *Cmd, s *dstore.Store) (*CmdRes, error) {
+	key, count, err := parseZPOPMINArgs(c)
+	if err != nil {
+		return cmdResNil, err
+	}
+
+	obj := s.Get(key)
+	if obj == nil {
+		return cmdResEmptySlice, nil
+	}
+
+	sortedSet, errInfo := sortedset.FromObject(obj)
+	if errInfo != nil {
+		return cmdResNil, errors.ErrWrongTypeOperation
+	}
+
+	res := sortedSet.PopMin(count)
+	return cmdResSlice(res), nil
+}
+
+func parseZPOPMINArgs(c *Cmd) (key string, count int, err error) {
+	if len(c.C.Args) == 0 || len(c.C.Args) > 2 {
+		return "", 0, errors.ErrWrongArgumentCount("ZPOPMIN")
+	}
+	key = c.C.Args[0]
+	count = 1
+	if len(c.C.Args) > 1 {
+		count, err = strconv.Atoi(c.C.Args[1])
+		if err != nil || count <= 0 {
+			return "", 0, errors.ErrIntegerOutOfRange
+		}
+	}
+	return key, count, nil
+}
+
+func executeZPOPMIN(c *Cmd, sm *shardmanager.ShardManager) (*CmdRes, error) {
+	if len(c.C.Args) < 1 {
+		return cmdResNil, errors.ErrWrongArgumentCount("ZPOPMIN")
+	}
+	shard := sm.GetShardForKey(c.C.Args[0])
+	return evalZPOPMIN(c, shard.Thread.Store())
+}

--- a/internal/eval/sortedset/sorted_set.go
+++ b/internal/eval/sortedset/sorted_set.go
@@ -239,6 +239,32 @@ func (ss *Set) PopMax(count int) []string {
 	return result
 }
 
+// This func is used to remove the minimum element from the sortedset.
+// It takes count as an argument which tells the number of elements to be removed from the sortedset.
+func (ss *Set) PopMin(count int) []string {
+	result := make([]string, 2*count)
+
+	size := 0
+	for i := 0; i < count; i++ {
+		item := ss.tree.DeleteMin()
+		if item == nil {
+			break
+		}
+		ssi := item.(*Item)
+		result[2*i] = ssi.Member
+		result[2*i+1] = strconv.FormatFloat(ssi.Score, 'g', -1, 64)
+
+		delete(ss.memberMap, ssi.Member)
+		size++
+	}
+
+	if size < count {
+		result = result[:2*size]
+	}
+
+	return result
+}
+
 // Iterate over elements in the B-Tree with scores in the [min, max] range
 func (ss *Set) CountInRange(minVal, maxVal float64) int {
 	count := 0


### PR DESCRIPTION
Depends on ZADD Command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command that removes and returns the lowest-scoring members from a sorted set, complete with usage information and robust error handling.
	- Enhanced sorted set functionality with the ability to remove a specified number of minimum elements, dynamically adjusting the results when fewer elements are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->