### PR TITLE
fix: Condition ClientID updates and watcher notifications on command success

### DIFF
--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -56,9 +56,11 @@ func (t *IOThread) StartSync(ctx context.Context, shardManager *shardmanager.Sha
 		// Also, CLientID is duplicated in command and io-thread.
 		// Also, we shouldn't allow execution/registration incase of invalid commands
 		// like for B.WATCH cmd since it'll err out we shall return and not create subscription
-		t.ClientID = _c.ClientID
+		if err == nil {
+			t.ClientID = _c.ClientID
+		}
 
-		if c.Cmd == "HANDSHAKE" {
+		if c.Cmd == "HANDSHAKE" && err == nil {
 			t.ClientID = _c.C.Args[0]
 			t.Mode = _c.C.Args[1]
 		}
@@ -79,7 +81,9 @@ func (t *IOThread) StartSync(ctx context.Context, shardManager *shardmanager.Sha
 
 		// TODO: Streamline this because we need ordering of updates
 		// that are being sent to watchers.
-		watchManager.NotifyWatchers(_c, shardManager, t)
+		if err == nil {
+			watchManager.NotifyWatchers(_c, shardManager, t)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds error checks to prevent updating the client identifier and notifying watchers when command execution fails. The changes ensure that:

1. ClientID updates only occur after successful command execution
2. HANDSHAKE commands only update ClientID and Mode on success
3. Watchers are only notified about successful state changes

These safeguards prevent propagation of failed command effects, maintaining data consistency across the system and avoiding potential race conditions.

Bug fixes include improved error handling during command processing, ensuring that client identifier updates and watcher notifications only occur after successful command execution. In particular, handshake operations now properly check for command success before updating client state. These changes reduce the possibility of inconsistent state propagation and improve system stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling to ensure that key system updates and notifications occur only after successful operations, thereby improving overall stability and reliability for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->