### PR TITLE
FIRST PR: Add Upper Bound Check for EXPIREAT

### DIFF
--- a/internal/cmd/cmd_expireat.go
+++ b/internal/cmd/cmd_expireat.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/dicedb/dice/internal/errors"
 	"github.com/dicedb/dice/internal/shardmanager"
@@ -67,6 +68,9 @@ var (
 	EXPIREATResUnchangedRes = newEXPIREATRes(false)
 )
 
+// maxAllowedTimestamp represents the maximum allowed timestamp (10 years from now)
+var maxAllowedTimestamp = time.Now().AddDate(10, 0, 0).Unix()
+
 func evalEXPIREAT(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 	if len(c.C.Args) < 2 {
 		return EXPIREATResNilRes, errors.ErrWrongArgumentCount("EXPIREAT")
@@ -74,8 +78,7 @@ func evalEXPIREAT(c *Cmd, s *dstore.Store) (*CmdRes, error) {
 
 	var key = c.C.Args[0]
 	exUnixTimeSec, err := strconv.ParseInt(c.C.Args[1], 10, 64)
-	if err != nil || exUnixTimeSec < 0 {
-		// TODO: Check for the upper bound of the input.
+	if err != nil || exUnixTimeSec < 0 || exUnixTimeSec > maxAllowedTimestamp {
 		return EXPIREATResNilRes, errors.ErrInvalidExpireTime("EXPIREAT")
 	}
 

--- a/tests/commands/ironhawk/expireat_test.go
+++ b/tests/commands/ironhawk/expireat_test.go
@@ -84,7 +84,7 @@ func TestEXPIREAT(t *testing.T) {
 			commands: []string{
 				"SET test_key test_value",
 				"EXPIREAT test_key " + strconv.FormatInt(time.Now().Unix()+10, 10) + " XX",
-				"EXPIREAT test_key " + strconv.FormatInt(time.Now().Unix()+10, 10),
+				"EXPIREAT test_key " + strconv.FormatInt(time.Now().Unix()+10, 10) + " XX",
 				"EXPIREAT test_key " + strconv.FormatInt(time.Now().Unix()+10, 10) + " XX",
 			},
 			expected:       []interface{}{"OK", false, true, true},
@@ -121,6 +121,18 @@ func TestEXPIREAT(t *testing.T) {
 				errors.New("NX and XX, GT or LT options at the same time are not compatible"),
 				errors.New("NX and XX, GT or LT options at the same time are not compatible")},
 			valueExtractor: []ValueExtractorFn{extractValueSET, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil},
+		},
+		{
+			name: "Test upper bound check for EXPIREAT",
+			commands: []string{
+				"SET test_key test_value",
+				"EXPIREAT test_key " + strconv.FormatInt(time.Now().AddDate(11, 0, 0).Unix(), 10),
+			},
+			expected: []interface{}{
+				"OK",
+				errors.New("invalid expire time in 'EXPIREAT' command"),
+			},
+			valueExtractor: []ValueExtractorFn{extractValueSET, nil},
 		},
 	}
 	runTestcases(t, client, testCases)


### PR DESCRIPTION
Implementing the TODO comment about checking for the upper bound of the input time for EXPIREAT

Test: Setting expire with more than 10 years timestamp vs setting with less than 10 years

<img width="808" alt="image" src="https://github.com/user-attachments/assets/1e74b008-22c7-4182-9ffd-5cda391cfc66" />

