### PR TITLE
Second `sponsor` badge changed to plural form

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ DiceDB
 <a href="https://dicedb.io/get-started/installation/">![Docs](https://img.shields.io/badge/docs-00A1FF?style=flat-square)</a>
 <a target="_blank" href="https://discord.gg/6r8uXWtXh7"><img src="https://dcbadge.limes.pink/api/server/6r8uXWtXh7?style=flat" alt="discord community" /></a>
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
-![GitHub Sponsor](https://img.shields.io/github/sponsors/arpitbbhayani?label=Sponsor&logo=GitHub)
+![GitHub Sponsor](https://img.shields.io/github/sponsors/arpitbbhayani?label=Sponsors&logo=GitHub)
 
 ### What is DiceDB?
 


### PR DESCRIPTION
Just like my previous Pull Request, I found out that there's one more badge that needs to be changed to improve readability.
I updated the README.md file, you can merge the PR if you want the badge to show `sponsors`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the GitHub Sponsors badge text in the project documentation, changing the label from "Sponsor" to "Sponsors" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->