### PR TITLE
[DICEDB] Add initial REST API proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Makefile.dep
 .ccls
 .ccls-cache/*
 compile_commands.json
+proxy/dicedb-proxy
 redis.code-workspace
 .cache
 .cscope*

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -1,0 +1,35 @@
+CC = gcc
+MHD_PREFIX := $(shell brew --prefix libmicrohttpd 2>/dev/null)
+MHD_CFLAGS := $(if $(MHD_PREFIX),-I$(MHD_PREFIX)/include)
+MHD_LDFLAGS := $(if $(MHD_PREFIX),-L$(MHD_PREFIX)/lib)
+CFLAGS = -Wall -Wextra -Werror -g -O2 -I../deps/hiredis -I./include $(MHD_CFLAGS)
+LDFLAGS = ../deps/hiredis/libhiredis.a $(MHD_LDFLAGS) -lmicrohttpd -lpthread -lm
+
+SRC_DIR = src
+OBJ_DIR = obj
+
+SRCS = $(wildcard $(SRC_DIR)/*.c)
+OBJS = $(SRCS:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
+TARGET = dicedb-proxy
+
+all: hiredis $(TARGET)
+
+hiredis:
+	$(MAKE) -C ../deps/hiredis
+
+$(TARGET): $(OBJS)
+	$(CC) $(OBJS) -o $@ $(LDFLAGS)
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)
+
+clean:
+	rm -rf $(OBJ_DIR) $(TARGET)
+
+test: all
+	python3 tests/test_proxy.py
+
+.PHONY: all clean hiredis test

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,0 +1,63 @@
+# DiceDB REST API Proxy
+
+An initial REST API proxy for DiceDB written in C.
+
+## Features
+
+* **REST API:** Exposes DiceDB commands over a simple REST API interface (`/cmd/key/val`).
+* **Valkey C SDK:** Uses the official Valkey C SDK (`hiredis`) for high performance and compatibility.
+* **HTTP Server:** Powered by `libmicrohttpd` for lightweight, concurrent request handling.
+* **Reactivity:** Server-Sent Events (SSE) backed by the DiceDB `OBSERVE` command.
+* **Authentication:** Bearer tokens stored under `proxy:auth:tokens:<token>` in DiceDB, allowing tokens to be added and removed without restarting the proxy.
+* **Rate limiting:** Shared fixed-window limits for each token and client IP.
+
+This is not yet a complete implementation of issue #1787. Cluster-aware routing,
+TLS, connection pooling, metrics, deployment manifests, and the full Upstash REST
+API shape remain to be implemented.
+
+## Building
+
+Dependencies:
+* `make`
+* `gcc` / `clang`
+* `libmicrohttpd` (e.g. `brew install libmicrohttpd` or `apt-get install libmicrohttpd-dev`)
+
+To build the proxy:
+```bash
+make
+```
+
+Run the integration test with `make test` after building `../src/dicedb-server`.
+
+## Running
+
+```bash
+./dicedb-proxy [port]
+```
+
+Configuration is read from `DICEDB_PROXY_PORT`, `DICEDB_HOST`, and
+`DICEDB_PORT`. The defaults are `8080`, `127.0.0.1`, and `6379`.
+
+## Examples
+
+Start DiceDB:
+```bash
+docker run -p 6379:6379 dicedb/dicedb
+```
+
+Run the proxy:
+```bash
+./dicedb-proxy
+```
+
+Provision a bearer token:
+
+```bash
+../src/dicedb-cli SET proxy:auth:tokens:example-token active
+```
+
+Test the API:
+```bash
+curl -H 'Authorization: Bearer example-token' http://localhost:8080/SET/mykey/myval
+curl -H 'Authorization: Bearer example-token' http://localhost:8080/GET/mykey
+```

--- a/proxy/include/auth.h
+++ b/proxy/include/auth.h
@@ -1,0 +1,9 @@
+#ifndef AUTH_H
+#define AUTH_H
+
+#include <stdbool.h>
+
+/* Validates a bearer token and applies per-token and per-IP rate limits. */
+bool auth_and_rate_limit(const char *token, const char *client_ip);
+
+#endif // AUTH_H

--- a/proxy/include/http_server.h
+++ b/proxy/include/http_server.h
@@ -1,0 +1,6 @@
+#ifndef HTTP_SERVER_H
+#define HTTP_SERVER_H
+
+int start_http_server(int port);
+
+#endif // HTTP_SERVER_H

