### PR TITLE
FIX #1741 removed invalid Note section

### DIFF
--- a/docs/src/content/docs/get-started/hello-world.mdx
+++ b/docs/src/content/docs/get-started/hello-world.mdx
@@ -66,7 +66,6 @@ Here's a breakdown of what happened,
 - `v1`: This is the actual value we want to store. It's a simple string in this case
 - `OK`: DiceDB's response indicating successful storage
 
-Note: The first `OK` is the status of the command, while the second `OK` is the output of the command.
 
 ### Bottom Line
 


### PR DESCRIPTION
fixes #1741
Note section of the commands breakdown is no longer valid as only single OK is returned for SET