### PR TITLE
fix: Fixing the watcher resp updates for new GET.WATCH connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 dice
 main
 tmp/
+vendor/
 
 # build output
 dist/

--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -87,7 +87,9 @@ func (t *IOThread) Start(ctx context.Context, shardManager *shardmanager.ShardMa
 			t.Mode = _c.C.Args[1]
 		}
 
-		if strings.HasSuffix(c.Cmd, ".WATCH") {
+		isWatchCmd := strings.HasSuffix(c.Cmd, "WATCH")
+
+		if isWatchCmd{
 			watchManager.HandleWatch(_c, t)
 		}
 
@@ -97,8 +99,12 @@ func (t *IOThread) Start(ctx context.Context, shardManager *shardmanager.ShardMa
 
 		watchManager.RegisterThread(t)
 
-		if sendErr := t.serverWire.Send(ctx, res.Rs); sendErr != nil {
-			return sendErr.Unwrap()
+		// Only send the response directly if this is not a watch command
+		// For watch commands, the response will be sent by NotifyWatchers
+		if !isWatchCmd{
+			if sendErr := t.serverWire.Send(ctx, res.Rs); sendErr != nil {
+				return sendErr.Unwrap()
+			}
 		}
 
 		// TODO: Streamline this because we need ordering of updates


### PR DESCRIPTION
If a client has opened multiple watch connections, the updates for all watch connections are sent as responses on TCP connection. However for all the get.watch command fired there are 2 identical responses being sent to the client and due to which when multiple watch responses are there, these responses get jumbled up and wrong values are being returned to the wrong fired command hence making it impossible for the client to check for the corresponding fingerprint of a get.watch command. 
This happens due to the fact that IoThread sends a generic command handling response as well as a response from NotifyWatchers. This PR aims to fix this behaviour.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/b252c3a2-653e-4858-ae4a-13973cc2e7ed" />