--- a/proxy/include/reactivity.h
+++ b/proxy/include/reactivity.h
@@ -1,0 +1,11 @@
+#ifndef REACTIVITY_H
+#define REACTIVITY_H
+
+#include <microhttpd.h>
+
+/* Handle an SSE /OBSERVE request */
+enum MHD_Result handle_observe_request(struct MHD_Connection *connection, const char *key);
+
+void init_reactivity(const char *hostname, int port);
+
+#endif // REACTIVITY_H

--- a/proxy/include/valkey_client.h
+++ b/proxy/include/valkey_client.h
@@ -1,0 +1,16 @@
+#ifndef VALKEY_CLIENT_H
+#define VALKEY_CLIENT_H
+
+#include <hiredis.h>
+
+/* Initialize the Valkey client connection pool */
+int init_valkey_client(const char *hostname, int port);
+
+/* Execute a REST command and get the JSON response back.
+   The caller must free the returned string. */
+char* valkey_execute_rest_command(const char *cmd, const char *key, const char *val);
+
+/* Close all Valkey connections */
+void cleanup_valkey_client();
+
+#endif // VALKEY_CLIENT_H

--- a/proxy/src/auth.c
+++ b/proxy/src/auth.c
@@ -1,0 +1,57 @@
+#include "auth.h"
+#include "valkey_client.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define RATE_LIMIT_MAX 100
+#define RATE_LIMIT_WINDOW_SECONDS "60"
+
+static bool increment_rate_limit(const char *scope, const char *identity) {
+    char key[512];
+    char *result;
+    int count = 0;
+
+    if (!identity || snprintf(key, sizeof(key), "proxy:rate_limit:%s:%s", scope,
+                              identity) >= (int)sizeof(key)) {
+        return false;
+    }
+
+    result = valkey_execute_rest_command("INCR", key, NULL);
+    if (!result || sscanf(result, "{\"result\": %d}", &count) != 1) {
+        free(result);
+        return false;
+    }
+    free(result);
+
+    if (count == 1) {
+        result = valkey_execute_rest_command("EXPIRE", key,
+                                             RATE_LIMIT_WINDOW_SECONDS);
+        free(result);
+    }
+    return count <= RATE_LIMIT_MAX;
+}
+
+bool auth_and_rate_limit(const char *token, const char *client_ip) {
+    if (!token || token[0] == '\0') return false;
+
+    // 1. Verify token exists in DiceDB (e.g. GET proxy:auth:tokens:<token>)
+    char auth_key[512];
+    if (snprintf(auth_key, sizeof(auth_key), "proxy:auth:tokens:%s", token) >=
+        (int)sizeof(auth_key)) {
+        return false;
+    }
+
+    char *auth_res = valkey_execute_rest_command("GET", auth_key, NULL);
+    if (!auth_res) return false;
+
+    if (strstr(auth_res, "\"result\": null") != NULL ||
+        strstr(auth_res, "\"error\"") != NULL) {
+        free(auth_res);
+        return false;
+    }
+    free(auth_res);
+
+    return increment_rate_limit("token", token) &&
+           increment_rate_limit("ip", client_ip ? client_ip : "unknown");
+}

