### PR TITLE
feat: Making fingerprints of watchable commands and their .WATCH commands identical

### DIFF
--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -89,6 +89,12 @@ func (t *IOThread) Start(ctx context.Context, shardManager *shardmanager.ShardMa
 			t.ClientID = _c.ClientID
 		}
 
+		if _c.Meta.IsWatchable {
+			_cWatch := _c
+			_cWatch.C.Cmd += ".WATCH"
+			res.Rs.Fingerprint64 = _cWatch.Fingerprint()
+		}
+
 		if c.Cmd == "HANDSHAKE" && err == nil {
 			t.ClientID = _c.C.Args[0]
 			t.Mode = _c.C.Args[1]

--- a/internal/server/ironhawk/watch_manager.go
+++ b/internal/server/ironhawk/watch_manager.go
@@ -160,7 +160,7 @@ func (w *WatchManager) NotifyWatchers(c *cmd.Cmd, shardManager *shardmanager.Sha
 
 			// If this is first time a client is connecting it'd be sending a .WATCH command
 			// in that case we don't need to notify all other clients subscribed to the key
-			if strings.HasSuffix(c.C.Cmd, ".WATCH") {
+			if strings.HasSuffix(c.C.Cmd, ".WATCH") && t.ClientID != clientID {
 				continue
 			}
 


### PR DESCRIPTION
 Making fingerprints of watchable commands and their `.WATCH` commands identical for easy detection in SDK