### PR TITLE
[DICEDB] Dynamic module registry for OBSERVE

### DIFF
--- a/docs/OBSERVE.md
+++ b/docs/OBSERVE.md
@@ -27,18 +27,19 @@ The fingerprint is a CRC64 hash of the command name + arguments (e.g., `GET key1
 3. If `observe_debounce_period > 0`, changes are buffered and flushed by a timer; otherwise fired immediately
 4. `executeObserveCommand()` finds all fingerprints watching the key and pushes updates to subscribed clients
 
-## Adding OBSERVE Support for a New Command
+## Adding OBSERVE Support for a New Built-in Command
 
 ### Step 1 — Register the handler in observe.c
 
-File: `src/observe.c`, function `findHandlerForCommand()` (near the top of the file):
+File: `src/observe.c`, function `findHandlerForCommand()`:
 
 ```c
 static observeCommandHandler findHandlerForCommand(const char *cmd_name) {
     if (!strcasecmp(cmd_name, "GET"))    return getCommand;
     if (!strcasecmp(cmd_name, "ZRANGE")) return zrangeCommand;
     if (!strcasecmp(cmd_name, "HGET"))   return hgetCommand;  /* ADD HERE */
-    return NULL;
+    /* ... */
+    return NULL; /* falls through to module registry */
 }
 ```
 
@@ -48,11 +49,128 @@ Rule: The handler must be the existing read-only command's proc function. It rec
 
 Because `OBSERVE` is a single generic command, no new command functions, `server.h` declarations, or `commands.def` entries are required for new supported commands.
 
+## Adding OBSERVE Support for Module Commands
+
+Modules can register their own read-only command handlers so that clients can `OBSERVE` them. The registration API in `src/observe.c` handles this without touching the built-in if/else chain.
+
+### How it works
+
+`findHandlerForCommand()` exhausts the built-in if/else table first. If nothing matches, it falls through to `server.observe_command_registry` — a case-insensitive dict populated via the registration API.
+
+### Step 1 — Register on module load
+
+Call `ValkeyModule_ObserveRegisterCommandHandler()` inside your module's `OnLoad` function:
+
+```c
+#include "server.h"
+
+/* Your read-only command handler — same signature as any built-in command. */
+void myModuleGetCommand(client *c) {
+    /* c->argv[0] = command name, c->argv[1] = key, c->argv[2..] = extra args */
+    robj *val = lookupKeyRead(c->db, c->argv[1]);
+    if (val == NULL) {
+        addReplyNull(c);
+    } else {
+        addReplyBulk(c, val);
+    }
+}
+
+int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    if (ValkeyModule_Init(ctx, "mymodule", 1, VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    /* Register the command with Valkey as usual */
+    if (ValkeyModule_CreateCommand(ctx, "MYMOD.GET", ...) == VALKEYMODULE_ERR)
+        return VALKEYMODULE_ERR;
+
+    /* Register the internal handler with OBSERVE so clients can subscribe */
+    ValkeyModule_ObserveRegisterCommandHandler("MYMOD.GET", myModuleGetCommand);
+
+    return VALKEYMODULE_OK;
+}
+```
+
+After this, clients can run:
+
+```
+OBSERVE MYMOD.GET mykey
+```
+
+and receive push notifications whenever `mykey` changes.
+
+### Step 2 — Unregister on module unload
+
+Call `ValkeyModule_ObserveUnregisterCommandHandler()` in your `OnUnload` to prevent dangling handler pointers:
+
+```c
+int ValkeyModule_OnUnload(ValkeyModuleCtx *ctx) {
+    ValkeyModule_ObserveUnregisterCommandHandler("MYMOD.GET");
+    return VALKEYMODULE_OK;
+}
+```
+
+### Step 3 — Signal key changes from write commands
+
+OBSERVE fires when `signalModifiedKey` is called for a key. For built-in commands this happens automatically. For module write commands you must call it explicitly after mutating a key:
+
+```c
+void MyModuleSetCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
+    /* ... write to your storage ... */
+
+    /* Tell the server (and OBSERVE subscribers) that the key changed. */
+    ValkeyModule_SignalModifiedKey(ctx, argv[1]);
+
+    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+}
+```
+
+Call this once per modified key, after the mutation is complete. If you skip it, any `OBSERVE` subscription on that key will not receive an update.
+
+**When you do NOT need to call it:**
+
+- You write via `ValkeyModule_Call(ctx, "SET"/"RESTORE"/…)` — the dispatched built-in command signals automatically.
+- You opened the key with `ValkeyModule_OpenKey` in `WRITE` mode and closed it with `ValkeyModule_CloseKey` — the close path signals automatically (unless `VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED` is set).
+
+Only use `ValkeyModule_SignalModifiedKey` when your write command bypasses both of the above paths (e.g. writing directly to an external store like RocksDB while keeping a Valkey key in sync).
+
+### Handler contract
+
+The handler registered via `ValkeyModule_ObserveRegisterCommandHandler()` must follow the same rules as any built-in OBSERVE handler:
+
+| Rule | Details |
+|------|---------|
+| Read-only | Must not modify any key or global state |
+| Signature | `ValkeyModuleObserveCmdProc` — `void (*)(struct client *c)`, identical to a built-in command proc |
+| argv layout | `argv[0]` = command name, `argv[1]` = key, `argv[2..]` = additional args |
+| Reply | Use `addReply*` as normal; the framework wraps the reply in the 5-element observe envelope |
+| Key notifications | Call `ValkeyModule_SignalModifiedKey` from write commands that bypass the built-in key API; otherwise signalling is automatic |
+
+### Module API reference
+
+```c
+/* Register (or update) a read handler so clients can OBSERVE your command.
+ * Returns 1 if new, 0 if updated. */
+int ValkeyModule_ObserveRegisterCommandHandler(const char *cmd_name, ValkeyModuleObserveCmdProc handler);
+
+/* Remove a previously registered handler. No-op if not registered. */
+void ValkeyModule_ObserveUnregisterCommandHandler(const char *cmd_name);
+
+/* Signal that a key has been modified. Call this from write commands that
+ * bypass ValkeyModule_OpenKey/CloseKey and ValkeyModule_Call, so that OBSERVE
+ * subscribers receive their push notification. */
+int ValkeyModule_SignalModifiedKey(ValkeyModuleCtx *ctx, ValkeyModuleString *keyname);
+```
+
+All three functions are declared in `src/valkeymodule.h` and implemented in `src/module.c`.
+
 ## Key Files Reference
 
 | File | What to change |
 |------|----------------|
-| `src/observe.c` | Add `else if` branch in `findHandlerForCommand()` |
+| `src/observe.c` | Add branch in `findHandlerForCommand()` for built-in commands; `observeRegisterCommand` / `observeUnregisterCommand` for internal use |
+| `src/server.h` | `observeRegisterCommand`, `observeUnregisterCommand`, `observeRegistryDictType` declared here (internal) |
+| `src/valkeymodule.h` | `ValkeyModule_ObserveRegisterCommandHandler`, `ValkeyModule_ObserveUnregisterCommandHandler` — module-facing API |
+| `src/module.c` | `VM_ObserveRegisterCommandHandler`, `VM_ObserveUnregisterCommandHandler` — bridge between module API and observe.c |
 
 ## Existing Examples
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -1020,6 +1020,15 @@ void debugCommand(client *c) {
     } else if (!strcasecmp(c->argv[1]->ptr, "client-enforce-reply-list") && c->argc == 3) {
         server.debug_client_enforce_reply_list = atoi(c->argv[2]->ptr);
         addReply(c, shared.ok);
+    } else if (!strcasecmp(c->argv[1]->ptr, "observe-register") && c->argc == 3) {
+        /* DEBUG OBSERVE-REGISTER <cmd> — register getCommand as a fake handler
+         * for <cmd> so integration tests can exercise the module registry path. */
+        int isnew = observeRegisterCommand(c->argv[2]->ptr, getCommand);
+        addReplyLongLong(c, isnew);
+    } else if (!strcasecmp(c->argv[1]->ptr, "observe-unregister") && c->argc == 3) {
+        /* DEBUG OBSERVE-UNREGISTER <cmd> — remove a previously registered handler. */
+        observeUnregisterCommand(c->argv[2]->ptr);
+        addReply(c, shared.ok);
     } else if (!handleDebugClusterCommand(c)) {
         addReplySubcommandSyntaxError(c);
         return;

--- a/src/module.c
+++ b/src/module.c
@@ -13540,6 +13540,14 @@ int VM_GetDbIdFromDefragCtx(ValkeyModuleDefragCtx *ctx) {
     return ctx->dbid;
 }
 
+int VM_ObserveRegisterCommandHandler(const char *cmd_name, ValkeyModuleObserveCmdProc handler) {
+    return observeRegisterCommand(cmd_name, (observeCommandHandler)handler);
+}
+
+void VM_ObserveUnregisterCommandHandler(const char *cmd_name) {
+    observeUnregisterCommand(cmd_name);
+}
+
 /* Register all the APIs we export. Keep this function at the end of the
  * file so that's easy to seek it to add new entries. */
 void moduleRegisterCoreAPI(void) {
@@ -13903,4 +13911,6 @@ void moduleRegisterCoreAPI(void) {
     REGISTER_API(RdbStreamFree);
     REGISTER_API(RdbLoad);
     REGISTER_API(RdbSave);
+    REGISTER_API(ObserveRegisterCommandHandler);
+    REGISTER_API(ObserveUnregisterCommandHandler);
 }

--- a/src/observe.c
+++ b/src/observe.c
@@ -85,6 +85,40 @@ void genericExecuteObserveNotification(client *c, observeCommandHandler handler,
     if (!old_flags.pushing) c->flag.pushing = 0;
 }
 
+/* Dict type for the observe command registry: SDS keys (case-insensitive), handler pointer values. */
+dictType observeRegistryDictType = {
+    dictSdsCaseHash,            /* hash function */
+    dictSdsDup,                 /* key dup */
+    dictSdsKeyCaseCompare,      /* key compare */
+    dictSdsDestructor,          /* key destructor */
+    NULL,                       /* val destructor - function pointers need no freeing */
+};
+
+/* Register a custom read-only command handler so it can be used with OBSERVE.
+ * cmd_name is case-insensitive. Returns 1 if newly registered, 0 if updated. */
+int observeRegisterCommand(const char *cmd_name, observeCommandHandler handler) {
+    if (server.observe_command_registry == NULL)
+        server.observe_command_registry = dictCreate(&observeRegistryDictType);
+
+    sds key = sdsnew(cmd_name);
+    dictEntry *de = dictFind(server.observe_command_registry, key);
+    if (de) {
+        dictSetVal(server.observe_command_registry, de, (void *)(unsigned long)handler);
+        sdsfree(key);
+        return 0;
+    }
+    dictAdd(server.observe_command_registry, key, (void *)(unsigned long)handler);
+    return 1;
+}
+
+/* Unregister a previously registered command handler. */
+void observeUnregisterCommand(const char *cmd_name) {
+    if (server.observe_command_registry == NULL) return;
+    sds key = sdsnew(cmd_name);
+    dictDelete(server.observe_command_registry, key);
+    sdsfree(key);
+}
+
 /* Map a command name to its observe handler */
 static observeCommandHandler findHandlerForCommand(const char *cmd_name) {
     /* String commands */
@@ -160,6 +194,12 @@ static observeCommandHandler findHandlerForCommand(const char *cmd_name) {
     if (!strcasecmp(cmd_name, "PEXPIRETIME")) return pexpiretimeCommand;
     if (!strcasecmp(cmd_name, "EXISTS"))      return existsCommand;
     if (!strcasecmp(cmd_name, "TYPE"))        return typeCommand;
+
+    /* Fall back to dynamically registered handlers (e.g. from modules) */
+    if (server.observe_command_registry) {
+        dictEntry *de = dictFind(server.observe_command_registry, (void *)cmd_name);
+        if (de) return (observeCommandHandler)(unsigned long)dictGetVal(de);
+    }
 
     return NULL;
 }

--- a/src/server.h
+++ b/src/server.h
@@ -2167,6 +2167,7 @@ struct valkeyServer {
     dict *observe_fingerprints;           /* Map fingerprints to follow command info */
     dict *observe_key_to_fingerprints;    /* Map keys to list of fingerprints observing them */
     unsigned int observing_clients;       /* # of clients using .OBSERVE commands */
+    dict *observe_command_registry;       /* Dynamically registered command handlers (e.g. from modules) */
 
     dict *observe_debounce_buffer;        /* Buffer of keys that need observe notifications */
     unsigned int observe_debounce_period;     /* Debounce period in milliseconds */
@@ -3472,6 +3473,9 @@ void observeDebounceKeyChange(robj *key, int dbid);
 void initObserveDebounce(void);
 void freeObserveDebounceKey(observeDebounceKey *odk);
 void unobserveCommand(client *c);
+int observeRegisterCommand(const char *cmd_name, observeCommandHandler handler);
+void observeUnregisterCommand(const char *cmd_name);
+extern dictType observeRegistryDictType;
 
 /* Keyspace events notification */
 void notifyKeyspaceEvent(int type, char *event, robj *key, int dbid);

--- a/src/valkeymodule.h
+++ b/src/valkeymodule.h
@@ -875,6 +875,10 @@ typedef void (*ValkeyModuleClusterMessageReceiver)(ValkeyModuleCtx *ctx,
                                                    uint32_t len);
 typedef void (*ValkeyModuleTimerProc)(ValkeyModuleCtx *ctx, void *data);
 typedef void (*ValkeyModuleCommandFilterFunc)(ValkeyModuleCommandFilterCtx *filter);
+/* Handler type for OBSERVE command handlers registered by modules.
+ * Modules must include server.h for the full client definition. */
+struct client;
+typedef void (*ValkeyModuleObserveCmdProc)(struct client *c);
 typedef void (*ValkeyModuleForkDoneHandler)(int exitcode, int bysignal, void *user_data);
 typedef void (*ValkeyModuleScanCB)(ValkeyModuleCtx *ctx,
                                    ValkeyModuleString *keyname,
@@ -1450,6 +1454,9 @@ VALKEYMODULE_API void (*ValkeyModule_ThreadSafeContextUnlock)(ValkeyModuleCtx *c
 VALKEYMODULE_API int (*ValkeyModule_SubscribeToKeyspaceEvents)(ValkeyModuleCtx *ctx,
                                                                int types,
                                                                ValkeyModuleNotificationFunc cb) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ObserveRegisterCommandHandler)(const char *cmd_name,
+                                                                   ValkeyModuleObserveCmdProc handler) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ObserveUnregisterCommandHandler)(const char *cmd_name) VALKEYMODULE_ATTR;
 VALKEYMODULE_API int (*ValkeyModule_AddPostNotificationJob)(ValkeyModuleCtx *ctx,
                                                             ValkeyModulePostNotificationJobFunc callback,
                                                             void *pd,

--- a/tests/unit/observe.tcl
+++ b/tests/unit/observe.tcl
@@ -1165,4 +1165,115 @@ start_server {tags {"observe"}} {
         $rd read
         $rd close
     }
+
+    # ---------------------------------------------------------------------------
+    # Module registry tests
+    # These tests exercise the dynamic command registry added to support modules.
+    # The DEBUG OBSERVE-REGISTER / DEBUG OBSERVE-UNREGISTER subcommands are used
+    # as a test bridge since the C-level observeRegisterCommand() API is not
+    # directly reachable from Tcl.
+    # ---------------------------------------------------------------------------
+
+    test "OBSERVE module registry - unregistered command returns error" {
+        # Sanity: a command that is neither built-in nor in the registry must fail
+        r SELECT 0
+        r SET reg_k "value"
+        assert_error "*OBSERVE not supported*" {r OBSERVE NOTACOMMAND reg_k}
+    }
+
+    test "OBSERVE module registry - register makes command observable" {
+        r SELECT 0
+        r SET reg_k "hello"
+
+        # Register a fake handler (backed by getCommand) for FAKE.GET
+        set isnew [r DEBUG observe-register FAKE.GET]
+        assert_equal $isnew 1
+
+        set rd [valkey_deferring_client]
+        $rd SELECT 0
+        $rd read
+        $rd OBSERVE FAKE.GET reg_k
+        set observe [$rd read]
+
+        assert_equal [lindex $observe 0] "observe"
+        assert_equal [lindex $observe 1] "fingerprint"
+        assert_equal [lindex $observe 3] "result"
+        assert_equal [lindex $observe 4] "hello"
+
+        $rd UNOBSERVE [lindex $observe 2]
+        $rd read
+        $rd close
+        r DEBUG observe-unregister FAKE.GET
+    }
+
+    test "OBSERVE module registry - registered command receives key-change notifications" {
+        r SELECT 0
+        r SET reg_notif_k "initial"
+
+        r DEBUG observe-register FAKE.GET
+
+        set rd [valkey_deferring_client]
+        $rd SELECT 0
+        $rd read
+        $rd OBSERVE FAKE.GET reg_notif_k
+        set observe [$rd read]
+        set fingerprint [lindex $observe 2]
+        assert_equal [lindex $observe 4] "initial"
+
+        r SET reg_notif_k "updated"
+
+        set notif [$rd read]
+        assert_equal [lindex $notif 2] $fingerprint
+        assert_equal [lindex $notif 4] "updated"
+
+        $rd UNOBSERVE $fingerprint
+        $rd read
+        $rd close
+        r DEBUG observe-unregister FAKE.GET
+    }
+
+    test "OBSERVE module registry - lookup is case-insensitive" {
+        r SELECT 0
+        r SET reg_case_k "value"
+
+        # Register with mixed case
+        r DEBUG observe-register fake.get
+
+        set rd [valkey_deferring_client]
+        $rd SELECT 0
+        $rd read
+
+        # Subscribe using different casing — should still resolve
+        $rd OBSERVE FAKE.GET reg_case_k
+        set observe [$rd read]
+        assert_equal [lindex $observe 0] "observe"
+
+        $rd UNOBSERVE [lindex $observe 2]
+        $rd read
+        $rd close
+        r DEBUG observe-unregister FAKE.GET
+    }
+
+    test "OBSERVE module registry - re-registering same command returns 0 (update)" {
+        r DEBUG observe-register FAKE.GET
+        set isnew [r DEBUG observe-register FAKE.GET]
+        assert_equal $isnew 0
+        r DEBUG observe-unregister FAKE.GET
+    }
+
+    test "OBSERVE module registry - unregister removes command from registry" {
+        r SELECT 0
+        r SET reg_unreg_k "value"
+
+        r DEBUG observe-register FAKE.GET
+        r DEBUG observe-unregister FAKE.GET
+
+        # After unregister, OBSERVE should fail again
+        assert_error "*OBSERVE not supported*" {r OBSERVE FAKE.GET reg_unreg_k}
+    }
+
+    test "OBSERVE module registry - unregister is a no-op for unknown command" {
+        # Must not crash or error when unregistering something never registered
+        r DEBUG observe-unregister NEVER.REGISTERED
+    }
 }


### PR DESCRIPTION
- C API for modules to register read-only command handlers at runtime
- Handler lookup falls through to the registry after the built-in if/else chain
- Add `DEBUG OBSERVE-REGISTER` / `DEBUG OBSERVE-UNREGISTER` subcommands as test bridge
- Integration tests covering registration, notification, re-register, unregister, and no-op unregister
- Document module integration flow and handler contract in `docs/OBSERVE.md`