--- a/proxy/src/http_server.c
+++ b/proxy/src/http_server.c
@@ -1,0 +1,138 @@
+#include "http_server.h"
+#include "valkey_client.h"
+#include "auth.h"
+#include "reactivity.h"
+#include <microhttpd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <signal.h>
+
+#define PAGE "{\"error\": \"Not Found\"}"
+#define UNAUTH_PAGE "{\"error\": \"Unauthorized or Rate Limited\"}"
+
+static volatile sig_atomic_t server_running = 1;
+
+static void stop_server(int signal_number) {
+    (void)signal_number;
+    server_running = 0;
+}
+
+static enum MHD_Result answer_to_connection(void *cls, struct MHD_Connection *connection,
+                                            const char *url, const char *method,
+                                            const char *version, const char *upload_data,
+                                            size_t *upload_data_size, void **con_cls) {
+    (void)cls;               /* Unused */
+    (void)version;           /* Unused */
+    (void)upload_data;       /* Unused */
+    (void)upload_data_size;  /* Unused */
+
+    if (NULL == *con_cls) {
+        *con_cls = connection;
+        return MHD_YES;
+    }
+
+    struct MHD_Response *response;
+    enum MHD_Result ret;
+
+    char client_ip[INET6_ADDRSTRLEN] = "unknown";
+    const union MHD_ConnectionInfo *connection_info = MHD_get_connection_info(
+        connection, MHD_CONNECTION_INFO_CLIENT_ADDRESS);
+    if (connection_info && connection_info->client_addr) {
+        const struct sockaddr *addr = connection_info->client_addr;
+        if (addr->sa_family == AF_INET) {
+            inet_ntop(AF_INET, &((const struct sockaddr_in *)addr)->sin_addr,
+                      client_ip, sizeof(client_ip));
+        } else if (addr->sa_family == AF_INET6) {
+            inet_ntop(AF_INET6, &((const struct sockaddr_in6 *)addr)->sin6_addr,
+                      client_ip, sizeof(client_ip));
+        }
+    }
+
+    // Extract Bearer token
+    const char *auth_header = MHD_lookup_connection_value(connection, MHD_HEADER_KIND, "Authorization");
+    char *token = NULL;
+    if (auth_header && strncmp(auth_header, "Bearer ", 7) == 0) {
+        token = strdup(auth_header + 7);
+    }
+
+    // Authenticate and Rate Limit
+    if (!auth_and_rate_limit(token, client_ip)) {
+        response = MHD_create_response_from_buffer(strlen(UNAUTH_PAGE), (void *)UNAUTH_PAGE, MHD_RESPMEM_PERSISTENT);
+        MHD_add_response_header(response, "Content-Type", "application/json");
+        ret = MHD_queue_response(connection, MHD_HTTP_UNAUTHORIZED, response);
+        MHD_destroy_response(response);
+        if (token) free(token);
+        return ret;
+    }
+    if (token) free(token);
+
+    // Handle OBSERVE Reactivity endpoint
+    if (strncmp(url, "/OBSERVE/", 9) == 0) {
+        const char *key = url + 9;
+        return handle_observe_request(connection, key);
+    }
+
+    char *json_response = NULL;
+
+    if (strcmp(method, "GET") == 0 || strcmp(method, "POST") == 0) {
+        char *url_copy = strdup(url);
+        char *cmd = NULL;
+        char *key = NULL;
+        char *val = NULL;
+
+        char *t = strtok(url_copy, "/");
+        if (t) {
+            cmd = t;
+            t = strtok(NULL, "/");
+            if (t) {
+                key = t;
+                t = strtok(NULL, "/");
+                if (t) val = t;
+            }
+        }
+
+        if (cmd) {
+            json_response = valkey_execute_rest_command(cmd, key, val);
+        }
+        free(url_copy);
+    }
+
+    if (json_response) {
+        response = MHD_create_response_from_buffer(strlen(json_response),
+                                                   (void *)json_response,
+                                                   MHD_RESPMEM_MUST_FREE);
+        MHD_add_response_header(response, "Content-Type", "application/json");
+        ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
+    } else {
+        response = MHD_create_response_from_buffer(strlen(PAGE), (void *)PAGE, MHD_RESPMEM_PERSISTENT);
+        MHD_add_response_header(response, "Content-Type", "application/json");
+        ret = MHD_queue_response(connection, MHD_HTTP_NOT_FOUND, response);
+    }
+
+    MHD_destroy_response(response);
+    return ret;
+}
+
+int start_http_server(int port) {
+    struct MHD_Daemon *daemon;
+    daemon = MHD_start_daemon(MHD_USE_THREAD_PER_CONNECTION, port, NULL, NULL,
+                              &answer_to_connection, NULL, MHD_OPTION_END);
+    if (NULL == daemon) {
+        return 1;
+    }
+    printf("REST API Proxy listening on port %d\n", port);
+
+    signal(SIGINT, stop_server);
+    signal(SIGTERM, stop_server);
+
+    while(server_running) {
+        sleep(1);
+    }
+
+    MHD_stop_daemon(daemon);
+    return 0;
+}

