### PR TITLE
Fix #1653 : Fix for GET.WATCH Notified Unexpectedly on GET Operation

### DIFF
--- a/internal/server/ironhawk/iothread.go
+++ b/internal/server/ironhawk/iothread.go
@@ -96,7 +96,7 @@ func (t *IOThread) Start(ctx context.Context, shardManager *shardmanager.ShardMa
 
 		isWatchCmd := strings.HasSuffix(c.Cmd, "WATCH")
 
-		if isWatchCmd{
+		if isWatchCmd {
 			watchManager.HandleWatch(_c, t)
 		} else if strings.HasSuffix(c.Cmd, "UNWATCH") {
 			watchManager.HandleUnwatch(_c, t)
@@ -106,7 +106,7 @@ func (t *IOThread) Start(ctx context.Context, shardManager *shardmanager.ShardMa
 
 		// Only send the response directly if this is not a watch command
 		// For watch commands, the response will be sent by NotifyWatchers
-		if !isWatchCmd{
+		if !isWatchCmd {
 			if sendErr := t.serverWire.Send(ctx, res.Rs); sendErr != nil {
 				return sendErr.Unwrap()
 			}
@@ -114,7 +114,7 @@ func (t *IOThread) Start(ctx context.Context, shardManager *shardmanager.ShardMa
 
 		// TODO: Streamline this because we need ordering of updates
 		// that are being sent to watchers.
-		if err == nil {
+		if err == nil && watchManager.IsNotifiableCmd(_c) {
 			watchManager.NotifyWatchers(_c, shardManager, t)
 		}
 	}

--- a/internal/server/ironhawk/watch_manager.go
+++ b/internal/server/ironhawk/watch_manager.go
@@ -129,6 +129,23 @@ func (w *WatchManager) CleanupThreadWatchSubscriptions(t *IOThread) {
 	}
 }
 
+func (w *WatchManager) IsNotifiableCmd(c *cmd.Cmd) bool {
+	// This function returns true if the command should trigger a notification else false
+	// general rule is is command contains Get is it considered as DR operation , DR operation should not be notified
+	// any exception is this rule are in exceptoinlist hashmap
+	exceptionlist := map[string]bool{
+		"GETSET": true,
+	}
+	value, exists := exceptionlist[c.C.Cmd]
+	if exists {
+		return (value)
+	} else {
+		isGetRltdCmd := strings.HasSuffix(c.C.Cmd, "GET")
+		// if it is data read method , return false and vice versa.
+		return (!isGetRltdCmd)
+	}
+}
+
 func (w *WatchManager) NotifyWatchers(c *cmd.Cmd, shardManager *shardmanager.ShardManager, t *IOThread) {
 	// Use RLock instead as we are not really modifying any shared maps here.
 	w.mu.RLock()


### PR DESCRIPTION
his PR fixes an issue where watch client notifications were incorrectly triggered for GET commands.

The solution introduces a new function, IsNotifiableCmd, to control when notifications should be triggered. This ensures that:
1.Notifications are triggered only for Data Manipulation (DM) operations, not for Data Read (DR) operations.
2. An exception list (implemented as a hash map) allows fine-grained control over notification triggers for specific commands.

![image](https://github.com/user-attachments/assets/6c5e2dc4-fc11-4c3b-baac-423d88a97cc6)
