### PR TITLE
Update Golang Image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from a slim alpine image
-FROM golang:1.24.1-alpine AS builder
+FROM golang:1.24.2-alpine AS builder
 WORKDIR /src
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-services:
-  dicedb:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: dicedb  
-    ports:
-      - "7379:7379"
-    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  dicedb:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: dicedb  
+    ports:
+      - "7379:7379"
+    restart: unless-stopped


### PR DESCRIPTION
- Bump Docker Go to 1.24.2
- Add Docker-compose configuration

The current golang version 1.24.1-alpine has [Vulnerabilities](https://hub.docker.com/layers/library/golang/1.24.1-alpine/images/sha256-ba0e119509b381457e9bb434319f2ef7996ad7ca7ec11a66e4ecdd8da49b8ddf), thus update to the latest version 1.24.2-alpine

Also added docker-compose.yml file