--- a/proxy/src/main.c
+++ b/proxy/src/main.c
@@ -1,0 +1,55 @@
+#include "http_server.h"
+#include "reactivity.h"
+#include "valkey_client.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DEFAULT_PORT 8080
+#define DEFAULT_UPSTREAM_HOST "127.0.0.1"
+#define DEFAULT_UPSTREAM_PORT 6379
+
+static int read_port(const char *value, int fallback) {
+    char *end;
+    long port;
+
+    if (!value || value[0] == '\0') return fallback;
+    port = strtol(value, &end, 10);
+    if (*end != '\0' || port < 1 || port > 65535) {
+        fprintf(stderr, "Invalid port: %s\n", value);
+        return -1;
+    }
+    return (int)port;
+}
+
+int main(int argc, char **argv) {
+    int port = read_port(getenv("DICEDB_PROXY_PORT"), DEFAULT_PORT);
+    const char *upstream_host = getenv("DICEDB_HOST");
+    int upstream_port = read_port(getenv("DICEDB_PORT"), DEFAULT_UPSTREAM_PORT);
+
+    if (!upstream_host || upstream_host[0] == '\0') {
+        upstream_host = DEFAULT_UPSTREAM_HOST;
+    }
+
+    if (argc > 1) {
+        port = read_port(argv[1], port);
+    }
+    if (port < 0 || upstream_port < 0) return 1;
+
+    printf("Starting DiceDB REST API Proxy...\n");
+    printf("Connecting to upstream DiceDB at %s:%d\n", upstream_host, upstream_port);
+
+    if (init_valkey_client(upstream_host, upstream_port) != 0) {
+        fprintf(stderr, "Failed to connect to upstream DiceDB\n");
+        return 1;
+    }
+    init_reactivity(upstream_host, upstream_port);
+
+    if (start_http_server(port) != 0) {
+        fprintf(stderr, "Failed to start HTTP server\n");
+        cleanup_valkey_client();
+        return 1;
+    }
+
+    cleanup_valkey_client();
+    return 0;
+}

--- a/proxy/src/reactivity.c
+++ b/proxy/src/reactivity.c
@@ -1,0 +1,94 @@
+#include "reactivity.h"
+#include <hiredis.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char *upstream_host;
+static int upstream_port;
+
+void init_reactivity(const char *hostname, int port) {
+    upstream_host = hostname;
+    upstream_port = port;
+}
+
+// SSE context per connection
+struct sse_context {
+    redisContext *rc;
+    char *key;
+};
+
+// Callback to read SSE chunks.
+static ssize_t sse_reader_callback(void *cls, uint64_t pos, char *buf, size_t max) {
+    struct sse_context *ctx = (struct sse_context *)cls;
+    (void)pos;
+
+    // Block and wait for reply from OBSERVE
+    redisReply *reply;
+    if (redisGetReply(ctx->rc, (void**)&reply) == REDIS_OK) {
+        if (reply->type == REDIS_REPLY_ARRAY && reply->elements > 0) {
+            // OBSERVE pushes arrays
+            // Format as SSE: data: {"event": ...} \n\n
+            // Simplified string dump for this POC
+            char *json = "{\"event\": \"update\"}";
+            if (reply->elements > 1 && reply->element[1]->type == REDIS_REPLY_STRING) {
+                json = reply->element[1]->str;
+            }
+
+            int written = snprintf(buf, max, "data: %s\n\n", json);
+            freeReplyObject(reply);
+            if (written < 0) return MHD_CONTENT_READER_END_WITH_ERROR;
+            return (size_t)written < max ? written : (ssize_t)max;
+        }
+        freeReplyObject(reply);
+
+        // Return 0 means EOF / close connection? No, for SSE we need to keep waiting.
+        // Returning 0 might close the connection in MHD if we aren't suspended.
+        // Actually, returning a space or keepalive might be better, but let's just
+        // wait for the next event. If we just sleep and retry, it's better.
+    }
+
+    // If redisGetReply fails or connection drops
+    return MHD_CONTENT_READER_END_OF_STREAM;
+}
+
+static void sse_free_callback(void *cls) {
+    struct sse_context *ctx = (struct sse_context *)cls;
+    if (ctx) {
+        if (ctx->rc) redisFree(ctx->rc);
+        if (ctx->key) free(ctx->key);
+        free(ctx);
+    }
+}
+
+enum MHD_Result handle_observe_request(struct MHD_Connection *connection, const char *key) {
+    struct sse_context *ctx = malloc(sizeof(struct sse_context));
+    if (!ctx) return MHD_NO;
+    ctx->key = strdup(key);
+    ctx->rc = redisConnect(upstream_host, upstream_port);
+
+    if (!ctx->key || ctx->rc == NULL || ctx->rc->err) {
+        sse_free_callback(ctx);
+        return MHD_NO;
+    }
+
+    // Send the OBSERVE command
+    redisReply *reply = redisCommand(ctx->rc, "OBSERVE %s", key);
+    if (reply) freeReplyObject(reply); // Initial OK/Subscription reply
+
+    struct MHD_Response *response = MHD_create_response_from_callback(
+        MHD_SIZE_UNKNOWN, 1024, &sse_reader_callback, ctx, &sse_free_callback);
+    if (!response) {
+        sse_free_callback(ctx);
+        return MHD_NO;
+    }
+
+    MHD_add_response_header(response, "Content-Type", "text/event-stream");
+    MHD_add_response_header(response, "Cache-Control", "no-cache");
+    MHD_add_response_header(response, "Connection", "keep-alive");
+
+    enum MHD_Result ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
+    MHD_destroy_response(response);
+    return ret;
+}

