### PR TITLE
changed the logo label to `sponsors` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We are incredibly grateful to our sponsors for their generous support, which mak
 DiceDB is a project with a very strong vision and [roadmap](https://dicedb.io/roadmap/). If you like what
 we do and find DiceDB useful, please consider supporting and [sponsoring us on GitHub](https://github.com/sponsors/arpitbbhayani).
 
-![GitHub Sponsor](https://img.shields.io/github/sponsors/arpitbbhayani?label=Sponsor&logo=GitHub)
+![GitHub Sponsor](https://img.shields.io/github/sponsors/arpitbbhayani?label=Sponsors&logo=GitHub)
 
 ## Contributors
 


### PR DESCRIPTION
Updated the README.md file, `sponsor` wasn't looking good as there are more than one sponsors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the sponsorship badge to display a plural label for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->