### PR TITLE
version-path-from-env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,10 +34,15 @@ func init() {
 
 	// Read the VERSION file from the project root
 	// This approach works regardless of where the program is executed from
-	version, err := os.ReadFile(filepath.Join(projectRoot, "VERSION"))
+	path := filepath.Join(projectRoot, "VERSION")
+	if alt := os.Getenv("DICEDB_VERSION_PATH"); alt != "" {
+			path = alt
+	}
+
+	version, err := os.ReadFile(path)
 	if err != nil {
-		slog.Error("could not read the version file", slog.String("error", err.Error()))
-		os.Exit(1)
+			slog.Error("could not read the version file", slog.String("error", err.Error()))
+			os.Exit(1)
 	}
 
 	// Store the version string in the package-level DiceDBVersion variable


### PR DESCRIPTION
**What Changed?**
Checks path for VERSION file at env var DICEDB_VERSION_PATH first before defaulting to LOCAL.
**How will this help?**
Trying to create formula tap for homebrew. Everything works but the expectation is that the VERSION file resides in the directory where dicedb command is run from. With this change we can put it in the install dir and the caveat can include export like so 
```ruby
class Dicedb < Formula
  desc "DiceDB engine – fast, reactive, in-memory database"
  homepage "https://github.com/DiceDB/dice"
  url "https://github.com/DiceDB/dice/archive/refs/tags/v1.0.0.tar.gz"
  sha256 "1c613e44c8136d67dec73e92e084d38f39710d286fd1880998960891eb798a02"
  license "BSD-3-Clause"

  depends_on "go@1.24" => :build

  def install
    ENV["GOPROXY"] = "direct"
    ENV["GOSUMDB"] = "off"
    ENV.prepend_path "PATH", Formula["go@1.24"].opt_bin

    system "go", "build", "-o", bin/"dicedb", "./cmd/dicedb"

    # Install version file for runtime reference
    pkgshare.install "VERSION"
  end

  def caveats
    <<~EOS
      The DiceDB engine has been installed as 'dicedb'.

      To start the server:
        export DICEDB_VERSION_PATH=#{opt_pkgshare}/VERSION
        dicedb

      The server listens on port 7379 by default.
      For more info, visit: https://github.com/DiceDB/dice
    EOS
  end

  test do
    ENV["DICEDB_VERSION_PATH"] = "#{pkgshare}/VERSION"
    assert_match "DiceDB", shell_output("#{bin}/dicedb --help")
  end
end

```