--- a/proxy/src/valkey_client.c
+++ b/proxy/src/valkey_client.c
@@ -1,0 +1,76 @@
+#include "valkey_client.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+static redisContext *global_rc = NULL;
+static pthread_mutex_t global_rc_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+int init_valkey_client(const char *hostname, int port) {
+    global_rc = redisConnect(hostname, port);
+    if (global_rc == NULL || global_rc->err) {
+        if (global_rc) {
+            fprintf(stderr, "Connection error: %s\n", global_rc->errstr);
+            redisFree(global_rc);
+            global_rc = NULL;
+        } else {
+            fprintf(stderr, "Connection error: can't allocate redis context\n");
+        }
+        return -1;
+    }
+    return 0;
+}
+
+char* valkey_execute_rest_command(const char *cmd, const char *key, const char *val) {
+    pthread_mutex_lock(&global_rc_mutex);
+    if (!global_rc) {
+        pthread_mutex_unlock(&global_rc_mutex);
+        return NULL;
+    }
+
+    redisReply *reply;
+    if (val) {
+        reply = redisCommand(global_rc, "%s %s %s", cmd, key, val);
+    } else if (key) {
+        reply = redisCommand(global_rc, "%s %s", cmd, key);
+    } else {
+        reply = redisCommand(global_rc, "%s", cmd);
+    }
+
+    if (!reply) {
+        pthread_mutex_unlock(&global_rc_mutex);
+        return NULL;
+    }
+
+    char *result = NULL;
+    char buffer[1024];
+
+    if (reply->type == REDIS_REPLY_STRING || reply->type == REDIS_REPLY_STATUS) {
+        snprintf(buffer, sizeof(buffer), "{\"result\": \"%s\"}", reply->str);
+        result = strdup(buffer);
+    } else if (reply->type == REDIS_REPLY_INTEGER) {
+        snprintf(buffer, sizeof(buffer), "{\"result\": %lld}", reply->integer);
+        result = strdup(buffer);
+    } else if (reply->type == REDIS_REPLY_NIL) {
+        result = strdup("{\"result\": null}");
+    } else if (reply->type == REDIS_REPLY_ERROR) {
+        snprintf(buffer, sizeof(buffer), "{\"error\": \"%s\"}", reply->str);
+        result = strdup(buffer);
+    } else {
+        result = strdup("{\"result\": \"OK\"}");
+    }
+
+    freeReplyObject(reply);
+    pthread_mutex_unlock(&global_rc_mutex);
+    return result;
+}
+
+void cleanup_valkey_client() {
+    pthread_mutex_lock(&global_rc_mutex);
+    if (global_rc) {
+        redisFree(global_rc);
+        global_rc = NULL;
+    }
+    pthread_mutex_unlock(&global_rc_mutex);
+}

