### PR TITLE
Fix fd leak in connSocketBlockingConnect on connection timeout

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -349,6 +349,7 @@ static int connSocketBlockingConnect(connection *conn, const char *addr, int por
     }
 
     if ((aeWait(fd, AE_WRITABLE, timeout) & AE_WRITABLE) == 0) {
+        close(fd);
         conn->state = CONN_STATE_ERROR;
         conn->last_errno = ETIMEDOUT;
         return C_ERR;


### PR DESCRIPTION
## Summary

Fixes #1784.

`connSocketBlockingConnect()` leaks the socket fd when `anetTcpNonBlockConnect()` succeeds but `aeWait()` times out: `conn->fd` is only assigned on the success path, so on timeout the fd becomes unreachable and is never closed. Under repeated timeouts (e.g. `replicaof` pointing at an unreachable host with short timeout and retries), this can exhaust process fds.

The fix closes `fd` on the timeout path before returning `C_ERR`.

## Change

One line added in `src/socket.c` — `close(fd);` before the existing `return C_ERR;` on the `aeWait()` timeout branch.

## Testing

- `make` builds cleanly.
- `./src/dicedb-server --version` starts normally.
- No dedicated test added: reproducing an fd leak on this path requires hostile network conditions (unreachable peer + short timeout + many retries) and is impractical to assert deterministically in the existing test harness. The fix is self-evident on review.

## DCO

Signed-off-by: Akshay Kapoor <222360654+akshay-kapoor-db@users.noreply.github.com>