### PR TITLE
fix: Handle multiple watch commands for same client and minor improvements

### DIFF
--- a/internal/server/ironhawk/main.go
+++ b/internal/server/ironhawk/main.go
@@ -170,6 +170,7 @@ func (s *Server) startIOThread(ctx context.Context, wg *sync.WaitGroup, thread *
 				slog.Any("error", err))
 		}
 	}
+	thread.Stop()
 }
 
 func (s *Server) Shutdown() {

--- a/internal/server/ironhawk/watch_manager.go
+++ b/internal/server/ironhawk/watch_manager.go
@@ -125,11 +125,14 @@ func (w *WatchManager) CleanupThreadWatchSubscriptions(t *IOThread) {
 		delete(w.fpClientMap[fp], t.ClientID)
 		if len(w.fpClientMap[fp]) == 0 {
 			delete(w.fpClientMap, fp)
+
+			// If we have deleted the fingerprint, delete the command from the map
+			delete(w.fpCmdMap, fp)
 		}
 	}
 }
 
-func (w *WatchManager) NotifyWatchers(c *cmd.Cmd, shardManager *shardmanager.ShardManager, t *IOThread) {
+func (w *WatchManager) NotifyWatchers(c *cmd.Cmd, shardManager *shardmanager.ShardManager) {
 	// Use RLock instead as we are not really modifying any shared maps here.
 	w.mu.RLock()
 	defer w.mu.RUnlock()


### PR DESCRIPTION
- Simplified ClientID assignment logic to ensure it is set directly without error checks after the initial loop.
- Updated HANDSHAKE command handling to directly assign ClientID and Mode without redundant error checks.
- Modified watch command handling to ensure proper notification of watchers without unnecessary conditions.
- Enhanced cleanup logic in WatchManager to delete command entries when fingerprints are removed.

These changes improve code clarity and maintainability while ensuring correct behavior during command processing.

---

Example with `dicedb-cli`:
```sh
>> make run
go run main.go
localhost:7379> SET a v1
OK
localhost:7379> SET k w1
OK
localhost:7379> GET.WATCH k
entered the watch mode for GET.WATCH k
OK [fingerprint=6645377565653310095] "w2" # SET k w2 (on Terminal 2)
OK [fingerprint=6645377565653310095] "w3" # SET k w3 (on Terminal 2)
^Cexiting the watch mode. back to command mode
localhost:7379> GET a
OK "v1"
localhost:7379> GET k
OK "w3"
localhost:7379> GET.WATCH k
entered the watch mode for GET.WATCH k
OK [fingerprint=6645377565653310095] "w3" # GET k (on Terminal 2)
OK [fingerprint=6645377565653310095] "e1" # SET k e1 (on Terminal 2)
OK [fingerprint=6645377565653310095] "e2" # SET k e2 (on Terminal 2)
^Cexiting the watch mode. back to command mode
localhost:7379> GET a
OK "v1"
localhost:7379> GET k
OK "e2"
```

---

Related PR's: 
  - https://github.com/DiceDB/dicedb-cli/pull/45
  - https://github.com/DiceDB/dicedb-go/pull/17

Fixes: https://github.com/DiceDB/dice/issues/1696