### PR TITLE
fix(store): Add mutex synchronization to `AOF Load function`

### DIFF
--- a/internal/store/aof.go
+++ b/internal/store/aof.go
@@ -58,6 +58,9 @@ func (a *AOF) Close() error {
 }
 
 func (a *AOF) Load() ([]string, error) {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
 	f, err := os.Open(a.path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes: #1725

Fixes race condition in AOF Load function by adding mutex synchronization.

Previously, `Load()` could return temporally inconsistent data when concurrent `Write()` operations occurred during file scanning, especially with large AOF files.
