### PR TITLE
Ensure correct segment order when returning segment files

### DIFF
--- a/internal/wal/wal_forge.go
+++ b/internal/wal/wal_forge.go
@@ -293,14 +293,14 @@ func (wl *walForge) segments() ([]string, error) {
 		return nil, err
 	}
 
+	fullSegmentPrefix := filepath.Join(config.Config.WALDir, segmentPrefix)
+
 	sort.Slice(files, func(i, j int) bool {
-		s1, _ := strconv.Atoi(strings.Split(strings.TrimPrefix(files[i], segmentPrefix), ".")[0])
-		s2, _ := strconv.Atoi(strings.Split(strings.TrimPrefix(files[i], segmentPrefix), ".")[0])
+		s1, _ := strconv.Atoi(strings.Split(strings.TrimPrefix(files[i], fullSegmentPrefix), ".")[0])
+		s2, _ := strconv.Atoi(strings.Split(strings.TrimPrefix(files[j], fullSegmentPrefix), ".")[0])
 		return s1 < s2
 	})
 
-	// TODO: Check that the segment files are returned in the correct order
-	// The order has to be in ascending order of the segment index.
 	return files, nil
 }
 


### PR DESCRIPTION
Related to https://github.com/DiceDB/dice/issues/1762. In the `segments` method of the WAL forge, we grab all segment file paths in the WAL dir, extract their IDs by stripping the path to the segment file and the segment prefix, and order the segments paths by IDs in ascending order.