### PR TITLE
#1630 : Integration Tests for H* Commands

### DIFF
--- a/tests/commands/ironhawk/hget_test.go
+++ b/tests/commands/ironhawk/hget_test.go
@@ -32,6 +32,21 @@ func TestHGET(t *testing.T) {
 				errors.New("wrong number of arguments for 'HGET' command"),
 			},
 		},
+		{
+			name:     "Get Hash Field Value for Non-existent Field",
+			commands: []string{"HSET k1 f 1", "HGET k1 non_existent_field"},
+			expected: []interface{}{1, nil},
+		},
+		{
+			name:     "Get Hash Field Value for Non-existent Key",
+			commands: []string{"HGET non_existent_key f"},
+			expected: []interface{}{nil},
+		},
+		{
+			name:     "Get Hash Field Value for multiple Fields stored at Hash Key",
+			commands: []string{"HSET k f1 v1 f2 v2", "HGET k f1", "HGET k f2"},
+			expected: []interface{}{2, "v1", "v2"},
+		},
 	}
 	runTestcases(t, client, testCases)
 }

--- a/tests/commands/ironhawk/hgetall_test.go
+++ b/tests/commands/ironhawk/hgetall_test.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// Helper functions for large hash test
+// Function that generates HSET with a count of field-value pairs followed by HGETALL
 func generateLargeHashCommands(count int) []string {
 	commands := []string{"HSET large_k"}
 	for i := 0; i < count; i++ {
@@ -21,6 +21,7 @@ func generateLargeHashCommands(count int) []string {
 	return commands
 }
 
+// Function that generates expected result with a count of field-value pairs
 func generateLargeHashExpectedResult(count int) []interface{} {
 	result := []interface{}{count}
 	values := []*structpb.Value{}
@@ -97,8 +98,8 @@ func TestHGETALL(t *testing.T) {
 		},
 		{
 			name:     "HGETALL with very large hash",
-			commands: generateLargeHashCommands(10),       // Function that generates HSET with 100 field-value pairs followed by HGETALL
-			expected: generateLargeHashExpectedResult(10), // Function that generates expected result with 100 field-value pairs
+			commands: generateLargeHashCommands(1000),
+			expected: generateLargeHashExpectedResult(1000),
 		},
 	}
 	runTestcases(t, client, testCases)

--- a/tests/commands/ironhawk/hgetall_watch_test.go
+++ b/tests/commands/ironhawk/hgetall_watch_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2022-present, DiceDB contributors
+// All rights reserved. Licensed under the BSD 3-Clause License. See LICENSE file in the project root for full license information.
+
+package ironhawk
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestHGETALLWATCH(t *testing.T) {
+	client := getLocalConnection()
+	defer client.Close()
+
+	testCases := []TestCase{
+		{
+			name:     "HGETALL.WATCH Hash Key with Initial Values",
+			commands: []string{"HSET k f1 v1 f2 v2", "HGETALL.WATCH k"},
+			expected: []interface{}{2,
+				[]*structpb.Value{
+					structpb.NewStringValue("f1"),
+					structpb.NewStringValue("v1"),
+					structpb.NewStringValue("f2"),
+					structpb.NewStringValue("v2"),
+				},
+			},
+		},
+		{
+			name:     "HGETALL.WATCH Empty Hash",
+			commands: []string{"HGETALL.WATCH nonexistent_key"},
+			expected: []interface{}{
+				[]*structpb.Value{},
+			},
+		},
+		{
+			name:     "HGETALL.WATCH with no key argument",
+			commands: []string{"HGETALL.WATCH"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'HGETALL.WATCH' command"),
+			},
+		},
+		{
+			name:     "HGETALL.WATCH with too many arguments",
+			commands: []string{"HGETALL.WATCH key extra_arg"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'HGETALL.WATCH' command"),
+			},
+		},
+		{
+			name:     "HGETALL.WATCH with non-hash key",
+			commands: []string{"SET key 5", "HGETALL.WATCH key"},
+			expected: []interface{}{"OK",
+				errors.New("wrongtype operation against a key holding the wrong kind of value"),
+			},
+		},
+	}
+
+	runTestcases(t, client, testCases)
+}

--- a/tests/commands/ironhawk/hset_test.go
+++ b/tests/commands/ironhawk/hset_test.go
@@ -14,6 +14,20 @@ func TestHSET(t *testing.T) {
 
 	testCases := []TestCase{
 		{
+			name:     "HSET with no arguments",
+			commands: []string{"HSET"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'HSET' command"),
+			},
+		},
+		{
+			name:     "HSET with odd number of arguments",
+			commands: []string{"HSET k f1 v1 f2"},
+			expected: []interface{}{
+				errors.New("wrong number of arguments for 'HSET' command"),
+			},
+		},
+		{
 			name:     "Set Field Value at Key stored in Hash",
 			commands: []string{"HSET k f v"},
 			expected: []interface{}{1},
@@ -31,6 +45,16 @@ func TestHSET(t *testing.T) {
 			expected: []interface{}{
 				errors.New("wrong number of arguments for 'HSET' command"),
 			},
+		},
+		{
+			name:     "Set multiple Field-Value pairs at once",
+			commands: []string{"HSET k f1 v1 f2 v2 f3 v3"},
+			expected: []interface{}{3},
+		},
+		{
+			name:     "Update existing field value",
+			commands: []string{"HSET k1 f v1", "HSET k1 f v2"},
+			expected: []interface{}{1, 0},
 		},
 	}
 	runTestcases(t, client, testCases)


### PR DESCRIPTION
This PR adds more integration tests for the `HGET`, `HGETALL`, `HGETALL.WATCH`, and `HSET` commands.
- HGET: Added test cases for non-existent fields/keys and multiple fields.
- HGETALL: Introduced helper functions and test cases for large hashes and various scenarios.
- HGETALL.WATCH: New test cases for multiple scenarios.
- HSET: Added test cases for various argument scenarios and field updates.

Issue: #1630