### PR TITLE
minor fix to execute wg.Done after the thread has successfully started

### DIFF
--- a/internal/server/ironhawk/main.go
+++ b/internal/server/ironhawk/main.go
@@ -154,7 +154,7 @@ func (s *Server) AcceptConnectionRequests(ctx context.Context, wg *sync.WaitGrou
 }
 
 func (s *Server) startIOThread(ctx context.Context, wg *sync.WaitGroup, thread *IOThread) {
-	wg.Done()
+	defer wg.Done()
 	err := thread.Start(ctx, s.shardManager, s.watchManager)
 	if err != nil {
 		if err == io.EOF {


### PR DESCRIPTION
This shouldn't be executed immediately, but should first wait for the thread to successfully start.