### PR TITLE
Bug Fix - Server crashes in case of wrong number of args

### DIFF
--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -68,11 +68,16 @@ func (t *IOThread) Start(ctx context.Context, shardManager *shardmanager.ShardMa
 					Message: err.Error(),
 				},
 			}
-		} else {
-			res.Rs.Status = wire.Status_OK
-			if res.Rs.Message == "" {
-				res.Rs.Message = "OK"
+			if sendErr := t.serverWire.Send(ctx, res.Rs); sendErr != nil {
+				return sendErr.Unwrap()
 			}
+			// Continue in case of error
+			continue
+		}
+
+		res.Rs.Status = wire.Status_OK
+		if res.Rs.Message == "" {
+			res.Rs.Message = "OK"
 		}
 
 		// TODO: Optimize this. We are doing this for all command execution


### PR DESCRIPTION
In case of an incorrect number of arguments for HANDSHAKE, an error is generated, but the server continues processing and does not return the error. Which results in a crash because it tries to get `Args[0]` & `Args[1]`

![image](https://github.com/user-attachments/assets/465e4dbd-243b-436c-a862-4f2be85b5786)

