### PR TITLE
Fix vertical alignment for example links in footer

### DIFF
--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -66,6 +66,8 @@ const { stars } = await fetchRepoDetails();
           >
             Leaderboard</a
           >
+        </p>
+        <p>
           <a
             href="https://github.com/DiceDB/dice/tree/master/examples/chatroom-go"
             target="_blank"


### PR DESCRIPTION
Adds a separate `<p>` wrapper around each `<a>` element.

Before:
![image](https://github.com/user-attachments/assets/5c94e560-a8ac-4b8a-acb4-7a89d3c7cf39)

After:
![image](https://github.com/user-attachments/assets/86a3ec31-8e45-4485-a90a-26eca0846a71)