--- a/proxy/tests/test_proxy.py
+++ b/proxy/tests/test_proxy.py
@@ -1,0 +1,102 @@
+import subprocess
+import time
+import urllib.request
+import json
+import sys
+import socket
+import os
+import urllib.error
+
+TOKEN = "test-token"
+
+
+def send_command(*args):
+    encoded = [str(arg).encode() for arg in args]
+    request = f"*{len(encoded)}\r\n".encode()
+    for arg in encoded:
+        request += f"${len(arg)}\r\n".encode() + arg + b"\r\n"
+    with socket.create_connection(("127.0.0.1", 6379)) as sock:
+        sock.sendall(request)
+        return sock.recv(1024)
+
+def wait_for_port(port, timeout=10):
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            if sock.connect_ex(('127.0.0.1', port)) == 0:
+                return True
+        time.sleep(0.1)
+    return False
+
+def run_test():
+    dicedb_proc = None
+    proxy_proc = None
+    try:
+        # Start DiceDB server
+        print("Starting DiceDB server...")
+        dicedb_proc = subprocess.Popen(["../../src/dicedb-server", "--port", "6379"], cwd=os.path.dirname(__file__), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        if not wait_for_port(6379):
+            print("DiceDB server failed to start")
+            sys.exit(1)
+
+        assert send_command("SET", f"proxy:auth:tokens:{TOKEN}", "active").startswith(b"+OK")
+
+        # Start Proxy
+        print("Starting Proxy server...")
+        proxy_proc = subprocess.Popen(["../dicedb-proxy", "8080"], cwd=os.path.dirname(__file__), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        if not wait_for_port(8080):
+            print("Proxy server failed to start")
+            sys.exit(1)
+
+        import uuid
+        test_key = "testkey_" + str(uuid.uuid4())
+
+        # Give it a tiny bit of time to connect to upstream
+        time.sleep(0.5)
+
+        # Helper to make requests with auth header
+        def make_req(url):
+            req = urllib.request.Request(url)
+            req.add_header("Authorization", f"Bearer {TOKEN}")
+            return req
+
+        print("Testing authentication is required...")
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:8080/GET/{test_key}")
+            raise AssertionError("Expected a request without a token to fail")
+        except urllib.error.HTTPError as error:
+            assert error.code == 401, f"Expected 401, got {error.code}"
+
+        # Test 1: GET non-existent key
+        print("Testing GET non-existent key...")
+        with urllib.request.urlopen(make_req(f"http://127.0.0.1:8080/GET/{test_key}")) as response:
+            data = json.loads(response.read().decode())
+            assert data["result"] is None, f"Expected null, got {data}"
+
+        # Test 2: SET a key
+        print("Testing SET key...")
+        with urllib.request.urlopen(make_req(f"http://127.0.0.1:8080/SET/{test_key}/helloworld")) as response:
+            data = json.loads(response.read().decode())
+            assert data["result"] == "OK", f"Expected OK, got {data}"
+
+        # Test 3: GET the key
+        print("Testing GET existing key...")
+        with urllib.request.urlopen(make_req(f"http://127.0.0.1:8080/GET/{test_key}")) as response:
+            data = json.loads(response.read().decode())
+            assert data["result"] == "helloworld", f"Expected helloworld, got {data}"
+
+        print("All tests passed successfully!")
+
+    except Exception as e:
+        print(f"Test failed: {e}")
+        sys.exit(1)
+    finally:
+        if proxy_proc:
+            proxy_proc.terminate()
+            proxy_proc.wait()
+        if dicedb_proc:
+            dicedb_proc.terminate()
+            dicedb_proc.wait()
+
+if __name__ == "__main__":
+    run_test()


### PR DESCRIPTION
• ## Summary

  - Add an initial DiceDB REST API proxy written in C
  - Use hiredis for DiceDB communication and libmicrohttpd for HTTP handling
  - Support bearer-token authentication backed by DiceDB
  - Add per-token and per-IP fixed-window rate limiting
  - Add SSE-based reactivity using OBSERVE
  - Support environment-based upstream and proxy port configuration
  - Handle graceful shutdown on SIGINT and SIGTERM
  - Add integration tests for authentication and GET/SET requests

  ## Configuration

  - DICEDB_PROXY_PORT: HTTP proxy port, defaults to 8080
  - DICEDB_HOST: DiceDB hostname, defaults to 127.0.0.1
  - DICEDB_PORT: DiceDB port, defaults to 6379

  Tokens are stored in DiceDB using:

  proxy:auth:tokens:<token>

  This allows tokens to be added or revoked without restarting the proxy.

  ## Testing

  make
  make -C proxy clean
  make -C proxy test

  The proxy builds with -Wall -Wextra -Werror, and the integration tests pass.

  ## Current Limitations

  This is an initial implementation for #1787 and does not close the issue. The following remain as follow-up work:

  - Cluster-aware routing
  - Upstream connection pooling
  - Inbound and outbound TLS
  - Complete Upstash-compatible REST API
  - Prometheus metrics and request tracing
  - Configurable timeouts
  - Kubernetes or Helm deployment resources
  - Production-ready SSE buffering and reconnection

  Related to #1787.